### PR TITLE
[FIX]rooomdoo_fastapi: remove res_id and res_model from attachment.

### DIFF
--- a/roomdoo_fastapi/models/res_config_settings.py
+++ b/roomdoo_fastapi/models/res_config_settings.py
@@ -63,8 +63,6 @@ class ResConfigSettings(models.TransientModel):
                         {
                             "name": "roomdoo_fastapi_image",
                             "datas": self.roomdoo_fastapi_image,
-                            "res_model": "res.config.settings",
-                            "res_id": self.id,
                         }
                     )
                 )


### PR DESCRIPTION
When the related id is removed by autovacuum, the attachment is also removed.