### PR TITLE
[IMP]connector_pms: Allow to bind a internal record with multiple external ids

### DIFF
--- a/connector_pms/components_custom/binder.py
+++ b/connector_pms/components_custom/binder.py
@@ -83,9 +83,9 @@ class BinderCustom(AbstractComponent):
             [
                 (self._odoo_field, "=", relation.id),
                 (self._backend_field, "=", self.backend_record.id),
+                ('no_export', '=', False),
             ]
         )
-
         if not binding:
             if force:
                 binding = self.model.with_context(connector_no_export=True).create(
@@ -260,6 +260,32 @@ class BinderCustom(AbstractComponent):
 
         return self.model
 
+    def to_external(self, binding, wrap=False):
+        """Give the external ID for an Odoo binding ID
+
+        :param binding: Odoo binding for which we want the external id
+        :param wrap: if True, binding is a normal record, the
+                     method will search the corresponding binding and return
+                     the external id of the binding
+        :return: external ID of the record
+        """
+        if isinstance(binding, models.BaseModel):
+            binding.ensure_one()
+        else:
+            binding = self.model.browse(binding)
+        if wrap:
+            binding = self.model.with_context(active_test=False).search(
+                [
+                    (self._odoo_field, "=", binding.id),
+                    (self._backend_field, "=", self.backend_record.id),
+                    ('no_export', '=', False),
+                ]
+            )
+            if not binding:
+                return None
+            binding.ensure_one()
+            return binding[self._external_field]
+        return binding[self._external_field]
 
 # TODO: naming the methods more intuitively
 # TODO: unify both methods, they have a lot of common code

--- a/connector_pms/models/common/binding.py
+++ b/connector_pms/models/common/binding.py
@@ -32,6 +32,7 @@ class ChannelBinding(models.AbstractModel):
     synced_export = fields.Boolean(
         string="Synced (export)", compute="_compute_synced_export", readonly=True
     )
+    no_export = fields.Boolean(default=False)
 
     def _is_synced_export(self):
         self.ensure_one()
@@ -52,7 +53,7 @@ class ChannelBinding(models.AbstractModel):
         ),
         (
             "channel_internal_uniq",
-            "unique(backend_id, odoo_id)",
+            "EXCLUDE (backend_id WITH =, odoo_id WITH =) WHERE (no_export = False or no_export IS NULL)",
             "A binding already exists with the same Internal (Odoo) ID.",
         ),
     ]

--- a/connector_pms_wubook/views/pms_room_type_views.xml
+++ b/connector_pms_wubook/views/pms_room_type_views.xml
@@ -29,6 +29,7 @@
                             name="resync_export"
                             class="fa fa-upload"
                         />
+                        <field name="no_export" />
                         <field name="synced_export" />
                         <field name="sync_date_export" />
                     </tree>


### PR DESCRIPTION
Se añade campo no_export, al asociar varios id de wubook al tipo de habitación solamente uno de ellos podrá tener no_export=False