### PR TITLE
[FIX]pms_partner_type_residence: More robust logics in set_partner_address.

### DIFF
--- a/pms_api_rest/services/pms_reservation_service.py
+++ b/pms_api_rest/services/pms_reservation_service.py
@@ -1134,7 +1134,7 @@ class PmsReservationService(Component):
             "country_id": pms_checkin_partner_info.countryId,
             "origin_input_data": pms_checkin_partner_info.originInputData,
         }
-        if pms_checkin_partner_info.partnerId != partner_id:
+        if pms_checkin_partner_info.partnerId and pms_checkin_partner_info.partnerId != partner_id:
             vals.update({"partner_id": pms_checkin_partner_info.partnerId})
         if pms_checkin_partner_info.documentExpeditionDate:
             document_expedition_date = datetime.strptime(

--- a/pms_partner_type_residence/models/pms_checkin_partner.py
+++ b/pms_partner_type_residence/models/pms_checkin_partner.py
@@ -33,7 +33,12 @@ class PMSCheckinPartner(models.Model):
         address_fields_writed = residence_vals.keys()
         conflict_partner_address = any(
             self.partner_id[field]
-            and self.partner_id[field] != residence_vals.get(field)
+            and (
+                self.partner_id[field].id
+                if hasattr(self.partner_id[field], "id")
+                else self.partner_id[field]
+            )
+            != residence_vals.get(field)
             for field in address_fields_writed
         )
         residence = self.partner_id.residence_partner_id

--- a/pms_partner_type_residence/models/pms_checkin_partner.py
+++ b/pms_partner_type_residence/models/pms_checkin_partner.py
@@ -4,36 +4,60 @@ from odoo import models
 class PMSCheckinPartner(models.Model):
     _inherit = "pms.checkin.partner"
 
-    def set_partner_address(self):
+    def set_partner_address(self, residence_vals=None):
         """
-        If the partner has a child of type 'residence', set the address fields
-        (street, street2, zip, city, country_id, state_id) of the check-in partner
-        to the address of that residence partner.
-        If the partner has an adress but no residence, create the residence partner
+        Sets the checkin.partner address in the associated partner
+        or its residence child.
+
+        - If partner has no residence address and the changes do not conflict with
+          the partner's address: update partner address.
+        - If partner has residence child: update residence with checkin values
+        - If the changes conflict with partner's address:
+          update residence if exists, else create residence child.
         """
-        for record in self:
+        self.ensure_one()
+        if not self.partner_id:
+            return
+
+        address_fields = {"street", "street2", "zip", "city", "country_id", "state_id"}
+        if residence_vals is None:
             residence_vals = {
-                "street": record.street,
-                "street2": record.street2,
-                "zip": record.zip,
-                "city": record.city,
-                "country_id": record.country_id.id,
-                "state_id": record.state_id.id,
+                field: self[field].id if hasattr(self[field], "id") else self[field]
+                for field in address_fields
             }
-            if any(residence_vals.values()):
-                if record.partner_id:
-                    address_fields = residence_vals.keys()
-                    if not any(record.partner_id[field] for field in address_fields):
-                        super(PMSCheckinPartner, record).set_partner_address()
-                    else:
-                        residence = record.partner_id.residence_partner_id
-                        if residence and residence != record.partner_id:
-                            residence.write(residence_vals)
-                        else:
-                            residence_vals.update(
-                                {
-                                    "parent_id": record.partner_id.id,
-                                    "type": "residence",
-                                }
-                            )
-                            self.env["res.partner"].create(residence_vals)
+
+        if not any(residence_vals.values()):
+            return
+        partner = self.partner_id
+
+        address_fields_writed = residence_vals.keys()
+        conflict_partner_address = any(
+            self.partner_id[field]
+            and self.partner_id[field] != residence_vals.get(field)
+            for field in address_fields_writed
+        )
+        residence = self.partner_id.residence_partner_id
+        if not conflict_partner_address and residence == self.partner_id:
+            return super().set_partner_address(residence_vals)
+        if residence and residence != self.partner_id:
+            residence.write(residence_vals)
+        else:
+            # Establish the base fields, to preserve existing data
+            partner_address = {
+                field: (
+                    partner[field].id
+                    if hasattr(partner[field], "id")
+                    else partner[field]
+                )
+                for field in address_fields
+            }
+            # Update with residence write values
+            partner_address.update(residence_vals)
+
+            partner_address.update(
+                {
+                    "parent_id": self.partner_id.id,
+                    "type": "residence",
+                }
+            )
+            self.env["res.partner"].create(partner_address)

--- a/pms_partner_type_residence/tests/__init__.py
+++ b/pms_partner_type_residence/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_pms_checkin_partner
+from . import test_res_partner

--- a/pms_partner_type_residence/tests/test_pms_checkin_partner.py
+++ b/pms_partner_type_residence/tests/test_pms_checkin_partner.py
@@ -1,0 +1,220 @@
+import datetime
+
+from odoo.addons.pms.tests.common import TestPms
+
+
+class TestSetPartnerAddressResidence(TestPms):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        today = datetime.date(2012, 1, 14)
+        cls.room_type1 = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Triple",
+                "default_code": "TRP",
+                "class_id": cls.room_type_class1.id,
+            }
+        )
+        cls.room1 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Triple 101",
+                "room_type_id": cls.room_type1.id,
+                "capacity": 3,
+            }
+        )
+
+        cls.host1 = cls.env["res.partner"].create(
+            {
+                "name": "Miguel",
+                "email": "miguel@example.com",
+                "birthdate_date": "1995-12-10",
+                "gender": "male",
+            }
+        )
+        cls.sale_channel_direct1 = cls.env["pms.sale.channel"].create(
+            {
+                "name": "Door",
+                "channel_type": "direct",
+            }
+        )
+        reservation_vals = {
+            "checkin": today,
+            "checkout": today + datetime.timedelta(days=3),
+            "room_type_id": cls.room_type1.id,
+            "partner_id": cls.host1.id,
+            "adults": 3,
+            "pms_property_id": cls.pms_property1.id,
+            "sale_channel_origin_id": cls.sale_channel_direct1.id,
+        }
+        cls.reservation_1 = cls.env["pms.reservation"].create(reservation_vals)
+        cls.checkin1 = cls.env["pms.checkin.partner"].create(
+            {
+                "partner_id": cls.host1.id,
+                "reservation_id": cls.reservation_1.id,
+            }
+        )
+        cls.country_spain = cls.env.ref("base.es")
+        cls.country_france = cls.env.ref("base.fr")
+
+    def _create_partner(self, vals=None):
+        default_vals = {"name": "Test Partner"}
+        if vals:
+            default_vals.update(vals)
+        return self.env["res.partner"].create(default_vals)
+
+    def _create_residence(self, parent, vals=None):
+        default_vals = {
+            "name": parent.name,
+            "parent_id": parent.id,
+            "type": "residence",
+        }
+        if vals:
+            default_vals.update(vals)
+        return self.env["res.partner"].create(default_vals)
+
+    def _create_checkin_partner(self, partner, vals=None):
+        default_vals = {
+            "partner_id": partner.id,
+            "reservation_id": self.reservation_1.id,
+            "state": "draft",
+        }
+        if vals:
+            default_vals.update(vals)
+        return self.env["pms.checkin.partner"].create(default_vals)
+
+    def test_no_conflict_no_residence_writes_to_partner(self):
+        """Test that a partner without residence and no conflicting address
+        fields gets the address from the checkin partner.
+        """
+        partner = self._create_partner()
+        self._create_checkin_partner(
+            partner,
+            {
+                "street": "Calle Test",
+                "city": "Madrid",
+            },
+        )
+
+        self.assertEqual(partner.street, "Calle Test")
+        self.assertEqual(partner.city, "Madrid")
+        self.assertFalse(partner.child_ids.filtered(lambda p: p.type == "residence"))
+
+    def test_no_conflict_same_values_writes_new_fields_to_partner(self):
+        partner = self._create_partner({"street": "Calle Test"})
+        self._create_checkin_partner(
+            partner,
+            {
+                "street": "Calle Test",
+                "city": "Madrid",
+            },
+        )
+        self.assertEqual(partner.street, "Calle Test")
+        self.assertEqual(partner.city, "Madrid")
+        self.assertFalse(partner.child_ids.filtered(lambda p: p.type == "residence"))
+
+    def test_conflict_no_residence_creates_residence(self):
+        partner = self._create_partner({"street": "Calle Original"})
+        self._create_checkin_partner(
+            partner,
+            {
+                "street": "Calle Nueva",
+                "city": "Madrid",
+            },
+        )
+
+        self.assertEqual(partner.street, "Calle Original")
+        residence = partner.child_ids.filtered(lambda p: p.type == "residence")
+        self.assertTrue(residence)
+        self.assertEqual(residence.street, "Calle Nueva")
+        self.assertEqual(residence.city, "Madrid")
+
+    def test_conflict_creates_residence_with_partner_base_data(self):
+        partner = self._create_partner(
+            {
+                "street": "Calle Original",
+                "country_id": self.country_spain.id,
+            }
+        )
+        self._create_checkin_partner(
+            partner,
+            {
+                "street": "Calle Nueva",
+                "city": "Madrid",
+            },
+        )
+
+        residence = partner.child_ids.filtered(lambda p: p.type == "residence")
+        self.assertEqual(residence.street, "Calle Nueva")
+        self.assertEqual(residence.city, "Madrid")
+        self.assertEqual(residence.country_id, self.country_spain)
+
+    def test_conflict_country_creates_residence(self):
+        partner = self._create_partner({"country_id": self.country_spain.id})
+        self._create_checkin_partner(
+            partner,
+            {
+                "country_id": self.country_france.id,
+                "city": "Paris",
+            },
+        )
+
+        self.assertEqual(partner.country_id, self.country_spain)
+        residence = partner.child_ids.filtered(lambda p: p.type == "residence")
+        self.assertTrue(residence)
+        self.assertEqual(residence.country_id, self.country_france)
+        self.assertEqual(residence.city, "Paris")
+
+    def test_existing_residence_updates_residence(self):
+        partner = self._create_partner({"street": "Calle Fiscal"})
+        residence = self._create_residence(partner, {"street": "Calle Residencia"})
+        self._create_checkin_partner(
+            partner,
+            {
+                "street": "Calle Nueva",
+                "city": "Madrid",
+            },
+        )
+
+        self.assertEqual(partner.street, "Calle Fiscal")
+        self.assertEqual(residence.street, "Calle Nueva")
+        self.assertEqual(residence.city, "Madrid")
+
+    def test_existing_residence_overwrites_values(self):
+        partner = self._create_partner({"street": "Calle Fiscal"})
+        residence = self._create_residence(
+            partner,
+            {
+                "street": "Calle Residencia",
+                "street2": "Piso 3",
+                "city": "Barcelona",
+            },
+        )
+        self._create_checkin_partner(
+            partner,
+            {
+                "street": "Calle Nueva",
+                "street2": False,
+                "city": "Madrid",
+            },
+        )
+
+        self.assertEqual(residence.street, "Calle Nueva")
+        self.assertFalse(residence.street2)
+        self.assertEqual(residence.city, "Madrid")
+
+    def test_existing_residence_no_conflict_still_writes_to_residence(self):
+        partner = self._create_partner({"street": "Calle Test"})
+        residence = self._create_residence(partner, {"street": "Calle Test"})
+        self._create_checkin_partner(
+            partner,
+            {
+                "street": "Calle Test",
+                "city": "Madrid",
+            },
+        )
+
+        self.assertEqual(partner.street, "Calle Test")
+        self.assertFalse(partner.city)
+        self.assertEqual(residence.city, "Madrid")

--- a/pms_partner_type_residence/tests/test_res_partner.py
+++ b/pms_partner_type_residence/tests/test_res_partner.py
@@ -1,0 +1,101 @@
+from psycopg2 import IntegrityError
+
+from odoo.tests.common import TransactionCase
+
+
+class TestResPartnerResidence(TransactionCase):
+    def _create_partner(self, vals=None):
+        default_vals = {"name": "Test Partner"}
+        if vals:
+            default_vals.update(vals)
+        return self.env["res.partner"].create(default_vals)
+
+    def _create_residence(self, parent, vals=None):
+        default_vals = {
+            "name": parent.name,
+            "parent_id": parent.id,
+            "type": "residence",
+        }
+        if vals:
+            default_vals.update(vals)
+        return self.env["res.partner"].create(default_vals)
+
+    # =====================
+    # residence_partner_id compute
+    # =====================
+
+    def test_residence_partner_id_returns_self_when_no_residence(self):
+        partner = self._create_partner()
+        self.assertEqual(partner.residence_partner_id, partner)
+
+    def test_residence_partner_id_returns_residence_child(self):
+        partner = self._create_partner()
+        residence = self._create_residence(partner)
+        partner.invalidate_recordset()
+
+        self.assertEqual(partner.residence_partner_id, residence)
+
+    def test_residence_partner_id_ignores_other_child_types(self):
+        partner = self._create_partner()
+        self.env["res.partner"].create(
+            {
+                "name": "Contact Child",
+                "parent_id": partner.id,
+                "type": "contact",
+            }
+        )
+        partner.invalidate_recordset()
+
+        self.assertEqual(partner.residence_partner_id, partner)
+
+    def test_residence_partner_id_with_multiple_child_types(self):
+        partner = self._create_partner()
+        self.env["res.partner"].create(
+            {
+                "name": "Invoice Child",
+                "parent_id": partner.id,
+                "type": "invoice",
+            }
+        )
+        residence = self._create_residence(partner)
+        self.env["res.partner"].create(
+            {
+                "name": "Delivery Child",
+                "parent_id": partner.id,
+                "type": "delivery",
+            }
+        )
+        partner.invalidate_recordset()
+
+        self.assertEqual(partner.residence_partner_id, residence)
+
+    # =====================
+    # type selection
+    # =====================
+
+    def test_type_residence_available(self):
+        type_field = self.env["res.partner"]._fields["type"]
+        selection_keys = [key for key, _ in type_field.selection]
+        self.assertIn("residence", selection_keys)
+
+    # =====================
+    # unique index constraint
+    # =====================
+
+    def test_unique_residence_per_parent(self):
+        partner = self._create_partner()
+        self._create_residence(partner)
+
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            self._create_residence(partner)
+
+    def test_multiple_residences_different_parents_allowed(self):
+        partner1 = self._create_partner({"name": "Partner 1"})
+        partner2 = self._create_partner({"name": "Partner 2"})
+
+        residence1 = self._create_residence(partner1)
+        residence2 = self._create_residence(partner2)
+
+        self.assertTrue(residence1)
+        self.assertTrue(residence2)
+        self.assertNotEqual(residence1, residence2)


### PR DESCRIPTION
Change the logics of the inherited method:

- If partner has no residence address and the changes do not conflict with the partner's address: update partner address.
- If partner has residence child: update residence with checkin values
- If the changes conflict with partner's address: update residence if exists, else create residence child.