### PR TITLE
[IMP]pms_api_rest: add document number in general partner filter GET

### DIFF
--- a/pms_api_rest/services/pms_partner_service.py
+++ b/pms_api_rest/services/pms_partner_service.py
@@ -191,6 +191,11 @@ class PmsPartnerService(Component):
                 subdomains.append(
                     [("email", "ilike", pms_partner_search_params.filter)]
                 )
+            document_partner_ids = self._partner_ids_from_id_numbers_sql(
+                pms_partner_search_params.filter
+            )
+            if document_partner_ids:
+                subdomains.append([("id", "in", document_partner_ids)])
             domain_partner_search_field = expression.OR(subdomains)
             domain = expression.AND([domain, domain_partner_search_field])
         allowed_company_ids = self.env.user.company_ids.ids
@@ -349,6 +354,25 @@ class PmsPartnerService(Component):
             )
         return PmsPartnerResults(partners=result_partners, total=total_partners)
 
+    def _partner_ids_from_id_numbers_sql(self, term, limit=3000):
+        term = (term or "").strip()
+        if not term:
+            return []
+
+        pattern = f"%{term}%"
+
+        self.env.cr.execute(
+            """
+            SELECT DISTINCT partner_id
+            FROM res_partner_id_number
+            WHERE partner_id IS NOT NULL
+            AND name ILIKE %s
+            LIMIT %s
+        """,
+            (pattern, limit),
+        )
+        return [r[0] for r in self.env.cr.fetchall()]
+
     @restapi.method(
         [
             (
@@ -403,7 +427,7 @@ class PmsPartnerService(Component):
             .search(
                 [
                     ("partner_id", "=", partner_id),
-                    ("pms_property_id", "=", self.env.user.pms_property_ids.ids),
+                    ("pms_property_id", "in", self.env.user.pms_property_ids.ids),
                 ]
             )
         )


### PR DESCRIPTION
This pull request enhances partner search functionality and fixes a filtering issue in payment queries. The main improvements are the addition of a new search method for partner identification by document numbers and a correction to the payment query logic to support multiple property IDs.

**Partner search enhancements:**
* Added a new method `_partner_ids_from_id_numbers_sql` to efficiently search for partners by partial matches on their document ID numbers using a SQL query. This method returns partner IDs whose document numbers match the search term.
* Integrated the document ID search into the main partner search logic in `get_partners`, allowing users to find partners by document numbers in addition to existing fields.

**Payment query fix:**
* Updated the `get_partner_payments` method to use the `"in"` operator for `pms_property_id`, ensuring payments are correctly filtered when users have access to multiple properties.