### PR TITLE
[ADD] pms_fastapi: folio detail, sale-lines, contacts and invoice con…

### DIFF
--- a/pms_api_rest/__manifest__.py
+++ b/pms_api_rest/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",
     "category": "Generic Modules/Property Management System",
-    "version": "16.0.1.4.1",
+    "version": "16.0.1.4.2",
     "license": "AGPL-3",
     "depends": [
         "pms",

--- a/pms_api_rest/services/pms_transaction_service.py
+++ b/pms_api_rest/services/pms_transaction_service.py
@@ -605,6 +605,7 @@ class PmsTransactionService(Component):
             )
             # Force to complete the statement
             statement._compute_balance_start()
+            self._mark_cash_session_closed(statement)
             return {
                 "result": True,
                 "diff": 0,
@@ -622,6 +623,7 @@ class PmsTransactionService(Component):
             )
             # Force to complete the statement
             statement._compute_balance_start()
+            self._mark_cash_session_closed(statement)
             return {
                 "result": True,
                 "diff": diff,
@@ -745,6 +747,31 @@ class PmsTransactionService(Component):
                     statement_move_line.account_id = payment_move_line.account_id
                     lines_to_reconcile = payment_move_line + statement_move_line
                     lines_to_reconcile.reconcile()
+
+    def _mark_cash_session_closed(self, statement):
+        """TEMPORARY bridge to the FastAPI cash-session state. REMOVE WITH THIS MODULE.
+
+        ``cash_session_closed`` is owned by pms_fastapi (the surviving API),
+        which keys the open/closed state off it. While both APIs coexist behind
+        feature flags a cash session may be opened on one and closed on the
+        other, so this legacy API must also stamp the flag — otherwise a session
+        closed here would still look open to pms_fastapi.
+
+        This is throwaway glue: pms_api_rest is legacy and will be retired. When
+        it is, delete this method (and its callers) outright; nothing here needs
+        to migrate, the field stays in pms_fastapi. The field only exists when
+        pms_fastapi is installed (the only case where anyone reads it), so the
+        write is guarded on its presence.
+        """
+        if "cash_session_closed" not in statement._fields:
+            return
+        statement.write(
+            {
+                "cash_session_closed": True,
+                "cash_session_closed_uid": self.env.user.id,
+                "cash_session_closed_date": fields.Datetime.now(),
+            }
+        )
 
     def _get_last_cash_session(self, journal_id, pms_property_id=False):
         domain = [("journal_id", "=", journal_id)]

--- a/pms_fastapi/__manifest__.py
+++ b/pms_fastapi/__manifest__.py
@@ -18,6 +18,7 @@
         "partner_identification_unique",
         "pms_folio_report",
         "roomdoo_invoices_exporter",
+        "pms_autoreconcile_folio_payments",
     ],
     "external_dependencies": {
         "python": ["pyinstrument"],

--- a/pms_fastapi/__manifest__.py
+++ b/pms_fastapi/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "PMS FastAPI",
-    "version": "16.0.1.3.0",
+    "version": "16.0.1.4.0",
     "development_status": "Beta",
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",

--- a/pms_fastapi/__manifest__.py
+++ b/pms_fastapi/__manifest__.py
@@ -18,6 +18,7 @@
         "partner_identification_unique",
         "pms_folio_report",
         "roomdoo_invoices_exporter",
+        "roomdoo_payments_exporter",
         "pms_autoreconcile_folio_payments",
     ],
     "external_dependencies": {

--- a/pms_fastapi/__manifest__.py
+++ b/pms_fastapi/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "PMS FastAPI",
-    "version": "16.0.1.4.0",
+    "version": "16.0.1.5.0",
     "development_status": "Beta",
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",

--- a/pms_fastapi/i18n/es.po
+++ b/pms_fastapi/i18n/es.po
@@ -1,0 +1,1419 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Access denied"
+msgstr "Acceso denegado"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_needaction
+msgid "Action Needed"
+msgstr "Acción requerida"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "All folio lines must belong to the same property."
+msgstr "Todas las líneas del folio deben pertenecer al mismo hotel."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "All sale lines must belong to the same property."
+msgstr "Todas las líneas de venta deben pertenecer al mismo hotel."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_journal__allowed_on_pms
+msgid "Allowed on PMS"
+msgstr "Permitido en PMS"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_folio__amount_to_invoice
+#: model:ir.model.fields,field_description:pms_fastapi.field_folio_sale_line__amount_to_invoice
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_folio__amount_to_invoice
+msgid "Amount To Invoice"
+msgstr "Importe a facturar"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_fastapi_endpoint__app
+msgid "App"
+msgstr "Aplicación"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_attachment_count
+msgid "Attachment Count"
+msgstr "Número de adjuntos"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_bank_statement
+msgid "Bank Statement"
+msgstr "Extracto bancario"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__mobile_blacklisted
+msgid "Blacklisted Phone Is Mobile"
+msgstr "Teléfono en lista negra es móvil"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_blacklisted
+msgid "Blacklisted Phone is Phone"
+msgstr "Teléfono en lista negra es fijo"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Cancelled invoices cannot be edited."
+msgstr "Las facturas canceladas no se pueden editar."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Cannot specify both 'ids' and filter parameters. Use one or the other."
+msgstr "No se pueden indicar a la vez 'ids' y parámetros de filtro. Use uno u otro."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid "Cash difference observed during the counting (Loss) - closing"
+msgstr "Diferencia de caja observada durante el recuento (pérdida) - cierre"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid "Cash difference observed during the counting (Profit) - closing"
+msgstr "Diferencia de caja observada durante el recuento (ganancia) - cierre"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session %s does not exist."
+msgstr "La sesión de caja %s no existe."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session %s is already closed."
+msgstr "La sesión de caja %s ya está cerrada."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session already closed"
+msgstr "Sesión de caja ya cerrada"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session already open"
+msgstr "Sesión de caja ya abierta"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_closed
+msgid "Cash session closed"
+msgstr "Sesión de caja cerrada"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_closed_uid
+msgid "Cash session closed by"
+msgstr "Sesión de caja cerrada por"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_closed_date
+msgid "Cash session closed on"
+msgstr "Sesión de caja cerrada el"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session not found"
+msgstr "Sesión de caja no encontrada"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_note
+msgid "Cash session note"
+msgstr "Nota de la sesión de caja"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Contact does not meet invoicing requirements."
+msgstr "El contacto no cumple los requisitos de facturación."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Contact not found"
+msgstr "Contacto no encontrado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Contact not found."
+msgstr "Contacto no encontrado."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_partial_reconcile__credit_move_id
+msgid "Credit Move"
+msgstr "Apunte de haber"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_journal.py:0
+#, python-format
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Customer does not meet invoicing requirements."
+msgstr "El cliente no cumple los requisitos de facturación."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Customer not found."
+msgstr "Cliente no encontrado."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_partial_reconcile__debit_move_id
+msgid "Debit Move"
+msgstr "Apunte de debe"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Down-payment invoice out of scope"
+msgstr "Factura de anticipo fuera de alcance"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Down-payment invoices must belong to the same folios as folioLines."
+msgstr "Las facturas de anticipo deben pertenecer a los mismos folios que folioLines."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"Down-payment invoices must belong to the same folios as the invoiced lines."
+msgstr "Las facturas de anticipo deben pertenecer a los mismos folios que las líneas facturadas."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Down-payment invoices not found"
+msgstr "Facturas de anticipo no encontradas"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Duplicate down-payment invoices"
+msgstr "Facturas de anticipo duplicadas"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Duplicate sale lines"
+msgstr "Líneas de venta duplicadas"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Each down-payment invoice can only appear once in the request."
+msgstr "Cada factura de anticipo solo puede aparecer una vez en la petición."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Each folio line can only appear once in the request."
+msgstr "Cada línea del folio solo puede aparecer una vez en la petición."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Each sale line can only appear once in the request."
+msgstr "Cada línea de venta solo puede aparecer una vez en la petición."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/user.py:0
+#, python-format
+msgid "Empty image file uploaded. Use DELETE to remove image."
+msgstr "El archivo de imagen está vacío. Use DELETE para eliminar la imagen."
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_fastapi_endpoint
+msgid "FastAPI Endpoint"
+msgstr "Endpoint FastAPI"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__fastapi_total_invoiced
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__fastapi_total_invoiced
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__fastapi_total_invoiced
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__fastapi_total_invoiced
+msgid "Fastapi Total Invoiced"
+msgstr "Total facturado (FastAPI)"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__phone_sanitized
+msgid ""
+"Field used to store sanitized phone number. Helps speeding up searches and "
+"comparisons."
+msgstr "Campo para almacenar el número de teléfono normalizado. Acelera las búsquedas y comparaciones."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Folio %s does not exist."
+msgstr "El folio %s no existe."
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_folio_sale_line
+msgid "Folio Sale Line"
+msgstr "Línea de venta del folio"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Folio line %s is already included in invoice %s."
+msgstr "La línea del folio %s ya está incluida en la factura %s."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Folio line already invoiced"
+msgstr "Línea del folio ya facturada"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Folio lines from multiple properties"
+msgstr "Líneas del folio de varios hoteles"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_follower_ids
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_partner_ids
+msgid "Followers (Partners)"
+msgstr "Seguidores (contactos)"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__has_message
+msgid "Has Message"
+msgstr "Tiene mensaje"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__has_overdue_payments
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__has_overdue_payments
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__has_overdue_payments
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__has_overdue_payments
+msgid "Has Overdue Payments"
+msgstr "Tiene pagos vencidos"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__identification_number
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__identification_number
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__identification_number
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__identification_number
+msgid "Identification Number"
+msgstr "Número de identificación"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr "Si está marcado, los mensajes nuevos requieren su atención."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_has_error
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr "Si está marcado, algunos mensajes tienen un error de entrega."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_account_journal__allowed_on_pms
+msgid ""
+"If checked, this journal is available for PMS folio invoices and exposes the"
+" hotel/room configuration. Also gates PMS API behaviors that depend on the "
+"journal."
+msgstr "Si está marcado, este diario está disponible para las facturas de folio PMS y expone la configuración de hotel/habitación. También condiciona los comportamientos de la PMS API que dependen del diario."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__phone_sanitized_blacklisted
+msgid ""
+"If the sanitized phone number is on the blacklist, the contact won't receive"
+" mass mailing sms anymore, from any list"
+msgstr "Si el número de teléfono normalizado está en la lista negra, el contacto dejará de recibir SMS de envíos masivos, de cualquier lista"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__in_house
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__in_house
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__in_house
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__in_house
+msgid "In House"
+msgstr "Alojado"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__mobile_blacklisted
+msgid ""
+"Indicates if a blacklisted sanitized phone number is a mobile number. Helps "
+"distinguish which number is blacklisted             when there is both a "
+"mobile and phone field in a model."
+msgstr "Indica si un número normalizado en lista negra es un número móvil. Ayuda a distinguir qué número está en lista negra cuando un modelo tiene a la vez un campo de móvil y otro de teléfono."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__phone_blacklisted
+msgid ""
+"Indicates if a blacklisted sanitized phone number is a phone number. Helps "
+"distinguish which number is blacklisted             when there is both a "
+"mobile and phone field in a model."
+msgstr "Indica si un número normalizado en lista negra es un número de teléfono. Ayuda a distinguir qué número está en lista negra cuando un modelo tiene a la vez un campo de móvil y otro de teléfono."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid ""
+"Internal transfers only allow bank or cash journals. Invalid journals: %s."
+msgstr "Las transferencias internas solo permiten diarios de banco o caja. Diarios no válidos: %s."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invalid down-payment invoice"
+msgstr "Factura de anticipo no válida"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invalid folio line"
+msgstr "Línea del folio no válida"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invalid invoice composition"
+msgstr "Composición de factura no válida"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invalid reconciliation id"
+msgstr "Id de conciliación no válido"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invalid sale line"
+msgstr "Línea de venta no válida"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Invoice %s does not exist."
+msgstr "La factura %s no existe."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Invoice %s has no associated folio."
+msgstr "La factura %s no tiene folio asociado."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice %s is in state \"%s\" and cannot be validated."
+msgstr "La factura %s está en estado \"%s\" y no se puede validar."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invoice creation failed"
+msgstr "Error al crear la factura"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not editable"
+msgstr "Factura no editable"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not found"
+msgstr "Factura no encontrada"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not found."
+msgstr "Factura no encontrada."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not in draft state"
+msgstr "La factura no está en estado borrador"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invoice posting failed"
+msgstr "Error al validar la factura"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invoicing validation failed"
+msgstr "La validación de facturación ha fallado"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_is_follower
+msgid "Is Follower"
+msgstr "Es seguidor"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move_line__is_overdue
+msgid "Is Overdue"
+msgstr "Está vencido"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner_id_category__validable_document
+msgid "Is Validable Document"
+msgstr "Documento validable"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_journal
+msgid "Journal"
+msgstr "Diario"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Journal %s already has an open cash session."
+msgstr "El diario %s ya tiene una sesión de caja abierta."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Journal %s does not exist."
+msgstr "El diario %s no existe."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Journal %s is not of type cash; cannot operate a cash session on it."
+msgstr "El diario %s no es de tipo caja; no se puede operar una sesión de caja en él."
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento contable"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Journal is not a cash journal"
+msgstr "El diario no es de caja"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/user.py:0
+#, python-format
+msgid "Language %s is not available."
+msgstr "El idioma %s no está disponible."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__last_reservation_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__last_reservation_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__last_reservation_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__last_reservation_id
+msgid "Last Reservation"
+msgstr "Última reserva"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_main_attachment_id
+msgid "Main Attachment"
+msgstr "Adjunto principal"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_content
+msgid "Message Content"
+msgstr "Contenido del mensaje"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_has_error
+msgid "Message Delivery error"
+msgstr "Error de entrega del mensaje"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_content
+msgid "Message content, to be used only in searches"
+msgstr "Contenido del mensaje, para usar solo en búsquedas"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_ids
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__min_overdue_date
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__min_overdue_date
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__min_overdue_date
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__min_overdue_date
+msgid "Minimum Overdue Payment Date"
+msgstr "Fecha mínima de pago vencido"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Missing fiscal identification number"
+msgstr "Falta el número de identificación fiscal"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Multiple invoices created"
+msgstr "Se han creado varias facturas"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Mutually exclusive parameters"
+msgstr "Parámetros mutuamente excluyentes"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "No invoice could be built from the provided composition."
+msgstr "No se ha podido construir ninguna factura con la composición indicada."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "No invoice could be created from the provided sale lines."
+msgstr "No se ha podido crear ninguna factura con las líneas de venta indicadas."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "No reconciliation exists between invoice %s and payment %s."
+msgstr "No existe conciliación entre la factura %s y el pago %s."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Not found"
+msgstr "No encontrado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Not implemented"
+msgstr "No implementado"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_account_bank_statement__cash_session_note
+msgid "Note left for the next shift when closing the cash session."
+msgstr "Nota dejada para el siguiente turno al cerrar la sesión de caja."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_needaction_counter
+msgid "Number of Actions"
+msgstr "Número de acciones"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_has_error_counter
+msgid "Number of errors"
+msgstr "Número de errores"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de entrega"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
+"One or more folio lines were asked to invoice more than their pending "
+"quantity."
+msgstr "Se ha solicitado facturar más de la cantidad pendiente en una o más líneas del folio."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"One or more sale lines were asked to invoice a quantity greater than their "
+"pending quantity."
+msgstr "Se ha solicitado facturar una cantidad mayor que la pendiente en una o más líneas de venta."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Only down-payment invoices are accepted as downpaymentLines."
+msgstr "Solo se aceptan facturas de anticipo como downpaymentLines."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Origin and destination journals cannot be the same."
+msgstr "El diario de origen y el de destino no pueden ser el mismo."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "PDF report generation is not yet implemented."
+msgstr "La generación de informes PDF aún no está implementada."
+
+#. module: pms_fastapi
+#: model:ir.model.fields.selection,name:pms_fastapi.selection__fastapi_endpoint__app__pms_api
+msgid "PMS API"
+msgstr "PMS API"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_cash_session_cash_session_router_helper
+msgid "PMS API Cash Session Router Helper"
+msgstr "Helper del router de sesiones de caja (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_contact_contact_fiscal_document_type_router_helper
+msgid "PMS API Fiscal Document Type Router Helper"
+msgstr "Helper del router de tipos de documento fiscal (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_invoice_invoice_router_helper
+msgid "PMS API Invoice Router Helper"
+msgstr "Helper del router de facturas (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_journal_journal_router_helper
+msgid "PMS API Journal Router Helper"
+msgstr "Helper del router de diarios (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_payment_method_payment_method_router_helper
+msgid "PMS API Payment Method Router Helper"
+msgstr "Helper del router de métodos de pago (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_payment_payment_router_helper
+msgid "PMS API Payment Router Helper"
+msgstr "Helper del router de pagos (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_reservation_guest_router_helper
+msgid "PMS API Reservation Guest Router Helper"
+msgstr "Helper del router de huéspedes de reserva (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_reservation_router_helper
+msgid "PMS API Reservation Router Helper"
+msgstr "Helper del router de reservas (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_folio
+msgid "PMS Folio"
+msgstr "Folio PMS"
+
+#. module: pms_fastapi
+#: model:res.groups,name:pms_fastapi.pms_fastapi_group
+msgid "PMS endpoint group"
+msgstr "Grupo de endpoints PMS"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_partial_reconcile
+msgid "Partial Reconcile"
+msgstr "Conciliación parcial"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Partner %s does not exist."
+msgstr "El contacto %s no existe."
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_res_partner_id_category
+msgid "Partner ID Category"
+msgstr "Categoría de documento de identidad"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment %s does not exist."
+msgstr "El pago %s no existe."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment %s is already reconciled with invoice %s."
+msgstr "El pago %s ya está conciliado con la factura %s."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment %s not found."
+msgstr "Pago %s no encontrado."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment_method_line__payment_method_id
+msgid "Payment Method"
+msgstr "Método de pago"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_payment_method_line
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__payment_method_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__payment_method_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__payment_method_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__payment_method_ids
+msgid "Payment Methods"
+msgstr "Métodos de pago"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment already reconciled"
+msgstr "Pago ya conciliado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment does not belong to any folio of this invoice."
+msgstr "El pago no pertenece a ningún folio de esta factura."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment does not belong to the invoice's customer."
+msgstr "El pago no pertenece al cliente de la factura."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment is not in a reconcilable state."
+msgstr "El pago no está en un estado conciliable."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment method %s does not exist."
+msgstr "El método de pago %s no existe."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment not applicable"
+msgstr "Pago no aplicable"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment not found"
+msgstr "Pago no encontrado"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_sanitized_blacklisted
+msgid "Phone Blacklisted"
+msgstr "Teléfono en lista negra"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_mobile_search
+msgid "Phone/Mobile"
+msgstr "Teléfono/Móvil"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid ""
+"Please go on the %s journal and define a Loss Account. This account will be "
+"used to record cash difference."
+msgstr "Vaya al diario %s y defina una cuenta de pérdidas. Esta cuenta se usará para registrar la diferencia de caja."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid ""
+"Please go on the %s journal and define a Profit Account. This account will "
+"be used to record cash difference."
+msgstr "Vaya al diario %s y defina una cuenta de ganancias. Esta cuenta se usará para registrar la diferencia de caja."
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_agency_agency_router_helper
+msgid "Pms api agency Service Helper"
+msgstr "Helper de servicio de agencias (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_contact_contact_id_number_router_helper
+msgid "Pms api contact  id number Service Helper"
+msgstr "Helper de servicio de documentos de identidad de contacto (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_contact_contact_router_helper
+#: model:ir.model,name:pms_fastapi.model_pms_api_user_router_helper
+msgid "Pms api contact Service Helper"
+msgstr "Helper de servicio de contactos (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_customer_customer_router_helper
+msgid "Pms api customer Service Helper"
+msgstr "Helper de servicio de clientes (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_folio_folio_router_helper
+msgid "Pms api folio Service Helper"
+msgstr "Helper de servicio de folios (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_guest_guest_router_helper
+msgid "Pms api guest Service Helper"
+msgstr "Helper de servicio de huéspedes (PMS API)"
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_supplier_supplier_router_helper
+msgid "Pms api supplier Service Helper"
+msgstr "Helper de servicio de proveedores (PMS API)"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Property not found."
+msgstr "Hotel no encontrado."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Quantity to invoice exceeds pending quantity"
+msgstr "La cantidad a facturar supera la cantidad pendiente"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reconciliation id '%s' is malformed. Expected 'payment_{id}'."
+msgstr "El id de conciliación '%s' tiene un formato incorrecto. Se esperaba 'payment_{id}'."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reconciliation not found"
+msgstr "Conciliación no encontrada"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Record limit exceeded"
+msgstr "Límite de registros superado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Record not found"
+msgstr "Registro no encontrado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Refund confirmation required"
+msgstr "Se requiere confirmación del abono"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_channel_wubook_pms_folio__amount_to_invoice
+#: model:ir.model.fields,help:pms_fastapi.field_pms_folio__amount_to_invoice
+msgid "Remaining amount to invoice on the folio (taxes included)"
+msgstr "Importe pendiente de facturar en el folio (impuestos incluidos)"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_folio_sale_line__amount_to_invoice
+msgid "Remaining amount to invoice on the folio line (taxes included)"
+msgstr "Importe pendiente de facturar en la línea del folio (impuestos incluidos)"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__replaced_by_invoice_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__replaced_by_invoice_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__replaced_by_invoice_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__replaced_by_invoice_ids
+msgid "Replaced By Invoices"
+msgstr "Reemplazado por facturas"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__replaces_invoice_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__replaces_invoice_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__replaces_invoice_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__replaces_invoice_id
+msgid "Replaces Invoice"
+msgstr "Reemplaza a la factura"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation %s cannot be confirmed as departed in its current state."
+msgstr "La reserva %s no se puede confirmar como salida en su estado actual."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation %s cannot revert arrival in its current state."
+msgstr "La reserva %s no puede revertir la llegada en su estado actual."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation %s does not exist."
+msgstr "La reserva %s no existe."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation not found"
+msgstr "Reserva no encontrada"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation state does not allow confirming departures"
+msgstr "El estado de la reserva no permite confirmar salidas"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation state does not allow reverting arrival"
+msgstr "El estado de la reserva no permite revertir la llegada"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr "Error de entrega de SMS"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Sale lines from multiple properties"
+msgstr "Líneas de venta de varios hoteles"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Sale lines not found"
+msgstr "Líneas de venta no encontradas"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_sanitized
+msgid "Sanitized Number"
+msgstr "Número normalizado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"Sections, notes and down payments cannot be invoiced through this endpoint."
+msgstr "Las secciones, notas y anticipos no se pueden facturar a través de este endpoint."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Sections, notes and down payments cannot be sent as folioLines."
+msgstr "Las secciones, notas y anticipos no se pueden enviar como folioLines."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Simplified invoice limit exceeded"
+msgstr "Límite de factura simplificada superado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Some down-payment invoices could not be found."
+msgstr "No se han encontrado algunas facturas de anticipo."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Some folio lines cannot be invoiced."
+msgstr "Algunas líneas del folio no se pueden facturar."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Some folio lines could not be found."
+msgstr "No se han encontrado algunas líneas del folio."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Some sale lines could not be found."
+msgstr "No se han encontrado algunas líneas de venta."
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_folio__fastapi_sort_state
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_folio__fastapi_sort_state
+msgid "Sort State"
+msgstr "Estado de ordenación"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "The contact has no fiscal identification number configured."
+msgstr "El contacto no tiene configurado un número de identificación fiscal."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "The export requested %s records, but the maximum allowed is %s."
+msgstr "La exportación solicitó %s registros, pero el máximo permitido es %s."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/contact_id_number.py:0
+#, python-format
+msgid "The id number %s does not belong to the contact %s"
+msgstr "El número de identificación %s no pertenece al contacto %s"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "The invoice state does not allow new reconciliations."
+msgstr "El estado de la factura no permite nuevas conciliaciones."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "The invoice state does not allow undoing reconciliations."
+msgstr "El estado de la factura no permite deshacer conciliaciones."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"The invoice total exceeds the simplified invoice limit configured for this "
+"property."
+msgstr "El total de la factura supera el límite de factura simplificada configurado para este hotel."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
+"The provided composition could not be grouped into a single invoice "
+"(different currency or company)."
+msgstr "La composición indicada no se pudo agrupar en una sola factura (moneda o compañía distintas)."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"The provided sale lines could not be grouped into a single invoice "
+"(different currency or company)."
+msgstr "Las líneas de venta indicadas no se pudieron agrupar en una sola factura (moneda o compañía distintas)."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/utils.py:0
+#, python-format
+msgid "The record do not exist"
+msgstr "El registro no existe"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
+"This invoice is validated. Editing it will generate a refund and a new "
+"corrected invoice. Confirm by passing confirmRefund=true."
+msgstr "Esta factura está validada. Editarla generará un abono y una nueva factura rectificada. Confirme pasando confirmRefund=true."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_journal.py:0
+#, python-format
+msgid "Type"
+msgstr "Tipo"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Validation error"
+msgstr "Error de validación"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__website_message_ids
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__website_message_ids
+msgid "Website communication history"
+msgstr "Historial de comunicación del sitio web"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "You are not allowed to access some of the requested sale lines."
+msgstr "No tiene permiso para acceder a algunas de las líneas de venta solicitadas."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/schemas/base.py:0
+#, python-format
+msgid "You are not allowed to access these properties. %s"
+msgstr "No tiene permiso para acceder a estos hoteles. %s"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/schemas/base.py:0
+#: code:addons/pms_fastapi/schemas/base.py:0
+#, python-format
+msgid "You are not allowed to access this properties. %s"
+msgstr "No tiene permiso para acceder a estos hoteles. %s"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_journal.py:0
+#, python-format
+msgid ""
+"You cannot change %(fields)s on journal '%(journal)s' because it has "
+"payments linked to its payment method lines. Changing these fields would "
+"orphan those lines and break payment traceability."
+msgstr "No puede cambiar %(fields)s en el diario '%(journal)s' porque tiene pagos vinculados a sus líneas de método de pago. Cambiar estos campos dejaría huérfanas esas líneas y rompería la trazabilidad de los pagos."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/contact.py:0
+#: code:addons/pms_fastapi/routers/contact_id_number.py:0
+#, python-format
+msgid "contact not found"
+msgstr "contacto no encontrado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "folio not found"
+msgstr "folio no encontrado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "folioId and invoiceId are mutually exclusive."
+msgstr "folioId e invoiceId son mutuamente excluyentes."
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_fastapi_login_endpoint
+msgid "login endpoint helper"
+msgstr "Helper del endpoint de login"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "paymentMethodId does not apply to an internal transfer."
+msgstr "paymentMethodId no aplica a una transferencia interna."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "sale line not found"
+msgstr "línea de venta no encontrada"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "supplierPayment requires partnerId."
+msgstr "supplierPayment requiere partnerId."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/login.py:0
+#, python-format
+msgid "wrong user/pass"
+msgstr "usuario/contraseña incorrectos"

--- a/pms_fastapi/i18n/es.po
+++ b/pms_fastapi/i18n/es.po
@@ -77,12 +77,20 @@ msgstr "Teléfono en lista negra es fijo"
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
+msgid "Cancelled invoices cannot be deleted."
+msgstr "Las facturas canceladas no se pueden eliminar."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
 msgid "Cancelled invoices cannot be edited."
 msgstr "Las facturas canceladas no se pueden editar."
 
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "Cannot specify both 'ids' and filter parameters. Use one or the other."
@@ -219,6 +227,13 @@ msgstr "Apunte de debe"
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Destination payment method must be inbound."
+msgstr "El método de pago de destino debe ser de entrada."
+
+#. module: pms_fastapi
+#. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
@@ -312,6 +327,13 @@ msgid ""
 "Field used to store sanitized phone number. Helps speeding up searches and "
 "comparisons."
 msgstr "Campo para almacenar el número de teléfono normalizado. Acelera las búsquedas y comparaciones."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Fiscal lock date"
+msgstr "Fecha de bloqueo fiscal"
 
 #. module: pms_fastapi
 #. odoo-python
@@ -429,14 +451,6 @@ msgstr "Indica si un número normalizado en lista negra es un número de teléfo
 
 #. module: pms_fastapi
 #. odoo-python
-#: code:addons/pms_fastapi/routers/payment.py:0
-#, python-format
-msgid ""
-"Internal transfers only allow bank or cash journals. Invalid journals: %s."
-msgstr "Las transferencias internas solo permiten diarios de banco o caja. Diarios no válidos: %s."
-
-#. module: pms_fastapi
-#. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
@@ -506,6 +520,13 @@ msgstr "Error al crear la factura"
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not deletable"
+msgstr "Factura no eliminable"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
@@ -522,6 +543,7 @@ msgstr "Factura no encontrada"
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
@@ -583,14 +605,6 @@ msgstr "Diario"
 #, python-format
 msgid "Journal %s already has an open cash session."
 msgstr "El diario %s ya tiene una sesión de caja abierta."
-
-#. module: pms_fastapi
-#. odoo-python
-#: code:addons/pms_fastapi/routers/payment.py:0
-#: code:addons/pms_fastapi/routers/payment.py:0
-#, python-format
-msgid "Journal %s does not exist."
-msgstr "El diario %s no existe."
 
 #. module: pms_fastapi
 #. odoo-python
@@ -682,6 +696,7 @@ msgstr "Se han creado varias facturas"
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "Mutually exclusive parameters"
@@ -711,6 +726,7 @@ msgstr "No existe conciliación entre la factura %s y el pago %s."
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
@@ -787,6 +803,13 @@ msgstr "Solo se aceptan facturas de anticipo como downpaymentLines."
 #, python-format
 msgid "Origin and destination journals cannot be the same."
 msgstr "El diario de origen y el de destino no pueden ser el mismo."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Origin payment method must be outbound."
+msgstr "El método de pago de origen debe ser de salida."
 
 #. module: pms_fastapi
 #. odoo-python
@@ -911,6 +934,13 @@ msgstr "Métodos de pago"
 #, python-format
 msgid "Payment already reconciled"
 msgstr "Pago ya conciliado"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment cannot be modified"
+msgstr "El pago no se puede modificar"
 
 #. module: pms_fastapi
 #. odoo-python
@@ -1057,6 +1087,7 @@ msgstr "Conciliación no encontrada"
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "Record limit exceeded"
@@ -1071,6 +1102,7 @@ msgstr "Registro no encontrado"
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
 msgid "Refund confirmation required"
@@ -1144,6 +1176,20 @@ msgstr "El estado de la reserva no permite confirmar salidas"
 #, python-format
 msgid "Reservation state does not allow reverting arrival"
 msgstr "El estado de la reserva no permite revertir la llegada"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reversal of: %(move_name)s, %(reason)s"
+msgstr "Reversión de: %(move_name)s, %(reason)s"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reversal of: %s"
+msgstr "Reversión de: %s"
 
 #. module: pms_fastapi
 #: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_has_sms_error
@@ -1237,6 +1283,7 @@ msgstr "El contacto no tiene configurado un número de identificación fiscal."
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "The export requested %s records, but the maximum allowed is %s."
@@ -1274,6 +1321,15 @@ msgstr "El total de la factura supera el límite de factura simplificada configu
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid ""
+"The payment date falls within a locked fiscal period and cannot be "
+"cancelled."
+msgstr "La fecha del pago cae dentro de un periodo fiscal bloqueado y no se puede cancelar."
+
+#. module: pms_fastapi
+#. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
 msgid ""
@@ -1302,9 +1358,26 @@ msgstr "El registro no existe"
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
 msgid ""
+"This invoice is validated. Deleting it will generate a refund that cancels "
+"it. Confirm by passing confirmRefund=true."
+msgstr "Esta factura está validada. Al eliminarla se generará un abono que la cancela. Confírmalo pasando confirmRefund=true."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
 "This invoice is validated. Editing it will generate a refund and a new "
 "corrected invoice. Confirm by passing confirmRefund=true."
 msgstr "Esta factura está validada. Editarla generará un abono y una nueva factura rectificada. Confirme pasando confirmRefund=true."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid ""
+"This payment is reconciled against a bank statement and cannot be modified."
+msgstr "Este pago está conciliado con un extracto bancario y no se puede modificar."
 
 #. module: pms_fastapi
 #. odoo-python
@@ -1389,6 +1462,13 @@ msgstr "folioId e invoiceId son mutuamente excluyentes."
 #: model:ir.model,name:pms_fastapi.model_pms_fastapi_login_endpoint
 msgid "login endpoint helper"
 msgstr "Helper del endpoint de login"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "payment"
+msgstr "pago"
 
 #. module: pms_fastapi
 #. odoo-python

--- a/pms_fastapi/i18n/es.po
+++ b/pms_fastapi/i18n/es.po
@@ -1218,6 +1218,20 @@ msgstr "Número normalizado"
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/models/fastapi_endpoint.py:0
+#, python-format
+msgid "Search text must be at least %s characters."
+msgstr "El texto de búsqueda debe tener al menos %s caracteres."
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/fastapi_endpoint.py:0
+#, python-format
+msgid "Search text too short"
+msgstr "Texto de búsqueda demasiado corto"
+
+#. module: pms_fastapi
+#. odoo-python
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid ""

--- a/pms_fastapi/i18n/pms_fastapi.pot
+++ b/pms_fastapi/i18n/pms_fastapi.pot
@@ -1,0 +1,1422 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* pms_fastapi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Access denied"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "All folio lines must belong to the same property."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "All sale lines must belong to the same property."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_journal__allowed_on_pms
+msgid "Allowed on PMS"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_folio__amount_to_invoice
+#: model:ir.model.fields,field_description:pms_fastapi.field_folio_sale_line__amount_to_invoice
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_folio__amount_to_invoice
+msgid "Amount To Invoice"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_fastapi_endpoint__app
+msgid "App"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_bank_statement
+msgid "Bank Statement"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__mobile_blacklisted
+msgid "Blacklisted Phone Is Mobile"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_blacklisted
+msgid "Blacklisted Phone is Phone"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Cancelled invoices cannot be edited."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Cannot specify both 'ids' and filter parameters. Use one or the other."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid "Cash difference observed during the counting (Loss) - closing"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid "Cash difference observed during the counting (Profit) - closing"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session %s is already closed."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session already closed"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session already open"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_closed
+msgid "Cash session closed"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_closed_uid
+msgid "Cash session closed by"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_closed_date
+msgid "Cash session closed on"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Cash session not found"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement__cash_session_note
+msgid "Cash session note"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Contact does not meet invoicing requirements."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Contact not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Contact not found."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_partial_reconcile__credit_move_id
+msgid "Credit Move"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_journal.py:0
+#, python-format
+msgid "Currency"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Customer does not meet invoicing requirements."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Customer not found."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_partial_reconcile__debit_move_id
+msgid "Debit Move"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Down-payment invoice out of scope"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Down-payment invoices must belong to the same folios as folioLines."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"Down-payment invoices must belong to the same folios as the invoiced lines."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Down-payment invoices not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Duplicate down-payment invoices"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Duplicate sale lines"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Each down-payment invoice can only appear once in the request."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Each folio line can only appear once in the request."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Each sale line can only appear once in the request."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/user.py:0
+#, python-format
+msgid "Empty image file uploaded. Use DELETE to remove image."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_fastapi_endpoint
+msgid "FastAPI Endpoint"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__fastapi_total_invoiced
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__fastapi_total_invoiced
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__fastapi_total_invoiced
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__fastapi_total_invoiced
+msgid "Fastapi Total Invoiced"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__phone_sanitized
+msgid ""
+"Field used to store sanitized phone number. Helps speeding up searches and "
+"comparisons."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Folio %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_folio_sale_line
+msgid "Folio Sale Line"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Folio line %s is already included in invoice %s."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Folio line already invoiced"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Folio lines from multiple properties"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__has_overdue_payments
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__has_overdue_payments
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__has_overdue_payments
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__has_overdue_payments
+msgid "Has Overdue Payments"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__identification_number
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__identification_number
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__identification_number
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__identification_number
+msgid "Identification Number"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_has_error
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_account_journal__allowed_on_pms
+msgid ""
+"If checked, this journal is available for PMS folio invoices and exposes the"
+" hotel/room configuration. Also gates PMS API behaviors that depend on the "
+"journal."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__phone_sanitized_blacklisted
+msgid ""
+"If the sanitized phone number is on the blacklist, the contact won't receive"
+" mass mailing sms anymore, from any list"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__in_house
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__in_house
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__in_house
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__in_house
+msgid "In House"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__mobile_blacklisted
+msgid ""
+"Indicates if a blacklisted sanitized phone number is a mobile number. Helps "
+"distinguish which number is blacklisted             when there is both a "
+"mobile and phone field in a model."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__phone_blacklisted
+msgid ""
+"Indicates if a blacklisted sanitized phone number is a phone number. Helps "
+"distinguish which number is blacklisted             when there is both a "
+"mobile and phone field in a model."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid ""
+"Internal transfers only allow bank or cash journals. Invalid journals: %s."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invalid down-payment invoice"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invalid folio line"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invalid invoice composition"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invalid reconciliation id"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invalid sale line"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Invoice %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Invoice %s has no associated folio."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice %s is in state \"%s\" and cannot be validated."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invoice creation failed"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not editable"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not found."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not in draft state"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invoice posting failed"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Invoicing validation failed"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move_line__is_overdue
+msgid "Is Overdue"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner_id_category__validable_document
+msgid "Is Validable Document"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Journal %s already has an open cash session."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Journal %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Journal %s is not of type cash; cannot operate a cash session on it."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/cash_session.py:0
+#, python-format
+msgid "Journal is not a cash journal"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/user.py:0
+#, python-format
+msgid "Language %s is not available."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_property_availability__last_reservation_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_property__last_reservation_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__last_reservation_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_users__last_reservation_id
+msgid "Last Reservation"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_main_attachment_id
+msgid "Main Attachment"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_content
+msgid "Message Content"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_content
+msgid "Message content, to be used only in searches"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__min_overdue_date
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__min_overdue_date
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__min_overdue_date
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__min_overdue_date
+msgid "Minimum Overdue Payment Date"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Missing fiscal identification number"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Multiple invoices created"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Mutually exclusive parameters"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "No invoice could be built from the provided composition."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "No invoice could be created from the provided sale lines."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "No reconciliation exists between invoice %s and payment %s."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Not implemented"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_account_bank_statement__cash_session_note
+msgid "Note left for the next shift when closing the cash session."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
+"One or more folio lines were asked to invoice more than their pending "
+"quantity."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"One or more sale lines were asked to invoice a quantity greater than their "
+"pending quantity."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Only down-payment invoices are accepted as downpaymentLines."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Origin and destination journals cannot be the same."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "PDF report generation is not yet implemented."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields.selection,name:pms_fastapi.selection__fastapi_endpoint__app__pms_api
+msgid "PMS API"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_cash_session_cash_session_router_helper
+msgid "PMS API Cash Session Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_contact_contact_fiscal_document_type_router_helper
+msgid "PMS API Fiscal Document Type Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_invoice_invoice_router_helper
+msgid "PMS API Invoice Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_journal_journal_router_helper
+msgid "PMS API Journal Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_payment_method_payment_method_router_helper
+msgid "PMS API Payment Method Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_payment_payment_router_helper
+msgid "PMS API Payment Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_reservation_guest_router_helper
+msgid "PMS API Reservation Guest Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_reservation_router_helper
+msgid "PMS API Reservation Router Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_folio
+msgid "PMS Folio"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:res.groups,name:pms_fastapi.pms_fastapi_group
+msgid "PMS endpoint group"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_partial_reconcile
+msgid "Partial Reconcile"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Partner %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_res_partner_id_category
+msgid "Partner ID Category"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment %s is already reconciled with invoice %s."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment %s not found."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment_method_line__payment_method_id
+msgid "Payment Method"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_account_payment_method_line
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__payment_method_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__payment_method_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__payment_method_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__payment_method_ids
+msgid "Payment Methods"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment already reconciled"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment does not belong to any folio of this invoice."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment does not belong to the invoice's customer."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment is not in a reconcilable state."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment method %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Payment not applicable"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment not found"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_sanitized_blacklisted
+msgid "Phone Blacklisted"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_mobile_search
+msgid "Phone/Mobile"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid ""
+"Please go on the %s journal and define a Loss Account. This account will be "
+"used to record cash difference."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_bank_statement.py:0
+#, python-format
+msgid ""
+"Please go on the %s journal and define a Profit Account. This account will "
+"be used to record cash difference."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_agency_agency_router_helper
+msgid "Pms api agency Service Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_contact_contact_id_number_router_helper
+msgid "Pms api contact  id number Service Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_contact_contact_router_helper
+#: model:ir.model,name:pms_fastapi.model_pms_api_user_router_helper
+msgid "Pms api contact Service Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_customer_customer_router_helper
+msgid "Pms api customer Service Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_folio_folio_router_helper
+msgid "Pms api folio Service Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_guest_guest_router_helper
+msgid "Pms api guest Service Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_api_supplier_supplier_router_helper
+msgid "Pms api supplier Service Helper"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Property not found."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Quantity to invoice exceeds pending quantity"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reconciliation id '%s' is malformed. Expected 'payment_{id}'."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reconciliation not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Record limit exceeded"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Record not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Refund confirmation required"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_channel_wubook_pms_folio__amount_to_invoice
+#: model:ir.model.fields,help:pms_fastapi.field_pms_folio__amount_to_invoice
+msgid "Remaining amount to invoice on the folio (taxes included)"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_folio_sale_line__amount_to_invoice
+msgid "Remaining amount to invoice on the folio line (taxes included)"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__replaced_by_invoice_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__replaced_by_invoice_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__replaced_by_invoice_ids
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__replaced_by_invoice_ids
+msgid "Replaced By Invoices"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_bank_statement_line__replaces_invoice_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_move__replaces_invoice_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_account_payment__replaces_invoice_id
+#: model:ir.model.fields,field_description:pms_fastapi.field_docuware_account_move__replaces_invoice_id
+msgid "Replaces Invoice"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation %s cannot be confirmed as departed in its current state."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation %s cannot revert arrival in its current state."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation %s does not exist."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation state does not allow confirming departures"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_reservation.py:0
+#, python-format
+msgid "Reservation state does not allow reverting arrival"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Sale lines from multiple properties"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Sale lines not found"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__phone_sanitized
+msgid "Sanitized Number"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"Sections, notes and down payments cannot be invoiced through this endpoint."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Sections, notes and down payments cannot be sent as folioLines."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Simplified invoice limit exceeded"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Some down-payment invoices could not be found."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Some folio lines cannot be invoiced."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Some folio lines could not be found."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "Some sale lines could not be found."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_channel_wubook_pms_folio__fastapi_sort_state
+#: model:ir.model.fields,field_description:pms_fastapi.field_pms_folio__fastapi_sort_state
+msgid "Sort State"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "The contact has no fiscal identification number configured."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "The export requested %s records, but the maximum allowed is %s."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/contact_id_number.py:0
+#, python-format
+msgid "The id number %s does not belong to the contact %s"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "The invoice state does not allow new reconciliations."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "The invoice state does not allow undoing reconciliations."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"The invoice total exceeds the simplified invoice limit configured for this "
+"property."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
+"The provided composition could not be grouped into a single invoice "
+"(different currency or company)."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid ""
+"The provided sale lines could not be grouped into a single invoice "
+"(different currency or company)."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/utils.py:0
+#, python-format
+msgid "The record do not exist"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
+"This invoice is validated. Editing it will generate a refund and a new "
+"corrected invoice. Confirm by passing confirmRefund=true."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_journal.py:0
+#, python-format
+msgid "Type"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Validation error"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,field_description:pms_fastapi.field_res_partner__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model.fields,help:pms_fastapi.field_res_partner__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "You are not allowed to access some of the requested sale lines."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/schemas/base.py:0
+#, python-format
+msgid "You are not allowed to access these properties. %s"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/schemas/base.py:0
+#: code:addons/pms_fastapi/schemas/base.py:0
+#, python-format
+msgid "You are not allowed to access this properties. %s"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/account_journal.py:0
+#, python-format
+msgid ""
+"You cannot change %(fields)s on journal '%(journal)s' because it has "
+"payments linked to its payment method lines. Changing these fields would "
+"orphan those lines and break payment traceability."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/contact.py:0
+#: code:addons/pms_fastapi/routers/contact_id_number.py:0
+#, python-format
+msgid "contact not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "folio not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "folioId and invoiceId are mutually exclusive."
+msgstr ""
+
+#. module: pms_fastapi
+#: model:ir.model,name:pms_fastapi.model_pms_fastapi_login_endpoint
+msgid "login endpoint helper"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "paymentMethodId does not apply to an internal transfer."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/pms_folio.py:0
+#, python-format
+msgid "sale line not found"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "supplierPayment requires partnerId."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/login.py:0
+#, python-format
+msgid "wrong user/pass"
+msgstr ""

--- a/pms_fastapi/i18n/pms_fastapi.pot
+++ b/pms_fastapi/i18n/pms_fastapi.pot
@@ -1221,6 +1221,20 @@ msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/models/fastapi_endpoint.py:0
+#, python-format
+msgid "Search text must be at least %s characters."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/models/fastapi_endpoint.py:0
+#, python-format
+msgid "Search text too short"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid ""

--- a/pms_fastapi/i18n/pms_fastapi.pot
+++ b/pms_fastapi/i18n/pms_fastapi.pot
@@ -80,12 +80,20 @@ msgstr ""
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
+msgid "Cancelled invoices cannot be deleted."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
 msgid "Cancelled invoices cannot be edited."
 msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "Cannot specify both 'ids' and filter parameters. Use one or the other."
@@ -222,6 +230,13 @@ msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Destination payment method must be inbound."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
@@ -314,6 +329,13 @@ msgstr ""
 msgid ""
 "Field used to store sanitized phone number. Helps speeding up searches and "
 "comparisons."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Fiscal lock date"
 msgstr ""
 
 #. module: pms_fastapi
@@ -432,14 +454,6 @@ msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
-#: code:addons/pms_fastapi/routers/payment.py:0
-#, python-format
-msgid ""
-"Internal transfers only allow bank or cash journals. Invalid journals: %s."
-msgstr ""
-
-#. module: pms_fastapi
-#. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
@@ -509,6 +523,13 @@ msgstr ""
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Invoice not deletable"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
@@ -525,6 +546,7 @@ msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
@@ -585,14 +607,6 @@ msgstr ""
 #: code:addons/pms_fastapi/routers/cash_session.py:0
 #, python-format
 msgid "Journal %s already has an open cash session."
-msgstr ""
-
-#. module: pms_fastapi
-#. odoo-python
-#: code:addons/pms_fastapi/routers/payment.py:0
-#: code:addons/pms_fastapi/routers/payment.py:0
-#, python-format
-msgid "Journal %s does not exist."
 msgstr ""
 
 #. module: pms_fastapi
@@ -685,6 +699,7 @@ msgstr ""
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "Mutually exclusive parameters"
@@ -714,6 +729,7 @@ msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
@@ -789,6 +805,13 @@ msgstr ""
 #: code:addons/pms_fastapi/routers/payment.py:0
 #, python-format
 msgid "Origin and destination journals cannot be the same."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Origin payment method must be outbound."
 msgstr ""
 
 #. module: pms_fastapi
@@ -913,6 +936,13 @@ msgstr ""
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
 msgid "Payment already reconciled"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "Payment cannot be modified"
 msgstr ""
 
 #. module: pms_fastapi
@@ -1060,6 +1090,7 @@ msgstr ""
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "Record limit exceeded"
@@ -1074,6 +1105,7 @@ msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
 msgid "Refund confirmation required"
@@ -1146,6 +1178,20 @@ msgstr ""
 #: code:addons/pms_fastapi/routers/pms_reservation.py:0
 #, python-format
 msgid "Reservation state does not allow reverting arrival"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reversal of: %(move_name)s, %(reason)s"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid "Reversal of: %s"
 msgstr ""
 
 #. module: pms_fastapi
@@ -1240,6 +1286,7 @@ msgstr ""
 #. module: pms_fastapi
 #. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
+#: code:addons/pms_fastapi/routers/payment.py:0
 #: code:addons/pms_fastapi/routers/pms_folio.py:0
 #, python-format
 msgid "The export requested %s records, but the maximum allowed is %s."
@@ -1277,6 +1324,15 @@ msgstr ""
 
 #. module: pms_fastapi
 #. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid ""
+"The payment date falls within a locked fiscal period and cannot be "
+"cancelled."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
 msgid ""
@@ -1305,8 +1361,25 @@ msgstr ""
 #: code:addons/pms_fastapi/routers/invoice.py:0
 #, python-format
 msgid ""
+"This invoice is validated. Deleting it will generate a refund that cancels "
+"it. Confirm by passing confirmRefund=true."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/invoice.py:0
+#, python-format
+msgid ""
 "This invoice is validated. Editing it will generate a refund and a new "
 "corrected invoice. Confirm by passing confirmRefund=true."
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid ""
+"This payment is reconciled against a bank statement and cannot be modified."
 msgstr ""
 
 #. module: pms_fastapi
@@ -1391,6 +1464,13 @@ msgstr ""
 #. module: pms_fastapi
 #: model:ir.model,name:pms_fastapi.model_pms_fastapi_login_endpoint
 msgid "login endpoint helper"
+msgstr ""
+
+#. module: pms_fastapi
+#. odoo-python
+#: code:addons/pms_fastapi/routers/payment.py:0
+#, python-format
+msgid "payment"
 msgstr ""
 
 #. module: pms_fastapi

--- a/pms_fastapi/migrations/16.0.1.4.0/post-migrate.py
+++ b/pms_fastapi/migrations/16.0.1.4.0/post-migrate.py
@@ -1,0 +1,70 @@
+"""Backfill ``cash_session_closed`` for cash statements created before the
+flag existed.
+
+pms_fastapi tracks the open/closed state of a cash session explicitly on
+``account.bank.statement.cash_session_closed``. Every statement created before
+this field existed defaults to ``FALSE``, so without this backfill pms_fastapi
+would read every historical cash session (including those created by the legacy
+pms_api_rest API) as still open.
+
+The flag was historically inferred from the standard accounting field
+``is_complete`` (posted lines that balance ``balance_end`` against
+``balance_end_real``); empty closes were deleted outright, so a complete cash
+statement is unambiguously a closed session. We reuse that signal here. Closing
+metadata (date/uid) is approximated from the statement's write metadata, the
+same heuristic the legacy API used for ``date_done``.
+
+Open sessions (``is_complete = FALSE``) keep ``cash_session_closed = FALSE``,
+so the current shift per cash journal stays open.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    # (A) Mark completed cash statements as closed. Sessions created/closed by
+    # the legacy API never set the flag; ``is_complete`` is the accounting
+    # signal it used for "closed". Stamp the closing metadata from the write
+    # metadata (same heuristic the legacy API used for ``date_done``).
+    cr.execute(
+        """
+        UPDATE account_bank_statement st
+        SET cash_session_closed = TRUE,
+            cash_session_closed_date = COALESCE(
+                st.cash_session_closed_date, st.write_date),
+            cash_session_closed_uid = COALESCE(
+                st.cash_session_closed_uid, st.write_uid)
+        FROM account_journal j
+        WHERE st.journal_id = j.id
+          AND j.type = 'cash'
+          AND st.is_complete = TRUE
+          AND st.cash_session_closed IS NOT TRUE
+        """
+    )
+    marked = cr.rowcount
+    # (B) Repair already-closed sessions missing the closing metadata. Legacy
+    # rows may have the flag set without a date/uid, which breaks readers that
+    # require closedAt/closedBy (e.g. the last-closing endpoint -> HTTP 500).
+    cr.execute(
+        """
+        UPDATE account_bank_statement
+        SET cash_session_closed_date = COALESCE(
+                cash_session_closed_date, write_date),
+            cash_session_closed_uid = COALESCE(
+                cash_session_closed_uid, write_uid)
+        WHERE cash_session_closed = TRUE
+          AND (cash_session_closed_date IS NULL
+               OR cash_session_closed_uid IS NULL)
+        """
+    )
+    repaired = cr.rowcount
+    if marked or repaired:
+        _logger.info(
+            "Cash sessions backfill: %d marked closed, %d repaired metadata.",
+            marked,
+            repaired,
+        )

--- a/pms_fastapi/migrations/16.0.1.5.0/post-migrate.py
+++ b/pms_fastapi/migrations/16.0.1.5.0/post-migrate.py
@@ -1,0 +1,56 @@
+"""Close cash sessions left open by the 16.0.1.4.0 backfill.
+
+The 16.0.1.4.0 backfill marked ``cash_session_closed = TRUE`` only where the
+standard accounting flag ``is_complete`` was ``TRUE``. That premise was
+incomplete: ``is_complete`` is a computed *stored* field that was never
+recomputed for tens of thousands of historical statements, so it sits at
+``NULL`` (neither ``TRUE`` nor ``FALSE``) on them. ``NULL = TRUE`` is false, so
+those statements kept ``cash_session_closed = NULL``.
+
+Because the ORM reads ``cash_session_closed = False`` as matching ``NULL`` too,
+and ``get_current`` returns the newest such statement per journal without
+checking for a *later* closed one, every cash journal that had one of these
+stale statements (typically empty ones, left behind a session that was in fact
+closed afterwards) wrongly reported an open cash session.
+
+We close any cash statement that is superseded by a later closed statement in
+the same journal, using the same ``create_date`` ordering ``get_current`` uses
+to pick the "current" session. A statement with no later close is left open, so
+the genuinely-current shift per cash journal stays open. Closing metadata is
+approximated from the write metadata, the same heuristic 16.0.1.4.0 used.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        """
+        UPDATE account_bank_statement st
+        SET cash_session_closed = TRUE,
+            cash_session_closed_date = COALESCE(
+                st.cash_session_closed_date, st.write_date),
+            cash_session_closed_uid = COALESCE(
+                st.cash_session_closed_uid, st.write_uid)
+        FROM account_journal j
+        WHERE st.journal_id = j.id
+          AND j.type = 'cash'
+          AND st.cash_session_closed IS NOT TRUE
+          AND EXISTS (
+              SELECT 1
+              FROM account_bank_statement later
+              WHERE later.journal_id = st.journal_id
+                AND later.cash_session_closed = TRUE
+                AND (later.create_date > st.create_date
+                     OR (later.create_date = st.create_date
+                         AND later.id > st.id))
+          )
+        """
+    )
+    closed = cr.rowcount
+    if closed:
+        _logger.info("Cash sessions backfill fix: %d stale sessions closed.", closed)

--- a/pms_fastapi/models/__init__.py
+++ b/pms_fastapi/models/__init__.py
@@ -4,6 +4,7 @@ from . import pms_folio
 from . import res_partner
 from . import id_number_category
 from . import account_journal
+from . import account_bank_statement
 from . import account_move
 from . import account_move_line
 from . import account_partial_reconcile

--- a/pms_fastapi/models/account_bank_statement.py
+++ b/pms_fastapi/models/account_bank_statement.py
@@ -1,0 +1,199 @@
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+# Maps account.payment.pms_api_transaction_type (defined in pms_api_rest) to the
+# cash-session breakdown buckets. ``internal_transfer`` is handled apart because
+# its sign depends on the payment leg direction on this journal.
+_INCOME_TYPES = ("customer_inbound", "supplier_inbound")
+
+
+class AccountBankStatement(models.Model):
+    _inherit = "account.bank.statement"
+
+    # A cash session (turno de caja) is backed by an account.bank.statement.
+    # The accounting model has no open/closed state, so we track it explicitly
+    # instead of inferring it from balances.
+    cash_session_closed = fields.Boolean(
+        string="Cash session closed",
+        default=False,
+        copy=False,
+        index=True,
+    )
+    cash_session_closed_uid = fields.Many2one(
+        comodel_name="res.users",
+        string="Cash session closed by",
+        copy=False,
+        readonly=True,
+    )
+    cash_session_closed_date = fields.Datetime(
+        string="Cash session closed on",
+        copy=False,
+        readonly=True,
+    )
+    cash_session_note = fields.Text(
+        string="Cash session note",
+        help="Note left for the next shift when closing the cash session.",
+        copy=False,
+    )
+
+    # -- Cash session breakdown / close (ported from pms_api_rest
+    #    pms.transaction.service: _action_close_cash_session,
+    #    _session_create_statement_lines, _post_statement_difference) --
+
+    def _pms_cash_session_breakdown(self):
+        """Return the shift financial breakdown computed from its payments.
+
+        The window is [opened_at, closed_at] (or now while open). ``expected``
+        reproduces the legacy ``balance_start + inbound - outbound`` cash effect
+        of this journal, expressed through the contract buckets.
+        """
+        self.ensure_one()
+        income = refund = expense = internal_transfer = 0.0
+        for payment in self._pms_cash_session_payments():
+            amount = abs(payment.amount)
+            ttype = payment.pms_api_transaction_type
+            if ttype in _INCOME_TYPES:
+                income += amount
+            elif ttype == "customer_outbound":
+                refund += amount
+            elif ttype == "supplier_outbound":
+                expense += amount
+            elif ttype == "internal_transfer":
+                # Net money leaving the cash register through transfers: an
+                # outbound leg lowers cash, an inbound leg raises it.
+                internal_transfer += (
+                    amount if payment.payment_type == "outbound" else -amount
+                )
+        expected = self.balance_start + income - refund - expense - internal_transfer
+        return {
+            "income": income,
+            "refund": refund,
+            "expense": expense,
+            "internal_transfer": internal_transfer,
+            "expected": expected,
+        }
+
+    def _pms_cash_session_payments(self):
+        """Posted payments of this journal within the session window."""
+        self.ensure_one()
+        domain = [
+            ("journal_id", "=", self.journal_id.id),
+            ("state", "=", "posted"),
+            ("create_date", ">=", self.create_date),
+        ]
+        if self.cash_session_closed and self.cash_session_closed_date:
+            domain.append(("create_date", "<=", self.cash_session_closed_date))
+        return self.env["account.payment"].sudo().search(domain)
+
+    def _pms_close_cash_session(self, counted_cash, note):
+        """Close the cash session recording the physically counted cash.
+
+        Posts the difference as a profit/loss line, creates and reconciles the
+        statement lines for the shift payments, and stamps the closing
+        metadata. The mismatch never blocks the close.
+        """
+        self.ensure_one()
+        breakdown = self._pms_cash_session_breakdown()
+        difference = round(counted_cash - breakdown["expected"], 2)
+        session_payments = self._pms_cash_session_payments()
+        if difference:
+            self._pms_post_statement_difference(difference)
+        self._pms_create_statement_lines(session_payments, counted_cash)
+        self.write(
+            {
+                "balance_end_real": counted_cash,
+                "cash_session_closed": True,
+                "cash_session_closed_uid": self.env.user.id,
+                "cash_session_closed_date": fields.Datetime.now(),
+                "cash_session_note": note or "",
+            }
+        )
+        return difference
+
+    def _pms_post_statement_difference(self, amount):
+        """Create the profit/loss statement line for the cash mismatch."""
+        self.ensure_one()
+        journal = self.journal_id
+        st_line_vals = {
+            "statement_id": self.id,
+            "journal_id": journal.id,
+            "amount": amount,
+            "date": fields.Date.today(),
+        }
+        if amount < 0.0:
+            if not journal.loss_account_id:
+                raise UserError(
+                    _(
+                        "Please go on the %s journal and define a Loss Account."
+                        " This account will be used to record cash difference.",
+                        journal.name,
+                    )
+                )
+            st_line_vals["payment_ref"] = _(
+                "Cash difference observed during the counting (Loss) - closing"
+            )
+            st_line_vals["counterpart_account_id"] = journal.loss_account_id.id
+        else:
+            if not journal.profit_account_id:
+                raise UserError(
+                    _(
+                        "Please go on the %s journal and define a Profit Account."
+                        " This account will be used to record cash difference.",
+                        journal.name,
+                    )
+                )
+            st_line_vals["payment_ref"] = _(
+                "Cash difference observed during the counting (Profit) - closing"
+            )
+            st_line_vals["counterpart_account_id"] = journal.profit_account_id.id
+        self.env["account.bank.statement.line"].sudo().create(st_line_vals)
+
+    def _pms_create_statement_lines(self, session_payments, counted_cash):
+        """Create statement lines for the shift payments and reconcile them."""
+        self.ensure_one()
+        journal = self.journal_id
+        payment_statement_line_match = []
+        for payment in session_payments:
+            statement_line = (
+                self.env["account.bank.statement.line"]
+                .sudo()
+                .create(
+                    {
+                        "date": payment.date,
+                        "journal_id": journal.id,
+                        "amount": payment.amount
+                        if payment.payment_type == "inbound"
+                        else -payment.amount,
+                        "payment_ref": payment.ref,
+                        "partner_id": payment.partner_id.id,
+                        "pms_property_id": payment.pms_property_id.id,
+                        "statement_id": self.id,
+                    }
+                )
+            )
+            payment_statement_line_match.append((payment, statement_line))
+
+        # Do not call button post (avoids creating an extra profit/loss line via
+        # _check_balance_end_real_same_as_computed).
+        if not self.name:
+            self._set_next_sequence()
+        self.balance_end = counted_cash
+        lines_of_moves_to_post = self.line_ids.filtered(
+            lambda line: line.move_id.state != "posted"
+        )
+        if lines_of_moves_to_post:
+            lines_of_moves_to_post.move_id._post(soft=False)
+
+        for payment, statement_line in payment_statement_line_match:
+            payment_move_line = payment.move_id.line_ids.filtered(
+                lambda x, p=payment: x.reconciled is False
+                and x.journal_id == journal
+                and x.account_id in p._get_valid_liquidity_accounts()
+            )
+            statement_move_line = statement_line.move_id.line_ids.filtered(
+                lambda line: line.account_id.reconcile
+                or line.account_id == line.journal_id.suspense_account_id
+            )
+            if payment_move_line and statement_move_line:
+                statement_move_line.account_id = payment_move_line.account_id
+                (payment_move_line + statement_move_line).reconcile()

--- a/pms_fastapi/models/account_bank_statement.py
+++ b/pms_fastapi/models/account_bank_statement.py
@@ -12,8 +12,12 @@ class AccountBankStatement(models.Model):
     _inherit = "account.bank.statement"
 
     # A cash session (turno de caja) is backed by an account.bank.statement.
-    # The accounting model has no open/closed state, so we track it explicitly
-    # instead of inferring it from balances.
+    # The accounting model has no open/closed state, so we track it explicitly.
+    # This (surviving) API owns these fields. While the legacy pms_api_rest API
+    # still coexists behind feature flags, it also stamps cash_session_closed
+    # (via its temporary _mark_cash_session_closed bridge) so a session closed
+    # there is not seen as open here. That bridge lives in the legacy module and
+    # disappears with it; these fields stay here.
     cash_session_closed = fields.Boolean(
         string="Cash session closed",
         default=False,
@@ -140,11 +144,19 @@ class AccountBankStatement(models.Model):
         Posts the difference as a profit/loss line, creates and reconciles the
         statement lines for the shift payments, and stamps the closing
         metadata. The mismatch never blocks the close.
+
+        A shift closed without any movement (no payments and the count matching
+        the declared base) leaves no accounting trace, so the empty statement is
+        discarded instead of being kept as an empty closed session. Returns True
+        when the session is actually closed and False when it is discarded.
         """
         self.ensure_one()
         breakdown = self._pms_cash_session_breakdown()
         difference = round(counted_cash - breakdown["expected"], 2)
         session_payments = self._pms_cash_session_payments()
+        if not session_payments and not difference:
+            self.unlink()
+            return False
         if difference:
             self._pms_post_statement_difference(difference)
         self._pms_create_statement_lines(session_payments, counted_cash)
@@ -157,7 +169,7 @@ class AccountBankStatement(models.Model):
                 "cash_session_note": note or "",
             }
         )
-        return difference
+        return True
 
     def _pms_post_statement_difference(self, amount):
         """Create the profit/loss statement line for the cash mismatch."""

--- a/pms_fastapi/models/account_bank_statement.py
+++ b/pms_fastapi/models/account_bank_statement.py
@@ -1,5 +1,6 @@
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import get_lang
 
 # Maps account.payment.pms_api_transaction_type (defined in pms_api_rest) to the
 # cash-session breakdown buckets. ``internal_transfer`` is handled apart because
@@ -35,6 +36,54 @@ class AccountBankStatement(models.Model):
         help="Note left for the next shift when closing the cash session.",
         copy=False,
     )
+
+    # -- Cash session open --
+
+    @api.model
+    def _pms_create_cash_session(self, journal, base_amount, pms_property):
+        """Create an open cash session (statement) with a declared base.
+
+        ``balance_start`` is a stored computed field (depends on create_date)
+        that otherwise resolves to the previous statement's ending balance, so
+        we override it after create to make the declared base stick.
+        """
+        today = fields.Date.today().strftime(get_lang(self.env).date_format)
+        statement = self.create(
+            {
+                "name": f"{today} ({self.env.user.login})",
+                "journal_id": journal.id,
+                "pms_property_id": pms_property.id,
+                "cash_session_closed": False,
+            }
+        )
+        statement.balance_start = base_amount
+        return statement
+
+    @api.model
+    def _pms_ensure_open_cash_session(self, journal):
+        """Ensure the cash journal has an open session, auto-opening one if not.
+
+        Replicates the legacy behaviour of opening a cash session on demand
+        when a payment is registered on a cash journal. The base balance
+        continues from the previous close (or 0).
+        """
+        if journal.type != "cash":
+            return self.browse()
+        open_session = self.search(
+            [("journal_id", "=", journal.id), ("cash_session_closed", "=", False)],
+            order="create_date desc, id desc",
+            limit=1,
+        )
+        if open_session:
+            return open_session
+        last_closed = self.search(
+            [("journal_id", "=", journal.id), ("cash_session_closed", "=", True)],
+            order="cash_session_closed_date desc, id desc",
+            limit=1,
+        )
+        base_amount = last_closed.balance_end_real or 0.0
+        pms_property = journal.pms_property_ids[:1] or self.env.user.pms_property_id
+        return self._pms_create_cash_session(journal, base_amount, pms_property)
 
     # -- Cash session breakdown / close (ported from pms_api_rest
     #    pms.transaction.service: _action_close_cash_session,

--- a/pms_fastapi/models/account_move.py
+++ b/pms_fastapi/models/account_move.py
@@ -18,6 +18,18 @@ class AccountMove(models.Model):
     min_overdue_date = fields.Date(
         string="Minimum Overdue Payment Date", compute="_compute_min_overdue_date"
     )
+    replaces_invoice_id = fields.Many2one(
+        comodel_name="account.move",
+        string="Replaces Invoice",
+        readonly=True,
+        index=True,
+    )
+    replaced_by_invoice_ids = fields.One2many(
+        comodel_name="account.move",
+        inverse_name="replaces_invoice_id",
+        string="Replaced By Invoices",
+        readonly=True,
+    )
 
     def _compute_payment_method_ids(self):
         for move in self:

--- a/pms_fastapi/models/fastapi_endpoint.py
+++ b/pms_fastapi/models/fastapi_endpoint.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 from ..schemas.base import MIN_SEARCH_TEXT_LENGTH, BaseSearch
 
@@ -74,6 +74,27 @@ class FastapiEndpoint(models.Model):
         ondelete={APP_NAME: "cascade"},
     )
 
+    def _search_text_too_short_problem(self, field: str) -> JSONResponse:
+        """RFC 9457 problem+json for a free-text search value below the minimum.
+
+        Built here (and not in the ``async`` guard wrapper) so ``_()`` resolves
+        the request language through ``self.env``, which the fastapi dispatcher
+        already set from the ``Accept-Language`` header.
+        """
+        return JSONResponse(
+            status_code=400,
+            media_type="application/problem+json",
+            content={
+                "type": "/errors/search-text-too-short",
+                "title": _("Search text too short"),
+                "status": 400,
+                "detail": _("Search text must be at least %s characters.")
+                % MIN_SEARCH_TEXT_LENGTH,
+                "field": field,
+                "minLength": MIN_SEARCH_TEXT_LENGTH,
+            },
+        )
+
     @api.model
     def _get_fastapi_routers(self):
         if self.app == APP_NAME:
@@ -136,24 +157,6 @@ class FastapiEndpoint(models.Model):
         return params
 
 
-def _search_text_too_short_problem(field: str) -> JSONResponse:
-    """RFC 9457 problem+json for a free-text search value below the minimum length."""
-    return JSONResponse(
-        status_code=400,
-        media_type="application/problem+json",
-        content={
-            "type": "/errors/search-text-too-short",
-            "title": "Search text too short",
-            "status": 400,
-            "detail": (
-                f"Search text must be at least {MIN_SEARCH_TEXT_LENGTH} characters."
-            ),
-            "field": field,
-            "minLength": MIN_SEARCH_TEXT_LENGTH,
-        },
-    )
-
-
 def _endpoint_search_param(endpoint) -> str | None:
     """Name of the endpoint param typed as a BaseSearch subclass, if any."""
     for name, hint in get_type_hints(endpoint, include_extras=True).items():
@@ -180,7 +183,8 @@ def _guard_search_text(endpoint):
         if filters is not None:
             field = filters.first_short_search_text()
             if field is not None:
-                return _search_text_too_short_problem(field)
+                env = next(v for v in kwargs.values() if isinstance(v, api.Environment))
+                return env["fastapi.endpoint"]._search_text_too_short_problem(field)
         return await endpoint(*args, **kwargs)
 
     return wrapper

--- a/pms_fastapi/models/folio_sale_line.py
+++ b/pms_fastapi/models/folio_sale_line.py
@@ -1,5 +1,7 @@
 from odoo import api, fields, models
 
+FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX = "folio_invoice_line_descriptions"
+
 
 class FolioSaleLine(models.Model):
     _inherit = "folio.sale.line"
@@ -24,3 +26,14 @@ class FolioSaleLine(models.Model):
                 partner=line.folio_id.partner_id,
             )
             line.amount_to_invoice = taxes["total_included"]
+
+    def _prepare_invoice_line(self, qty=False, invoice_fpos=None, **optional_values):
+        res = super()._prepare_invoice_line(
+            qty=qty, invoice_fpos=invoice_fpos, **optional_values
+        )
+        descriptions = self.env.context.get(FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX) or {}
+        description = descriptions.get(self.id)
+        if description is not None:
+            res["name"] = description
+            res["name_changed_by_user"] = True
+        return res

--- a/pms_fastapi/routers/__init__.py
+++ b/pms_fastapi/routers/__init__.py
@@ -20,5 +20,6 @@ from . import pms_folio
 from . import invoice
 from . import journal
 from . import payment_method
+from . import payment
 from . import reservation_guest
 from . import pms_reservation

--- a/pms_fastapi/routers/__init__.py
+++ b/pms_fastapi/routers/__init__.py
@@ -19,6 +19,7 @@ from . import guest
 from . import pms_folio
 from . import invoice
 from . import journal
+from . import cash_session
 from . import payment_method
 from . import payment
 from . import reservation_guest

--- a/pms_fastapi/routers/cash_session.py
+++ b/pms_fastapi/routers/cash_session.py
@@ -1,0 +1,240 @@
+from fastapi import Response, status
+from fastapi.responses import JSONResponse
+
+from odoo import fields, models
+from odoo.tools import get_lang
+
+from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
+from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.schemas.base import PmsBaseModel
+from odoo.addons.pms_fastapi.schemas.cash_session import (
+    CashClosing,
+    CashLastClosing,
+    CashSessionCloseInput,
+    CashSessionOpenInput,
+    CashSessionSummary,
+)
+
+
+class _CashSessionProblem(Exception):
+    """Control-flow exception carrying an RFC 9457 JSONResponse."""
+
+    def __init__(self, response):
+        super().__init__()
+        self.response = response
+
+
+@pms_api_router.post(
+    "/cash-sessions",
+    response_model=CashSessionSummary,
+    status_code=201,
+    tags=["account"],
+)
+async def open_cash_session(
+    env: AuthenticatedEnv,
+    payload: CashSessionOpenInput,
+) -> CashSessionSummary:
+    """Open a cash session (shift) on a cash journal with an initial balance.
+
+    Only one open session is allowed per journal.
+    """
+    return env["pms_api_cash_session.cash_session_router.helper"].new().open(payload)
+
+
+@pms_api_router.get(
+    "/cash-sessions/current",
+    response_model=CashSessionSummary,
+    responses={204: {"description": "No open cash session on the journal"}},
+    tags=["account"],
+)
+async def get_current_cash_session(
+    env: AuthenticatedEnv,
+    journalId: int,
+) -> CashSessionSummary | Response:
+    """Return the open cash session of the journal with its financial
+    breakdown. Responds 204 when there is no open session."""
+    return (
+        env["pms_api_cash_session.cash_session_router.helper"]
+        .new()
+        .get_current(journalId)
+    )
+
+
+@pms_api_router.get(
+    "/cash-sessions/last-closing",
+    response_model=CashLastClosing,
+    responses={204: {"description": "The journal never had a cash session close"}},
+    tags=["account"],
+)
+async def get_last_cash_closing(
+    env: AuthenticatedEnv,
+    journalId: int,
+) -> CashLastClosing | Response:
+    """Return the last cash session close of the journal. Responds 204 when
+    the journal never had a close."""
+    return (
+        env["pms_api_cash_session.cash_session_router.helper"]
+        .new()
+        .get_last_closing(journalId)
+    )
+
+
+@pms_api_router.post(
+    "/cash-sessions/{session_id}/closing",
+    response_model=CashClosing,
+    tags=["account"],
+)
+async def close_cash_session(
+    env: AuthenticatedEnv,
+    session_id: int,
+    payload: CashSessionCloseInput,
+) -> CashClosing:
+    """Close the cash session recording the physically counted cash and an
+    optional note. The backend recomputes the mismatch and closing balance.
+    The mismatch is recorded but never blocks the close."""
+    return (
+        env["pms_api_cash_session.cash_session_router.helper"]
+        .new()
+        .close(session_id, payload)
+    )
+
+
+class PmsApiCashSessionRouterHelper(models.AbstractModel):
+    _name = "pms_api_cash_session.cash_session_router.helper"
+    _description = "PMS API Cash Session Router Helper"
+
+    @staticmethod
+    def _problem(status_code, type_, title, detail):
+        raise _CashSessionProblem(
+            JSONResponse(
+                status_code=status_code,
+                content={
+                    "type": type_,
+                    "title": title,
+                    "status": status_code,
+                    "detail": detail,
+                },
+                media_type="application/problem+json",
+            )
+        )
+
+    def _resolve_cash_journal(self, journal_id):
+        journal = self.env["account.journal"].sudo().browse(journal_id).exists()
+        if not journal or journal.type != "cash":
+            self._problem(
+                409,
+                "/errors/journal-not-cash",
+                "Journal is not a cash journal",
+                f"Journal {journal_id} is not of type cash; cannot operate a "
+                "cash session on it.",
+            )
+        PmsBaseModel.pms_api_check_access(self.env.user, journal)
+        return journal
+
+    def _open_session(self, journal_id):
+        return (
+            self.env["account.bank.statement"]
+            .sudo()
+            .search(
+                [
+                    ("journal_id", "=", journal_id),
+                    ("cash_session_closed", "=", False),
+                ],
+                order="create_date desc, id desc",
+                limit=1,
+            )
+        )
+
+    def open(self, payload: CashSessionOpenInput):
+        try:
+            journal = self._resolve_cash_journal(payload.journalId)
+            if self._open_session(journal.id):
+                self._problem(
+                    409,
+                    "/errors/cash-session-already-open",
+                    "Cash session already open",
+                    f"Journal {journal.id} already has an open cash session.",
+                )
+            pms_property = journal.pms_property_ids
+            pms_property = (
+                pms_property
+                if len(pms_property) == 1
+                else self.env.user.pms_property_id
+            )
+            today = fields.Date.today().strftime(get_lang(self.env).date_format)
+            statement = (
+                self.env["account.bank.statement"]
+                .sudo()
+                .create(
+                    {
+                        "name": f"{today} ({self.env.user.login})",
+                        "journal_id": journal.id,
+                        "pms_property_id": pms_property.id,
+                        "cash_session_closed": False,
+                    }
+                )
+            )
+            # balance_start is a stored computed field (depends on create_date)
+            # that otherwise resolves to the previous statement's ending
+            # balance. The contract declares the opening balance explicitly, so
+            # we override it after create to make the value stick.
+            statement.balance_start = payload.baseAmount
+        except _CashSessionProblem as problem:
+            return problem.response
+        return CashSessionSummary.from_account_bank_statement(statement)
+
+    def get_current(self, journal_id):
+        try:
+            journal = self._resolve_cash_journal(journal_id)
+        except _CashSessionProblem as problem:
+            return problem.response
+        statement = self._open_session(journal.id)
+        if not statement:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        return CashSessionSummary.from_account_bank_statement(statement)
+
+    def get_last_closing(self, journal_id):
+        try:
+            journal = self._resolve_cash_journal(journal_id)
+        except _CashSessionProblem as problem:
+            return problem.response
+        statement = (
+            self.env["account.bank.statement"]
+            .sudo()
+            .search(
+                [
+                    ("journal_id", "=", journal.id),
+                    ("cash_session_closed", "=", True),
+                ],
+                order="cash_session_closed_date desc, id desc",
+                limit=1,
+            )
+        )
+        if not statement:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        return CashLastClosing.from_account_bank_statement(statement)
+
+    def close(self, session_id, payload: CashSessionCloseInput):
+        try:
+            statement = (
+                self.env["account.bank.statement"].sudo().browse(session_id).exists()
+            )
+            if not statement or statement.journal_id.type != "cash":
+                self._problem(
+                    404,
+                    "/errors/cash-session-not-found",
+                    "Cash session not found",
+                    f"Cash session {session_id} does not exist.",
+                )
+            if statement.cash_session_closed:
+                self._problem(
+                    409,
+                    "/errors/cash-session-already-closed",
+                    "Cash session already closed",
+                    f"Cash session {session_id} is already closed.",
+                )
+            PmsBaseModel.pms_api_check_access(self.env.user, statement)
+            statement._pms_close_cash_session(payload.countedCash, payload.note)
+        except _CashSessionProblem as problem:
+            return problem.response
+        return CashClosing.from_account_bank_statement(statement)

--- a/pms_fastapi/routers/cash_session.py
+++ b/pms_fastapi/routers/cash_session.py
@@ -1,7 +1,7 @@
 from fastapi import Response, status
 from fastapi.responses import JSONResponse
 
-from odoo import models
+from odoo import _, models
 
 from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
@@ -123,9 +123,12 @@ class PmsApiCashSessionRouterHelper(models.AbstractModel):
             self._problem(
                 409,
                 "/errors/journal-not-cash",
-                "Journal is not a cash journal",
-                f"Journal {journal_id} is not of type cash; cannot operate a "
-                "cash session on it.",
+                _("Journal is not a cash journal"),
+                _(
+                    "Journal %s is not of type cash; cannot operate a "
+                    "cash session on it."
+                )
+                % journal_id,
             )
         PmsBaseModel.pms_api_check_access(self.env.user, journal)
         return journal
@@ -151,8 +154,8 @@ class PmsApiCashSessionRouterHelper(models.AbstractModel):
                 self._problem(
                     409,
                     "/errors/cash-session-already-open",
-                    "Cash session already open",
-                    f"Journal {journal.id} already has an open cash session.",
+                    _("Cash session already open"),
+                    _("Journal %s already has an open cash session.") % journal.id,
                 )
             pms_property = journal.pms_property_ids
             pms_property = (
@@ -209,15 +212,15 @@ class PmsApiCashSessionRouterHelper(models.AbstractModel):
                 self._problem(
                     404,
                     "/errors/cash-session-not-found",
-                    "Cash session not found",
-                    f"Cash session {session_id} does not exist.",
+                    _("Cash session not found"),
+                    _("Cash session %s does not exist.") % session_id,
                 )
             if statement.cash_session_closed:
                 self._problem(
                     409,
                     "/errors/cash-session-already-closed",
-                    "Cash session already closed",
-                    f"Cash session {session_id} is already closed.",
+                    _("Cash session already closed"),
+                    _("Cash session %s is already closed.") % session_id,
                 )
             PmsBaseModel.pms_api_check_access(self.env.user, statement)
             statement._pms_close_cash_session(payload.countedCash, payload.note)

--- a/pms_fastapi/routers/cash_session.py
+++ b/pms_fastapi/routers/cash_session.py
@@ -81,16 +81,24 @@ async def get_last_cash_closing(
 @pms_api_router.post(
     "/cash-sessions/{session_id}/closing",
     response_model=CashClosing,
+    responses={
+        204: {
+            "description": "Cash session closed without movements; "
+            "the empty statement was discarded"
+        }
+    },
     tags=["account"],
 )
 async def close_cash_session(
     env: AuthenticatedEnv,
     session_id: int,
     payload: CashSessionCloseInput,
-) -> CashClosing:
+) -> CashClosing | Response:
     """Close the cash session recording the physically counted cash and an
     optional note. The backend recomputes the mismatch and closing balance.
-    The mismatch is recorded but never blocks the close."""
+    The mismatch is recorded but never blocks the close. A close with no
+    movements (no payments and the count matching the base) is discarded and
+    responds 204."""
     return (
         env["pms_api_cash_session.cash_session_router.helper"]
         .new()
@@ -223,7 +231,10 @@ class PmsApiCashSessionRouterHelper(models.AbstractModel):
                     _("Cash session %s is already closed.") % session_id,
                 )
             PmsBaseModel.pms_api_check_access(self.env.user, statement)
-            statement._pms_close_cash_session(payload.countedCash, payload.note)
+            if not statement._pms_close_cash_session(
+                payload.countedCash, payload.note
+            ):
+                return Response(status_code=status.HTTP_204_NO_CONTENT)
         except _CashSessionProblem as problem:
             return problem.response
         return CashClosing.from_account_bank_statement(statement)

--- a/pms_fastapi/routers/cash_session.py
+++ b/pms_fastapi/routers/cash_session.py
@@ -1,8 +1,7 @@
 from fastapi import Response, status
 from fastapi.responses import JSONResponse
 
-from odoo import fields, models
-from odoo.tools import get_lang
+from odoo import models
 
 from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
@@ -161,24 +160,11 @@ class PmsApiCashSessionRouterHelper(models.AbstractModel):
                 if len(pms_property) == 1
                 else self.env.user.pms_property_id
             )
-            today = fields.Date.today().strftime(get_lang(self.env).date_format)
             statement = (
                 self.env["account.bank.statement"]
                 .sudo()
-                .create(
-                    {
-                        "name": f"{today} ({self.env.user.login})",
-                        "journal_id": journal.id,
-                        "pms_property_id": pms_property.id,
-                        "cash_session_closed": False,
-                    }
-                )
+                ._pms_create_cash_session(journal, payload.baseAmount, pms_property)
             )
-            # balance_start is a stored computed field (depends on create_date)
-            # that otherwise resolves to the previous statement's ending
-            # balance. The contract declares the opening balance explicitly, so
-            # we override it after create to make the value stick.
-            statement.balance_start = payload.baseAmount
         except _CashSessionProblem as problem:
             return problem.response
         return CashSessionSummary.from_account_bank_statement(statement)

--- a/pms_fastapi/routers/contact.py
+++ b/pms_fastapi/routers/contact.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException
 
-from odoo import api, models
+from odoo import _, api, models
 from odoo.exceptions import MissingError
 from odoo.osv import expression
 
@@ -77,13 +77,7 @@ async def contactDetail(
 ) -> ContactDetail:
     """Get detail info of a contact"""
     helper = env["pms_api_contact.contact_router.helper"].new()
-    try:
-        partner = helper.get(contact_id)
-    except MissingError as err:
-        raise HTTPException(
-            status_code=404,
-            detail="contact not found",
-        ) from err
+    partner = helper.get_or_404(contact_id)
     return ContactDetail.from_res_partner(partner)
 
 
@@ -113,13 +107,7 @@ async def update_contact(
     contactData: ContactUpdate,
 ) -> ContactDetail:
     helper = env["pms_api_contact.contact_router.helper"].new()
-    try:
-        contact = helper.get(contact_id)
-    except MissingError as err:
-        raise HTTPException(
-            status_code=404,
-            detail="contact not found",
-        ) from err
+    contact = helper.get_or_404(contact_id)
     helper.update_contact(contactData, contact_id)
     return ContactDetail.from_res_partner(contact)
 
@@ -150,6 +138,15 @@ class PmsApiContactRouterHelper(models.AbstractModel):
 
     def get(self, record_id) -> Partner:
         return self.model_adapter.get(record_id)
+
+    def get_or_404(self, contact_id) -> Partner:
+        try:
+            return self.get(contact_id)
+        except MissingError as err:
+            raise HTTPException(
+                status_code=404,
+                detail=_("contact not found"),
+            ) from err
 
     def _search(self, paging, params, order) -> tuple[int, Partner]:
         return self.model_adapter.search_with_count(

--- a/pms_fastapi/routers/contact_id_number.py
+++ b/pms_fastapi/routers/contact_id_number.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException, Response, status
 
-from odoo import models
+from odoo import _, models
 
 from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
@@ -103,12 +103,8 @@ async def contact_id_numbers(
     contact_id: int,
 ) -> list[ContactIdNumberSummary]:
     """Get identification numbers of a contact"""
-    partner = env["res.partner"].sudo().search([("id", "=", contact_id)])
-    if not partner:
-        raise HTTPException(
-            status_code=404,
-            detail="contact not found",
-        )
+    helper = env["pms_api_contact.contact_id_number_router.helper"].new()
+    partner = helper._get_partner_or_404(contact_id)
     id_numbers = []
     for id_number in partner.id_numbers:
         id_numbers.append(ContactIdNumberSummary.from_res_partner_id_number(id_number))
@@ -142,16 +138,8 @@ async def update_contact_id_number(
     idNumber_id: int,
     idNumberData: ContactIdNumberUpdate,
 ) -> ContactIdNumberSummary:
-    id_number = env["res.partner.id_number"].sudo().browse(idNumber_id)
-    if id_number.partner_id.id != contact_id:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"The id number {idNumber_id} does not belong "
-                f"to the contact {contact_id}"
-            ),
-        )
     helper = env["pms_api_contact.contact_id_number_router.helper"].new()
+    id_number = helper._get_id_number_for_contact(contact_id, idNumber_id)
     helper.write_id_number(id_number, idNumberData)
     return ContactIdNumberSummary.from_res_partner_id_number(id_number)
 
@@ -166,15 +154,8 @@ async def set_fiscal_number_contact_id_number(
     contact_id: int,
     idNumber_id: int,
 ) -> ContactIdNumberSummary:
-    id_number = env["res.partner.id_number"].sudo().browse(idNumber_id)
-    if id_number.partner_id.id != contact_id:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"The id number {idNumber_id} does not belong "
-                f"to the contact {contact_id}"
-            ),
-        )
+    helper = env["pms_api_contact.contact_id_number_router.helper"].new()
+    id_number = helper._get_id_number_for_contact(contact_id, idNumber_id)
     id_number.sudo().set_partner_id_field()
     return ContactIdNumberSummary.from_res_partner_id_number(id_number)
 
@@ -189,21 +170,33 @@ async def delete_contact_id_number(
     contact_id: int,
     idNumber_id: int,
 ):
-    id_number = env["res.partner.id_number"].sudo().browse(idNumber_id)
-    if id_number.partner_id.id != contact_id:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"The id number {idNumber_id} does not belong "
-                f"to the contact {contact_id}"
-            ),
-        )
+    helper = env["pms_api_contact.contact_id_number_router.helper"].new()
+    id_number = helper._get_id_number_for_contact(contact_id, idNumber_id)
     id_number.sudo().unlink()
 
 
 class PmsApiContactIdNumberRouterHelper(models.AbstractModel):
     _name = "pms_api_contact.contact_id_number_router.helper"
     _description = "Pms api contact  id number Service Helper"
+
+    def _get_partner_or_404(self, contact_id: int):
+        partner = self.env["res.partner"].sudo().search([("id", "=", contact_id)])
+        if not partner:
+            raise HTTPException(
+                status_code=404,
+                detail=_("contact not found"),
+            )
+        return partner
+
+    def _get_id_number_for_contact(self, contact_id: int, id_number_id: int):
+        id_number = self.env["res.partner.id_number"].sudo().browse(id_number_id)
+        if id_number.partner_id.id != contact_id:
+            raise HTTPException(
+                status_code=400,
+                detail=_("The id number %s does not belong to the contact %s")
+                % (id_number_id, contact_id),
+            )
+        return id_number
 
     def get_duplicate_fiscal_number(
         self, fiscal_number: str, document_type: str, country_id: int | None = None

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -1,3 +1,4 @@
+import re
 from typing import Annotated
 
 from fastapi import Depends, Query
@@ -28,6 +29,8 @@ from odoo.addons.pms_fastapi.schemas.invoice import (
     InvoiceOrderField,
     InvoiceSearch,
     InvoiceSummary,
+    ReconcilablePayment,
+    ReconciliationCreate,
     ReportFormatEnum,
     ShareUrl,
 )
@@ -155,6 +158,71 @@ async def validate_invoice(
 ) -> InvoiceSummary:
     """Validate a draft invoice."""
     return env["pms_api_invoice.invoice_router.helper"].new()._validate_invoice(id)
+
+
+_PAYMENT_ID_RE = re.compile(r"^payment_(\d+)$")
+
+
+@pms_api_router.post(
+    "/invoices/{invoice_id}/reconciliations",
+    response_model=InvoiceDetail,
+    tags=["invoice"],
+)
+async def create_reconciliation(
+    env: AuthenticatedEnv,
+    invoice_id: int,
+    payload: ReconciliationCreate,
+):
+    """Reconcile an existing payment with the invoice.
+
+    The backend decides how much of the payment is applied, up to the
+    invoice's residual amount.
+    """
+    return (
+        env["pms_api_invoice.invoice_router.helper"]
+        .new()
+        ._create_reconciliation(invoice_id, payload)
+    )
+
+
+@pms_api_router.delete(
+    "/invoices/{invoice_id}/reconciliations/{reconciliation_id}",
+    response_model=InvoiceDetail,
+    tags=["invoice"],
+)
+async def delete_reconciliation(
+    env: AuthenticatedEnv,
+    invoice_id: int,
+    reconciliation_id: str,
+):
+    """Undo a previously applied reconciliation between a payment and the invoice."""
+    return (
+        env["pms_api_invoice.invoice_router.helper"]
+        .new()
+        ._delete_reconciliation(invoice_id, reconciliation_id)
+    )
+
+
+@pms_api_router.get(
+    "/invoices/{invoice_id}/reconcilable-payments",
+    response_model=list[ReconcilablePayment],
+    tags=["invoice"],
+)
+async def list_reconcilable_payments(
+    env: AuthenticatedEnv,
+    invoice_id: int,
+):
+    """List payments that can be reconciled with the given invoice.
+
+    Returns payments belonging to the folio associated with the invoice,
+    or payments of the invoice's customer when the invoice has no folio.
+    Only payments with available (non-fully-reconciled) amount are returned.
+    """
+    return (
+        env["pms_api_invoice.invoice_router.helper"]
+        .new()
+        ._get_reconcilable_payments(invoice_id)
+    )
 
 
 @pms_api_router.get(
@@ -376,7 +444,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 "Duplicate sale lines",
                 "Each folio line can only appear once in the request.",
             )
-        sale_lines = self.env["folio.sale.line"].browse(line_ids).exists()
+        sale_lines = self.env["folio.sale.line"].sudo().browse(line_ids).exists()
         missing = set(line_ids) - set(sale_lines.ids)
         if missing:
             self._raise_edit_problem(
@@ -408,7 +476,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 "Duplicate down-payment lines",
                 "Each down-payment line can only appear once in the request.",
             )
-        dp_lines = self.env["folio.sale.line"].browse(ids).exists()
+        dp_lines = self.env["folio.sale.line"].sudo().browse(ids).exists()
         missing = set(ids) - set(dp_lines.ids)
         if missing:
             self._raise_edit_problem(
@@ -452,7 +520,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
         return properties
 
     def _edit_resolve_partner(self, payload, pms_property):
-        partner = self.env["res.partner"].browse(payload.partner).exists()
+        partner = self.env["res.partner"].sudo().browse(payload.partner).exists()
         if not partner:
             self._raise_edit_problem(
                 404,
@@ -600,10 +668,14 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
     def _edit_draft_invoice(
         self, invoice, payload, sale_lines, downpayment_lines, partner
     ):
+        # Release the quantity held by this draft before recomputing the
+        # composition, so folio lines fully invoiced by this very draft can be
+        # re-invoiced (otherwise their qty_to_invoice is 0 at compute time and
+        # the rewritten invoice ends up empty).
+        invoice.invoice_line_ids.unlink()
         vals = self._edit_compute_invoice_vals(
             payload, sale_lines, downpayment_lines, partner
         )
-        invoice.invoice_line_ids.unlink()
         write_vals = {
             "partner_id": partner.id,
             "narration": payload.narration,
@@ -832,6 +904,259 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 media_type="application/problem+json",
             )
         return InvoiceSummary.from_account_move(invoice)
+
+    @staticmethod
+    def _parse_payment_composite_id(composite_id):
+        """Return the int payment id from 'payment_{id}', or raise 422."""
+        match = _PAYMENT_ID_RE.match(composite_id or "")
+        if not match:
+            PmsApiInvoiceRouterHelper._raise_edit_problem(
+                422,
+                "/errors/invalid-reconciliation-id",
+                "Invalid reconciliation id",
+                (
+                    f"Reconciliation id '{composite_id}' is malformed. "
+                    "Expected 'payment_{id}'."
+                ),
+            )
+        return int(match.group(1))
+
+    def _get_reconciliation_partials(self, invoice, payment):
+        invoice_recv = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type
+            in ("asset_receivable", "liability_payable")
+        )
+        payment_recv = payment.move_id.line_ids.filtered(
+            lambda line: line.account_id.account_type
+            in ("asset_receivable", "liability_payable")
+        )
+        partials = invoice_recv.matched_debit_ids.filtered(
+            lambda p: p.debit_move_id in payment_recv
+        ) | invoice_recv.matched_credit_ids.filtered(
+            lambda p: p.credit_move_id in payment_recv
+        )
+        return invoice_recv, payment_recv, partials
+
+    def _create_reconciliation(self, invoice_id, payload):
+        try:
+            invoice = self.get(invoice_id)
+        except MissingError:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/invoice-not-found",
+                    "title": "Invoice not found",
+                    "status": 404,
+                    "detail": "Invoice not found.",
+                },
+                media_type="application/problem+json",
+            )
+        try:
+            payment_id = self._parse_payment_composite_id(payload.paymentId)
+            if invoice.state != "posted" or invoice.payment_state in (
+                "paid",
+                "reversed",
+            ):
+                self._raise_edit_problem(
+                    409,
+                    "/errors/invoice-not-editable",
+                    "Invoice not editable",
+                    "The invoice state does not allow new reconciliations.",
+                )
+            payment = (
+                self.env["account.payment"]
+                .sudo()
+                .search(
+                    [
+                        ("id", "=", payment_id),
+                        ("company_id", "=", invoice.company_id.id),
+                    ],
+                    limit=1,
+                )
+            )
+            if not payment:
+                self._raise_edit_problem(
+                    404,
+                    "/errors/payment-not-found",
+                    "Payment not found",
+                    f"Payment {payment_id} not found.",
+                )
+            if invoice.folio_ids:
+                if not (payment.folio_ids & invoice.folio_ids):
+                    self._raise_edit_problem(
+                        409,
+                        "/errors/payment-not-applicable",
+                        "Payment not applicable",
+                        ("Payment does not belong to any folio of this " "invoice."),
+                    )
+            elif (
+                payment.partner_id.commercial_partner_id
+                != invoice.commercial_partner_id
+            ):
+                self._raise_edit_problem(
+                    409,
+                    "/errors/payment-not-applicable",
+                    "Payment not applicable",
+                    "Payment does not belong to the invoice's customer.",
+                )
+            invoice_recv, payment_recv, partials = self._get_reconciliation_partials(
+                invoice, payment
+            )
+            if partials:
+                self._raise_edit_problem(
+                    409,
+                    "/errors/payment-already-reconciled",
+                    "Payment already reconciled",
+                    (
+                        f"Payment {payment.id} is already reconciled with "
+                        f"invoice {invoice.id}."
+                    ),
+                )
+            if not invoice_recv or not payment_recv:
+                self._raise_edit_problem(
+                    409,
+                    "/errors/payment-not-applicable",
+                    "Payment not applicable",
+                    "Payment is not in a reconcilable state.",
+                )
+            try:
+                (invoice_recv + payment_recv).filtered(
+                    lambda line: not line.reconciled
+                ).reconcile()
+            except UserError as e:
+                self._raise_edit_problem(
+                    409,
+                    "/errors/payment-not-applicable",
+                    "Payment not applicable",
+                    str(e),
+                )
+        except _InvoiceEditProblem as problem:
+            return problem.response
+        # Reconciling updated payment_state/amount_residual on the stored
+        # record; drop the stale cache so the response reflects the new state.
+        invoice.invalidate_recordset()
+        return InvoiceDetail.from_account_move(invoice)
+
+    def _delete_reconciliation(self, invoice_id, reconciliation_id):
+        try:
+            invoice = self.get(invoice_id)
+        except MissingError:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/invoice-not-found",
+                    "title": "Invoice not found",
+                    "status": 404,
+                    "detail": "Invoice not found.",
+                },
+                media_type="application/problem+json",
+            )
+        try:
+            payment_id = self._parse_payment_composite_id(reconciliation_id)
+            if invoice.state != "posted":
+                self._raise_edit_problem(
+                    409,
+                    "/errors/invoice-not-editable",
+                    "Invoice not editable",
+                    "The invoice state does not allow undoing reconciliations.",
+                )
+            payment = (
+                self.env["account.payment"]
+                .sudo()
+                .search(
+                    [
+                        ("id", "=", payment_id),
+                        ("company_id", "=", invoice.company_id.id),
+                    ],
+                    limit=1,
+                )
+            )
+            if not payment:
+                self._raise_edit_problem(
+                    404,
+                    "/errors/reconciliation-not-found",
+                    "Reconciliation not found",
+                    (
+                        f"No reconciliation exists between invoice {invoice.id} "
+                        f"and payment {payment_id}."
+                    ),
+                )
+            _invoice_recv, _payment_recv, partials = self._get_reconciliation_partials(
+                invoice, payment
+            )
+            if not partials:
+                self._raise_edit_problem(
+                    404,
+                    "/errors/reconciliation-not-found",
+                    "Reconciliation not found",
+                    (
+                        f"No reconciliation exists between invoice {invoice.id} "
+                        f"and payment {payment.id}."
+                    ),
+                )
+            partials.unlink()
+        except _InvoiceEditProblem as problem:
+            return problem.response
+        # Undoing the reconciliation updated payment_state/amount_residual on
+        # the stored record; drop the stale cache before serializing.
+        invoice.invalidate_recordset()
+        return InvoiceDetail.from_account_move(invoice)
+
+    def _get_reconcilable_payments(self, invoice_id):
+        try:
+            invoice = self.get(invoice_id)
+        except MissingError:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/not-found",
+                    "title": "Not found",
+                    "status": 404,
+                    "detail": "Invoice not found.",
+                },
+                media_type="application/problem+json",
+            )
+        if invoice.state != "posted":
+            return []
+        pay_term_lines = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type
+            in ("asset_receivable", "liability_payable")
+        )
+        if not pay_term_lines:
+            return []
+        domain = [
+            ("account_id", "in", pay_term_lines.account_id.ids),
+            ("parent_state", "=", "posted"),
+            ("reconciled", "=", False),
+            "|",
+            ("amount_residual", "!=", 0.0),
+            ("amount_residual_currency", "!=", 0.0),
+            ("payment_id", "!=", False),
+        ]
+        if invoice.is_inbound():
+            domain.append(("balance", "<", 0.0))
+        else:
+            domain.append(("balance", ">", 0.0))
+        folio_ids = invoice.folio_ids.ids
+        if folio_ids:
+            domain.append(("folio_ids", "in", folio_ids))
+        else:
+            domain.append(("partner_id", "=", invoice.commercial_partner_id.id))
+        lines = self.env["account.move.line"].sudo().search(domain)
+        items = []
+        for line in lines:
+            payment = line.payment_id
+            pay_currency = payment.currency_id or payment.company_id.currency_id
+            available_currency = abs(line.amount_residual_currency)
+            available_company = abs(line.amount_residual)
+            if pay_currency.is_zero(available_currency):
+                continue
+            items.append(
+                ReconcilablePayment.from_account_payment(
+                    payment, available_currency, available_company
+                )
+            )
+        return items
 
     def _get_invoice_share_url(self, record_id):
         try:

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -505,39 +505,41 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/duplicate-downpayment-lines",
-                "Duplicate down-payment lines",
-                "Each down-payment line can only appear once in the request.",
+                "Duplicate down-payment invoices",
+                "Each down-payment invoice can only appear once in the request.",
             )
-        dp_lines = self.env["folio.sale.line"].sudo().browse(ids).exists()
-        missing = set(ids) - set(dp_lines.ids)
+        dp_invoices = self.env["account.move"].sudo().browse(ids).exists()
+        missing = set(ids) - set(dp_invoices.ids)
         if missing:
             self._raise_edit_problem(
                 404,
                 "/errors/downpayment-lines-not-found",
-                "Down-payment lines not found",
-                "Some down-payment lines could not be found.",
+                "Down-payment invoices not found",
+                "Some down-payment invoices could not be found.",
                 missingDownpaymentLineIds=sorted(missing),
             )
-        not_downpayment = dp_lines.filtered(lambda r: not r.is_downpayment)
+        not_downpayment = dp_invoices.filtered(lambda m: not m._is_downpayment())
         if not_downpayment:
             self._raise_edit_problem(
                 422,
                 "/errors/invalid-downpayment-line",
-                "Invalid down-payment line",
-                "Only down-payment lines are accepted as downpaymentLines.",
+                "Invalid down-payment invoice",
+                "Only down-payment invoices are accepted as downpaymentLines.",
                 invalidDownpaymentLineIds=not_downpayment.ids,
             )
         folio_ids = set(sale_lines.folio_id.ids)
-        out_of_scope = dp_lines.filtered(lambda r: r.folio_id.id not in folio_ids)
+        out_of_scope = dp_invoices.filtered(
+            lambda m: not set(m.folio_ids.ids) & folio_ids
+        )
         if out_of_scope:
             self._raise_edit_problem(
                 422,
                 "/errors/downpayment-line-out-of-scope",
-                "Down-payment line out of scope",
-                "Down-payment lines must belong to the same folios as folioLines.",
+                "Down-payment invoice out of scope",
+                "Down-payment invoices must belong to the same folios as folioLines.",
                 outOfScopeDownpaymentLineIds=out_of_scope.ids,
             )
-        return dp_lines
+        return dp_invoices.invoice_line_ids.folio_line_ids.filtered("is_downpayment")
 
     def _edit_resolve_property(self, sale_lines):
         properties = sale_lines.mapped("pms_property_id")

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -68,6 +68,35 @@ async def invoice_extra_features(
     return env["pms_api_invoice.invoice_router.helper"].extra_features()
 
 
+@pms_api_router.get(
+    "/invoices/validate-contact",
+    tags=["invoice"],
+    status_code=204,
+    responses={
+        204: {"description": "Contact meets invoicing requirements."},
+        422: {"description": "Contact does not meet invoicing requirements."},
+    },
+    response_class=Response,
+)
+async def validate_invoice_contact(
+    env: AuthenticatedEnv,
+    pmsPropertyId: Annotated[
+        int,
+        Query(description="ID of the property whose invoicing rules are validated."),
+    ],
+    contactId: Annotated[
+        int,
+        Query(description="ID of the contact to validate as invoicing customer."),
+    ],
+) -> Response:
+    """Validate if a contact meets the invoicing requirements of a property."""
+    return (
+        env["pms_api_invoice.invoice_router.helper"]
+        .new()
+        ._validate_contact(pmsPropertyId, contactId)
+    )
+
+
 @pms_api_router.post(
     "/invoices/{id}/validate",
     response_model=InvoiceSummary,
@@ -216,6 +245,73 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
 
     @api.model
     def extra_features(self):
+        return []
+
+    def _validate_contact(self, pms_property_id: int, contact_id: int):
+        partner = self.env["res.partner"].sudo().browse(contact_id)
+        if not partner.exists():
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/not-found",
+                    "title": "Not found",
+                    "status": 404,
+                    "detail": "Contact not found.",
+                },
+                media_type="application/problem+json",
+            )
+        pms_property = self.env["pms.property"].sudo().browse(pms_property_id)
+        if not pms_property.exists():
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/not-found",
+                    "title": "Not found",
+                    "status": 404,
+                    "detail": "Property not found.",
+                },
+                media_type="application/problem+json",
+            )
+        errors = self._get_contact_validation_errors(partner, pms_property)
+        if errors:
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "type": "/errors/invoicing-validation-failed",
+                    "title": "Invoicing validation failed",
+                    "status": 422,
+                    "detail": "Contact does not meet invoicing requirements.",
+                    "errors": errors,
+                },
+                media_type="application/problem+json",
+            )
+        return Response(status_code=204)
+
+    def _get_contact_validation_errors(self, partner, pms_property) -> list[dict]:
+        """Return RFC 9457 ProblemDetailItem dicts for each validation failure.
+
+        Override in localization modules to add country-specific checks.
+        """
+        errors = []
+        errors.extend(self._check_fiscal_id(partner, pms_property))
+        return errors
+
+    def _check_fiscal_id(self, partner, pms_property) -> list[dict]:
+        """Check fiscal identification. Override in localizations.
+
+        Base implementation requires a VAT number.
+        """
+        if not partner.vat:
+            return [
+                {
+                    "type": "/errors/missing-fiscal-id",
+                    "title": "Missing fiscal identification number",
+                    "detail": (
+                        "El contacto no tiene número de identificación"
+                        " fiscal configurado."
+                    ),
+                }
+            ]
         return []
 
     # -- Invoice report helpers --

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -163,26 +163,57 @@ async def edit_invoice(
 
 @pms_api_router.delete(
     "/invoices/{invoice_id}",
+    response_model=InvoiceDetail,
     tags=["invoice"],
-    status_code=204,
     responses={
-        204: {"description": "Invoice deleted."},
+        200: {
+            "description": (
+                "Validated invoice cancelled; returns the credit note that "
+                "reverses it."
+            )
+        },
+        204: {"description": "Draft invoice deleted."},
         404: {"description": "Invoice not found"},
-        409: {"description": "Invoice cannot be deleted in its current state"},
+        409: {
+            "description": (
+                "Invoice cannot be deleted in its current state, or refund "
+                "confirmation required."
+            )
+        },
     },
-    response_class=Response,
 )
 async def delete_invoice(
     env: AuthenticatedEnv,
     invoice_id: int,
-) -> Response:
-    """Delete a draft invoice.
+    confirmRefund: Annotated[
+        bool,
+        Query(
+            description=(
+                "Required when the invoice is validated. Without this flag, "
+                "deleting a validated invoice returns 409."
+            ),
+        ),
+    ] = False,
+    reason: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Reason for the cancellation, recorded on the credit note. "
+                "Only used when the invoice is validated."
+            ),
+        ),
+    ] = None,
+):
+    """Delete a draft invoice or cancel a validated one.
 
-    Only draft invoices can be deleted. Validated or cancelled invoices
-    return 409.
+    Drafts are deleted in place and the endpoint returns 204. Validated
+    invoices, when confirmRefund=true, generate a full refund that cancels
+    the original; the endpoint returns the resulting credit note.
     """
     return (
-        env["pms_api_invoice.invoice_router.helper"].new()._delete_invoice(invoice_id)
+        env["pms_api_invoice.invoice_router.helper"]
+        .new()
+        ._delete_invoice(invoice_id, confirmRefund, reason)
     )
 
 
@@ -421,7 +452,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
 
     # -- Invoice delete (DELETE /invoices/{id}) --
 
-    def _delete_invoice(self, invoice_id):
+    def _delete_invoice(self, invoice_id, confirm_refund=False, reason=None):
         try:
             invoice = self.get(invoice_id)
         except MissingError:
@@ -435,19 +466,32 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 },
                 media_type="application/problem+json",
             )
-        if invoice.state != "draft":
-            return JSONResponse(
-                status_code=409,
-                content={
-                    "type": "/errors/invoice-not-deletable",
-                    "title": _("Invoice not deletable"),
-                    "status": 409,
-                    "detail": _("Only draft invoices can be deleted."),
-                },
-                media_type="application/problem+json",
-            )
-        invoice.unlink()
-        return Response(status_code=204)
+        try:
+            if invoice.state == "cancel":
+                self._raise_edit_problem(
+                    409,
+                    "/errors/invoice-not-deletable",
+                    _("Invoice not deletable"),
+                    _("Cancelled invoices cannot be deleted."),
+                )
+            if invoice.state == "draft":
+                invoice.unlink()
+                return Response(status_code=204)
+            if not confirm_refund:
+                self._raise_edit_problem(
+                    409,
+                    "/errors/invoice-refund-confirmation-required",
+                    _("Refund confirmation required"),
+                    _(
+                        "This invoice is validated. Deleting it will generate "
+                        "a refund that cancels it. Confirm by passing "
+                        "confirmRefund=true."
+                    ),
+                )
+            credit_note = self._cancel_posted_invoice(invoice, reason)
+        except _InvoiceEditProblem as problem:
+            return problem.response
+        return InvoiceDetail.from_account_move(credit_note)
 
     # -- Invoice edit (PUT /invoices/{id}) --
 
@@ -782,6 +826,55 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
         invoice.write(write_vals)
         return invoice
 
+    def _reverse_invoice_move(self, invoice, reason=None, cancel=True):
+        """Create the credit note that reverses `invoice` and return it.
+
+        With cancel=True the credit note is posted and reconciled against the
+        original (full reversal). With cancel=False it is created in draft and
+        left untouched, so callers wanting it posted must post it explicitly.
+        The `ref` mirrors the account.move.reversal wizard, optionally carrying
+        the cancellation reason.
+        """
+        reversal_date = fields.Date.context_today(invoice)
+        ref = (
+            _(
+                "Reversal of: %(move_name)s, %(reason)s",
+                move_name=invoice.name,
+                reason=reason,
+            )
+            if reason
+            else _("Reversal of: %s", invoice.name)
+        )
+        return invoice._reverse_moves(
+            default_values_list=[
+                {
+                    "ref": ref,
+                    "date": reversal_date,
+                    "invoice_date": reversal_date,
+                    "invoice_date_due": reversal_date,
+                    "journal_id": invoice.journal_id.id,
+                }
+            ],
+            cancel=cancel,
+        )
+
+    def _cancel_posted_invoice(self, invoice, reason=None):
+        """Cancel a posted invoice with a credit note, returning the credit note.
+
+        An unpaid invoice is fully reversed: the credit note is reconciled
+        against the original, leaving it reversed. An invoice that already has
+        payments is left untouched with its payments; the credit note is posted
+        and left open as a refund owed to the customer (it is not reconciled
+        against the original).
+        """
+        has_payments = invoice.payment_state in ("paid", "in_payment", "partial")
+        credit_note = self._reverse_invoice_move(
+            invoice, reason=reason, cancel=not has_payments
+        )
+        if has_payments:
+            credit_note.action_post()
+        return credit_note
+
     def _edit_posted_invoice(
         self, invoice, payload, sale_lines, downpayment_lines, partner
     ):
@@ -790,19 +883,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             in ("asset_receivable", "liability_payable")
         )
         receivable_lines.remove_move_reconcile()
-        reversal_date = fields.Date.context_today(invoice)
-        invoice._reverse_moves(
-            default_values_list=[
-                {
-                    "ref": f"Reversal of: {invoice.name}",
-                    "date": reversal_date,
-                    "invoice_date": reversal_date,
-                    "invoice_date_due": reversal_date,
-                    "journal_id": invoice.journal_id.id,
-                }
-            ],
-            cancel=True,
-        )
+        self._reverse_invoice_move(invoice)
         vals = self._edit_compute_invoice_vals(
             payload, sale_lines, downpayment_lines, partner
         )

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -161,6 +161,31 @@ async def edit_invoice(
     )
 
 
+@pms_api_router.delete(
+    "/invoices/{invoice_id}",
+    tags=["invoice"],
+    status_code=204,
+    responses={
+        204: {"description": "Invoice deleted."},
+        404: {"description": "Invoice not found"},
+        409: {"description": "Invoice cannot be deleted in its current state"},
+    },
+    response_class=Response,
+)
+async def delete_invoice(
+    env: AuthenticatedEnv,
+    invoice_id: int,
+) -> Response:
+    """Delete a draft invoice.
+
+    Only draft invoices can be deleted. Validated or cancelled invoices
+    return 409.
+    """
+    return (
+        env["pms_api_invoice.invoice_router.helper"].new()._delete_invoice(invoice_id)
+    )
+
+
 @pms_api_router.post(
     "/invoices/{id}/validate",
     response_model=InvoiceSummary,
@@ -393,6 +418,36 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 media_type="application/problem+json",
             )
         return InvoiceDetail.from_account_move(invoice)
+
+    # -- Invoice delete (DELETE /invoices/{id}) --
+
+    def _delete_invoice(self, invoice_id):
+        try:
+            invoice = self.get(invoice_id)
+        except MissingError:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/not-found",
+                    "title": _("Not found"),
+                    "status": 404,
+                    "detail": _("Invoice not found."),
+                },
+                media_type="application/problem+json",
+            )
+        if invoice.state != "draft":
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "type": "/errors/invoice-not-deletable",
+                    "title": _("Invoice not deletable"),
+                    "status": 409,
+                    "detail": _("Only draft invoices can be deleted."),
+                },
+                media_type="application/problem+json",
+            )
+        invoice.unlink()
+        return Response(status_code=204)
 
     # -- Invoice edit (PUT /invoices/{id}) --
 

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import Depends, Query
 from fastapi.responses import JSONResponse, Response
 
-from odoo import SUPERUSER_ID, api, fields, models
+from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import MissingError, UserError
 from odoo.osv import expression
 
@@ -386,9 +386,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -420,9 +420,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -431,15 +431,15 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     409,
                     "/errors/invoice-not-editable",
-                    "Invoice not editable",
-                    "Cancelled invoices cannot be edited.",
+                    _("Invoice not editable"),
+                    _("Cancelled invoices cannot be edited."),
                 )
             if invoice.state == "posted" and not confirm_refund:
                 self._raise_edit_problem(
                     409,
                     "/errors/invoice-refund-confirmation-required",
-                    "Refund confirmation required",
-                    (
+                    _("Refund confirmation required"),
+                    _(
                         "This invoice is validated. Editing it will generate "
                         "a refund and a new corrected invoice. Confirm by "
                         "passing confirmRefund=true."
@@ -473,8 +473,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/duplicate-sale-lines",
-                "Duplicate sale lines",
-                "Each folio line can only appear once in the request.",
+                _("Duplicate sale lines"),
+                _("Each folio line can only appear once in the request."),
             )
         sale_lines = self.env["folio.sale.line"].sudo().browse(line_ids).exists()
         missing = set(line_ids) - set(sale_lines.ids)
@@ -482,8 +482,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 404,
                 "/errors/sale-lines-not-found",
-                "Sale lines not found",
-                "Some folio lines could not be found.",
+                _("Sale lines not found"),
+                _("Some folio lines could not be found."),
                 missingFolioLineIds=sorted(missing),
             )
         invalid_kind = sale_lines.filtered(lambda r: r.display_type or r.is_downpayment)
@@ -491,8 +491,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/invalid-folio-line",
-                "Invalid folio line",
-                "Sections, notes and down payments cannot be sent as folioLines.",
+                _("Invalid folio line"),
+                _("Sections, notes and down payments cannot be sent as folioLines."),
                 invalidFolioLineIds=invalid_kind.ids,
             )
         return sale_lines
@@ -505,8 +505,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/duplicate-downpayment-lines",
-                "Duplicate down-payment invoices",
-                "Each down-payment invoice can only appear once in the request.",
+                _("Duplicate down-payment invoices"),
+                _("Each down-payment invoice can only appear once in the request."),
             )
         dp_invoices = self.env["account.move"].sudo().browse(ids).exists()
         missing = set(ids) - set(dp_invoices.ids)
@@ -514,8 +514,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 404,
                 "/errors/downpayment-lines-not-found",
-                "Down-payment invoices not found",
-                "Some down-payment invoices could not be found.",
+                _("Down-payment invoices not found"),
+                _("Some down-payment invoices could not be found."),
                 missingDownpaymentLineIds=sorted(missing),
             )
         not_downpayment = dp_invoices.filtered(lambda m: not m._is_downpayment())
@@ -523,8 +523,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/invalid-downpayment-line",
-                "Invalid down-payment invoice",
-                "Only down-payment invoices are accepted as downpaymentLines.",
+                _("Invalid down-payment invoice"),
+                _("Only down-payment invoices are accepted as downpaymentLines."),
                 invalidDownpaymentLineIds=not_downpayment.ids,
             )
         folio_ids = set(sale_lines.folio_id.ids)
@@ -535,8 +535,11 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/downpayment-line-out-of-scope",
-                "Down-payment invoice out of scope",
-                "Down-payment invoices must belong to the same folios as folioLines.",
+                _("Down-payment invoice out of scope"),
+                _(
+                    "Down-payment invoices must belong to the same folios as"
+                    " folioLines."
+                ),
                 outOfScopeDownpaymentLineIds=out_of_scope.ids,
             )
         return dp_invoices.invoice_line_ids.folio_line_ids.filtered("is_downpayment")
@@ -547,8 +550,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/multiple-properties",
-                "Folio lines from multiple properties",
-                "All folio lines must belong to the same property.",
+                _("Folio lines from multiple properties"),
+                _("All folio lines must belong to the same property."),
                 propertyIds=properties.ids,
             )
         return properties
@@ -559,8 +562,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 404,
                 "/errors/not-found",
-                "Contact not found",
-                "Customer not found.",
+                _("Contact not found"),
+                _("Customer not found."),
             )
         various = self.env.ref("pms.various_pms_partner", raise_if_not_found=False)
         if various and partner.id == various.id:
@@ -570,8 +573,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/invoicing-validation-failed",
-                "Invoicing validation failed",
-                "Customer does not meet invoicing requirements.",
+                _("Invoicing validation failed"),
+                _("Customer does not meet invoicing requirements."),
                 errors=errors,
             )
         return partner
@@ -605,9 +608,11 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/quantity-exceeds-pending",
-                "Quantity to invoice exceeds pending quantity",
-                "One or more folio lines were asked to invoice more "
-                "than their pending quantity.",
+                _("Quantity to invoice exceeds pending quantity"),
+                _(
+                    "One or more folio lines were asked to invoice more "
+                    "than their pending quantity."
+                ),
                 lines=qty_errors,
             )
 
@@ -622,19 +627,17 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 composition_errors.append(
                     {
                         "type": "/errors/folio-line-already-invoiced",
-                        "title": "Folio line already invoiced",
-                        "detail": (
-                            f"Folio line {sl.id} is already included in "
-                            f"invoice {other_moves[0].id}."
-                        ),
+                        "title": _("Folio line already invoiced"),
+                        "detail": _("Folio line %s is already included in invoice %s.")
+                        % (sl.id, other_moves[0].id),
                     }
                 )
         if composition_errors:
             self._raise_edit_problem(
                 422,
                 "/errors/invoice-composition-invalid",
-                "Invalid invoice composition",
-                "Some folio lines cannot be invoiced.",
+                _("Invalid invoice composition"),
+                _("Some folio lines cannot be invoiced."),
                 errors=composition_errors,
             )
 
@@ -679,23 +682,25 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/invoice-creation-failed",
-                "Invoice creation failed",
+                _("Invoice creation failed"),
                 str(e),
             )
         if not vals_list:
             self._raise_edit_problem(
                 422,
                 "/errors/invoice-creation-failed",
-                "Invoice creation failed",
-                "No invoice could be built from the provided composition.",
+                _("Invoice creation failed"),
+                _("No invoice could be built from the provided composition."),
             )
         if len(vals_list) > 1:
             self._raise_edit_problem(
                 422,
                 "/errors/multiple-invoices-created",
-                "Multiple invoices created",
-                "The provided composition could not be grouped into a single "
-                "invoice (different currency or company).",
+                _("Multiple invoices created"),
+                _(
+                    "The provided composition could not be grouped into a single "
+                    "invoice (different currency or company)."
+                ),
             )
         return vals_list[0]
 
@@ -759,7 +764,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             self._raise_edit_problem(
                 422,
                 "/errors/invoice-creation-failed",
-                "Invoice creation failed",
+                _("Invoice creation failed"),
                 str(e),
             )
         return new_invoice
@@ -771,9 +776,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Contact not found.",
+                    "detail": _("Contact not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -783,9 +788,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Property not found.",
+                    "detail": _("Property not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -795,9 +800,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=422,
                 content={
                     "type": "/errors/invoicing-validation-failed",
-                    "title": "Invoicing validation failed",
+                    "title": _("Invoicing validation failed"),
                     "status": 422,
-                    "detail": "Contact does not meet invoicing requirements.",
+                    "detail": _("Contact does not meet invoicing requirements."),
                     "errors": errors,
                 },
                 media_type="application/problem+json",
@@ -822,10 +827,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             return [
                 {
                     "type": "/errors/missing-fiscal-id",
-                    "title": "Missing fiscal identification number",
-                    "detail": (
-                        "El contacto no tiene número de identificación"
-                        " fiscal configurado."
+                    "title": _("Missing fiscal identification number"),
+                    "detail": _(
+                        "The contact has no fiscal identification number" " configured."
                     ),
                 }
             ]
@@ -845,9 +849,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=400,
                 content={
                     "type": "/errors/mutually-exclusive-params",
-                    "title": "Mutually exclusive parameters",
+                    "title": _("Mutually exclusive parameters"),
                     "status": 400,
-                    "detail": (
+                    "detail": _(
                         "Cannot specify both 'ids' and filter parameters. "
                         "Use one or the other."
                     ),
@@ -870,12 +874,13 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=400,
                 content={
                     "type": "/errors/record-limit-exceeded",
-                    "title": "Record limit exceeded",
+                    "title": _("Record limit exceeded"),
                     "status": 400,
-                    "detail": (
-                        f"The export requested {count} records, "
-                        f"but the maximum allowed is {max_records}."
-                    ),
+                    "detail": _(
+                        "The export requested %s records, "
+                        "but the maximum allowed is %s."
+                    )
+                    % (count, max_records),
                     "requestedCount": count,
                     "maxAllowed": max_records,
                 },
@@ -904,9 +909,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -915,12 +920,10 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=400,
                 content={
                     "type": "/errors/invoice-not-draft",
-                    "title": "Invoice not in draft state",
+                    "title": _("Invoice not in draft state"),
                     "status": 400,
-                    "detail": (
-                        f"Invoice {invoice.name} is in state "
-                        f'"{invoice.state}" and cannot be validated.'
-                    ),
+                    "detail": _('Invoice %s is in state "%s" and cannot be validated.')
+                    % (invoice.name, invoice.state),
                 },
                 media_type="application/problem+json",
             )
@@ -931,7 +934,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=400,
                 content={
                     "type": "/errors/validation-error",
-                    "title": "Validation error",
+                    "title": _("Validation error"),
                     "status": 400,
                     "detail": str(e),
                 },
@@ -947,11 +950,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             PmsApiInvoiceRouterHelper._raise_edit_problem(
                 422,
                 "/errors/invalid-reconciliation-id",
-                "Invalid reconciliation id",
-                (
-                    f"Reconciliation id '{composite_id}' is malformed. "
-                    "Expected 'payment_{id}'."
-                ),
+                _("Invalid reconciliation id"),
+                _("Reconciliation id '%s' is malformed. Expected 'payment_{id}'.")
+                % composite_id,
             )
         return int(match.group(1))
 
@@ -979,9 +980,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/invoice-not-found",
-                    "title": "Invoice not found",
+                    "title": _("Invoice not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -994,8 +995,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     409,
                     "/errors/invoice-not-editable",
-                    "Invoice not editable",
-                    "The invoice state does not allow new reconciliations.",
+                    _("Invoice not editable"),
+                    _("The invoice state does not allow new reconciliations."),
                 )
             payment = (
                 self.env["account.payment"]
@@ -1012,16 +1013,16 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     404,
                     "/errors/payment-not-found",
-                    "Payment not found",
-                    f"Payment {payment_id} not found.",
+                    _("Payment not found"),
+                    _("Payment %s not found.") % payment_id,
                 )
             if invoice.folio_ids:
                 if not (payment.folio_ids & invoice.folio_ids):
                     self._raise_edit_problem(
                         409,
                         "/errors/payment-not-applicable",
-                        "Payment not applicable",
-                        ("Payment does not belong to any folio of this " "invoice."),
+                        _("Payment not applicable"),
+                        _("Payment does not belong to any folio of this " "invoice."),
                     )
             elif (
                 payment.partner_id.commercial_partner_id
@@ -1030,8 +1031,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     409,
                     "/errors/payment-not-applicable",
-                    "Payment not applicable",
-                    "Payment does not belong to the invoice's customer.",
+                    _("Payment not applicable"),
+                    _("Payment does not belong to the invoice's customer."),
                 )
             invoice_recv, payment_recv, partials = self._get_reconciliation_partials(
                 invoice, payment
@@ -1040,18 +1041,16 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     409,
                     "/errors/payment-already-reconciled",
-                    "Payment already reconciled",
-                    (
-                        f"Payment {payment.id} is already reconciled with "
-                        f"invoice {invoice.id}."
-                    ),
+                    _("Payment already reconciled"),
+                    _("Payment %s is already reconciled with invoice %s.")
+                    % (payment.id, invoice.id),
                 )
             if not invoice_recv or not payment_recv:
                 self._raise_edit_problem(
                     409,
                     "/errors/payment-not-applicable",
-                    "Payment not applicable",
-                    "Payment is not in a reconcilable state.",
+                    _("Payment not applicable"),
+                    _("Payment is not in a reconcilable state."),
                 )
             try:
                 (invoice_recv + payment_recv).filtered(
@@ -1061,7 +1060,7 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     409,
                     "/errors/payment-not-applicable",
-                    "Payment not applicable",
+                    _("Payment not applicable"),
                     str(e),
                 )
         except _InvoiceEditProblem as problem:
@@ -1079,9 +1078,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/invoice-not-found",
-                    "title": "Invoice not found",
+                    "title": _("Invoice not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -1091,8 +1090,8 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     409,
                     "/errors/invoice-not-editable",
-                    "Invoice not editable",
-                    "The invoice state does not allow undoing reconciliations.",
+                    _("Invoice not editable"),
+                    _("The invoice state does not allow undoing reconciliations."),
                 )
             payment = (
                 self.env["account.payment"]
@@ -1109,11 +1108,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     404,
                     "/errors/reconciliation-not-found",
-                    "Reconciliation not found",
-                    (
-                        f"No reconciliation exists between invoice {invoice.id} "
-                        f"and payment {payment_id}."
-                    ),
+                    _("Reconciliation not found"),
+                    _("No reconciliation exists between invoice %s and payment %s.")
+                    % (invoice.id, payment_id),
                 )
             _invoice_recv, _payment_recv, partials = self._get_reconciliation_partials(
                 invoice, payment
@@ -1122,11 +1119,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 self._raise_edit_problem(
                     404,
                     "/errors/reconciliation-not-found",
-                    "Reconciliation not found",
-                    (
-                        f"No reconciliation exists between invoice {invoice.id} "
-                        f"and payment {payment.id}."
-                    ),
+                    _("Reconciliation not found"),
+                    _("No reconciliation exists between invoice %s and payment %s.")
+                    % (invoice.id, payment.id),
                 )
             partials.unlink()
         except _InvoiceEditProblem as problem:
@@ -1144,9 +1139,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -1200,9 +1195,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -1221,9 +1216,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 status_code=404,
                 content={
                     "type": "/errors/not-found",
-                    "title": "Not found",
+                    "title": _("Not found"),
                     "status": 404,
-                    "detail": "Invoice not found.",
+                    "detail": _("Invoice not found."),
                 },
                 media_type="application/problem+json",
             )
@@ -1287,9 +1282,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             status_code=501,
             content={
                 "type": "/errors/not-implemented",
-                "title": "Not implemented",
+                "title": _("Not implemented"),
                 "status": 501,
-                "detail": "PDF report generation is not yet implemented.",
+                "detail": _("PDF report generation is not yet implemented."),
             },
             media_type="application/problem+json",
         )

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -114,6 +114,20 @@ async def validate_invoice_contact(
     )
 
 
+@pms_api_router.get(
+    "/invoices/{invoice_id}",
+    response_model=InvoiceDetail,
+    tags=["invoice"],
+    responses={404: {"description": "Invoice not found"}},
+)
+async def get_invoice(
+    env: AuthenticatedEnv,
+    invoice_id: int,
+):
+    """Get detail info of an invoice for editing purposes."""
+    return env["pms_api_invoice.invoice_router.helper"].new()._get_invoice(invoice_id)
+
+
 @pms_api_router.put(
     "/invoices/{invoice_id}",
     response_model=InvoiceDetail,
@@ -361,6 +375,24 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
     @api.model
     def extra_features(self):
         return []
+
+    # -- Invoice detail (GET /invoices/{id}) --
+
+    def _get_invoice(self, invoice_id):
+        try:
+            invoice = self.get(invoice_id)
+        except MissingError:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/not-found",
+                    "title": "Not found",
+                    "status": 404,
+                    "detail": "Invoice not found.",
+                },
+                media_type="application/problem+json",
+            )
+        return InvoiceDetail.from_account_move(invoice)
 
     # -- Invoice edit (PUT /invoices/{id}) --
 

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -48,6 +48,8 @@ class _InvoiceEditProblem(Exception):
 INVOICE_REPORT_MAX_RECORDS = 5000
 INVOICE_PDF_REPORT_MAX_RECORDS = 100
 
+_PAYMENT_ID_RE = re.compile(r"^payment_(\d+)$")
+
 InvoiceOrderDependency = create_order_dependency(
     InvoiceOrderField, INVOICE_ORDER_MAPPING, ["-invoice_date,-name"]
 )
@@ -228,9 +230,6 @@ async def validate_invoice(
 ) -> InvoiceSummary:
     """Validate a draft invoice."""
     return env["pms_api_invoice.invoice_router.helper"].new()._validate_invoice(id)
-
-
-_PAYMENT_ID_RE = re.compile(r"^payment_(\d+)$")
 
 
 @pms_api_router.post(

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends, Query
 from fastapi.responses import JSONResponse, Response
 
-from odoo import SUPERUSER_ID, api, models
+from odoo import SUPERUSER_ID, api, fields, models
 from odoo.exceptions import MissingError, UserError
 from odoo.osv import expression
 
@@ -18,8 +18,13 @@ from odoo.addons.pms_fastapi.dependencies import (
     create_order_dependency,
 )
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.models.folio_sale_line import (
+    FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX,
+)
 from odoo.addons.pms_fastapi.schemas.invoice import (
     INVOICE_ORDER_MAPPING,
+    InvoiceDetail,
+    InvoiceInput,
     InvoiceOrderField,
     InvoiceSearch,
     InvoiceSummary,
@@ -27,6 +32,15 @@ from odoo.addons.pms_fastapi.schemas.invoice import (
     ShareUrl,
 )
 from odoo.addons.pms_fastapi.utils import FilteredModelAdapter
+
+
+class _InvoiceEditProblem(Exception):
+    """Control-flow exception carrying an RFC 9457 JSONResponse."""
+
+    def __init__(self, response):
+        super().__init__()
+        self.response = response
+
 
 INVOICE_REPORT_MAX_RECORDS = 5000
 INVOICE_PDF_REPORT_MAX_RECORDS = 100
@@ -94,6 +108,39 @@ async def validate_invoice_contact(
         env["pms_api_invoice.invoice_router.helper"]
         .new()
         ._validate_contact(pmsPropertyId, contactId)
+    )
+
+
+@pms_api_router.put(
+    "/invoices/{invoice_id}",
+    response_model=InvoiceDetail,
+    tags=["invoice"],
+)
+async def edit_invoice(
+    env: AuthenticatedEnv,
+    invoice_id: int,
+    payload: InvoiceInput,
+    confirmRefund: Annotated[
+        bool,
+        Query(
+            description=(
+                "Required when the invoice is validated. Without this flag, "
+                "editing a validated invoice returns 409."
+            ),
+        ),
+    ] = False,
+):
+    """Edit an existing invoice as a full replacement.
+
+    Drafts are rewritten in-place (same id). Validated invoices, when
+    confirmRefund=true, generate a full refund that cancels the original
+    and a new corrected invoice in draft (different id) whose `replaces`
+    points to the original.
+    """
+    return (
+        env["pms_api_invoice.invoice_router.helper"]
+        .new()
+        ._edit_invoice(invoice_id, payload, confirmRefund)
     )
 
 
@@ -246,6 +293,370 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
     @api.model
     def extra_features(self):
         return []
+
+    # -- Invoice edit (PUT /invoices/{id}) --
+
+    @staticmethod
+    def _raise_edit_problem(status, type_, title, detail, **extra):
+        raise _InvoiceEditProblem(
+            JSONResponse(
+                status_code=status,
+                content={
+                    "type": type_,
+                    "title": title,
+                    "status": status,
+                    "detail": detail,
+                    **extra,
+                },
+                media_type="application/problem+json",
+            )
+        )
+
+    def _edit_invoice(self, invoice_id, payload, confirm_refund):
+        try:
+            invoice = self.get(invoice_id)
+        except MissingError:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "type": "/errors/not-found",
+                    "title": "Not found",
+                    "status": 404,
+                    "detail": "Invoice not found.",
+                },
+                media_type="application/problem+json",
+            )
+        try:
+            if invoice.state == "cancel":
+                self._raise_edit_problem(
+                    409,
+                    "/errors/invoice-not-editable",
+                    "Invoice not editable",
+                    "Cancelled invoices cannot be edited.",
+                )
+            if invoice.state == "posted" and not confirm_refund:
+                self._raise_edit_problem(
+                    409,
+                    "/errors/invoice-refund-confirmation-required",
+                    "Refund confirmation required",
+                    (
+                        "This invoice is validated. Editing it will generate "
+                        "a refund and a new corrected invoice. Confirm by "
+                        "passing confirmRefund=true."
+                    ),
+                )
+            sale_lines = self._edit_resolve_sale_lines(payload)
+            downpayment_lines = self._edit_resolve_downpayment_lines(
+                payload, sale_lines
+            )
+            pms_property = self._edit_resolve_property(sale_lines)
+            partner = self._edit_resolve_partner(payload, pms_property)
+            self._edit_check_quantities(payload, sale_lines, current_invoice=invoice)
+            self._edit_check_composition(
+                sale_lines, downpayment_lines, current_invoice=invoice
+            )
+            if invoice.state == "draft":
+                result = self._edit_draft_invoice(
+                    invoice, payload, sale_lines, downpayment_lines, partner
+                )
+            else:
+                result = self._edit_posted_invoice(
+                    invoice, payload, sale_lines, downpayment_lines, partner
+                )
+        except _InvoiceEditProblem as problem:
+            return problem.response
+        return InvoiceDetail.from_account_move(result)
+
+    def _edit_resolve_sale_lines(self, payload):
+        line_ids = [fl.id for fl in payload.folioLines]
+        if len(line_ids) != len(set(line_ids)):
+            self._raise_edit_problem(
+                422,
+                "/errors/duplicate-sale-lines",
+                "Duplicate sale lines",
+                "Each folio line can only appear once in the request.",
+            )
+        sale_lines = self.env["folio.sale.line"].browse(line_ids).exists()
+        missing = set(line_ids) - set(sale_lines.ids)
+        if missing:
+            self._raise_edit_problem(
+                404,
+                "/errors/sale-lines-not-found",
+                "Sale lines not found",
+                "Some folio lines could not be found.",
+                missingFolioLineIds=sorted(missing),
+            )
+        invalid_kind = sale_lines.filtered(lambda r: r.display_type or r.is_downpayment)
+        if invalid_kind:
+            self._raise_edit_problem(
+                422,
+                "/errors/invalid-folio-line",
+                "Invalid folio line",
+                "Sections, notes and down payments cannot be sent as folioLines.",
+                invalidFolioLineIds=invalid_kind.ids,
+            )
+        return sale_lines
+
+    def _edit_resolve_downpayment_lines(self, payload, sale_lines):
+        if not payload.downpaymentLines:
+            return self.env["folio.sale.line"]
+        ids = list(set(payload.downpaymentLines))
+        if len(ids) != len(payload.downpaymentLines):
+            self._raise_edit_problem(
+                422,
+                "/errors/duplicate-downpayment-lines",
+                "Duplicate down-payment lines",
+                "Each down-payment line can only appear once in the request.",
+            )
+        dp_lines = self.env["folio.sale.line"].browse(ids).exists()
+        missing = set(ids) - set(dp_lines.ids)
+        if missing:
+            self._raise_edit_problem(
+                404,
+                "/errors/downpayment-lines-not-found",
+                "Down-payment lines not found",
+                "Some down-payment lines could not be found.",
+                missingDownpaymentLineIds=sorted(missing),
+            )
+        not_downpayment = dp_lines.filtered(lambda r: not r.is_downpayment)
+        if not_downpayment:
+            self._raise_edit_problem(
+                422,
+                "/errors/invalid-downpayment-line",
+                "Invalid down-payment line",
+                "Only down-payment lines are accepted as downpaymentLines.",
+                invalidDownpaymentLineIds=not_downpayment.ids,
+            )
+        folio_ids = set(sale_lines.folio_id.ids)
+        out_of_scope = dp_lines.filtered(lambda r: r.folio_id.id not in folio_ids)
+        if out_of_scope:
+            self._raise_edit_problem(
+                422,
+                "/errors/downpayment-line-out-of-scope",
+                "Down-payment line out of scope",
+                "Down-payment lines must belong to the same folios as folioLines.",
+                outOfScopeDownpaymentLineIds=out_of_scope.ids,
+            )
+        return dp_lines
+
+    def _edit_resolve_property(self, sale_lines):
+        properties = sale_lines.mapped("pms_property_id")
+        if len(properties) > 1:
+            self._raise_edit_problem(
+                422,
+                "/errors/multiple-properties",
+                "Folio lines from multiple properties",
+                "All folio lines must belong to the same property.",
+                propertyIds=properties.ids,
+            )
+        return properties
+
+    def _edit_resolve_partner(self, payload, pms_property):
+        partner = self.env["res.partner"].browse(payload.partner).exists()
+        if not partner:
+            self._raise_edit_problem(
+                404,
+                "/errors/not-found",
+                "Contact not found",
+                "Customer not found.",
+            )
+        various = self.env.ref("pms.various_pms_partner", raise_if_not_found=False)
+        if various and partner.id == various.id:
+            return partner
+        errors = self._get_contact_validation_errors(partner, pms_property)
+        if errors:
+            self._raise_edit_problem(
+                422,
+                "/errors/invoicing-validation-failed",
+                "Invoicing validation failed",
+                "Customer does not meet invoicing requirements.",
+                errors=errors,
+            )
+        return partner
+
+    def _edit_check_quantities(self, payload, sale_lines, current_invoice):
+        sale_lines_by_id = {sl.id: sl for sl in sale_lines}
+        qty_errors = []
+        # When editing a draft, requested qty can include the qty already
+        # invoiced by this very draft (it'll be released on rewrite).
+        current_invoice_lines = (
+            current_invoice.invoice_line_ids if current_invoice else None
+        )
+        for payload_line in payload.folioLines:
+            sale_line = sale_lines_by_id[payload_line.id]
+            available = sale_line.qty_to_invoice
+            if current_invoice_lines:
+                available += sum(
+                    line.quantity
+                    for line in current_invoice_lines
+                    if sale_line in line.folio_line_ids
+                )
+            if payload_line.quantity > available:
+                qty_errors.append(
+                    {
+                        "folioLineId": sale_line.id,
+                        "requested": payload_line.quantity,
+                        "pending": available,
+                    }
+                )
+        if qty_errors:
+            self._raise_edit_problem(
+                422,
+                "/errors/quantity-exceeds-pending",
+                "Quantity to invoice exceeds pending quantity",
+                "One or more folio lines were asked to invoice more "
+                "than their pending quantity.",
+                lines=qty_errors,
+            )
+
+    def _edit_check_composition(self, sale_lines, downpayment_lines, current_invoice):
+        composition_errors = []
+        current_invoice_id = current_invoice.id if current_invoice else None
+        for sl in sale_lines | downpayment_lines:
+            other_moves = sl.invoice_lines.move_id.filtered(
+                lambda m: m.state != "cancel" and m.id != current_invoice_id
+            )
+            if other_moves:
+                composition_errors.append(
+                    {
+                        "type": "/errors/folio-line-already-invoiced",
+                        "title": "Folio line already invoiced",
+                        "detail": (
+                            f"Folio line {sl.id} is already included in "
+                            f"invoice {other_moves[0].id}."
+                        ),
+                    }
+                )
+        if composition_errors:
+            self._raise_edit_problem(
+                422,
+                "/errors/invoice-composition-invalid",
+                "Invalid invoice composition",
+                "Some folio lines cannot be invoiced.",
+                errors=composition_errors,
+            )
+
+    @staticmethod
+    def _edit_build_lines_to_invoice(payload, sale_lines, downpayment_lines):
+        lines_to_invoice = {fl.id: fl.quantity for fl in payload.folioLines}
+        for dp in downpayment_lines:
+            lines_to_invoice[dp.id] = dp.qty_to_invoice or 1
+        # Include sections and notes referenced by the regular sale lines
+        # so the resulting invoice keeps its structure.
+        section_ids = sale_lines.mapped("section_id")
+        for section in section_ids:
+            lines_to_invoice.setdefault(section.id, 0)
+        sections_in_scope = section_ids | sale_lines.filtered(
+            lambda r: r.display_type == "line_section"
+        )
+        notes = sale_lines.folio_id.sale_line_ids.filtered(
+            lambda r: r.display_type == "line_note"
+            and r.section_id in sections_in_scope
+        )
+        for note in notes:
+            lines_to_invoice.setdefault(note.id, 0)
+        return lines_to_invoice
+
+    def _edit_compute_invoice_vals(
+        self, payload, sale_lines, downpayment_lines, partner
+    ):
+        lines_to_invoice = self._edit_build_lines_to_invoice(
+            payload, sale_lines, downpayment_lines
+        )
+        descriptions = {fl.id: fl.description for fl in payload.folioLines}
+        folios = sale_lines.folio_id.with_context(
+            **{FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX: descriptions}
+        )
+        try:
+            vals_list = folios.get_invoice_vals_list(
+                final=True,
+                lines_to_invoice=lines_to_invoice,
+                partner_invoice_id=partner.id,
+            )
+        except UserError as e:
+            self._raise_edit_problem(
+                422,
+                "/errors/invoice-creation-failed",
+                "Invoice creation failed",
+                str(e),
+            )
+        if not vals_list:
+            self._raise_edit_problem(
+                422,
+                "/errors/invoice-creation-failed",
+                "Invoice creation failed",
+                "No invoice could be built from the provided composition.",
+            )
+        if len(vals_list) > 1:
+            self._raise_edit_problem(
+                422,
+                "/errors/multiple-invoices-created",
+                "Multiple invoices created",
+                "The provided composition could not be grouped into a single "
+                "invoice (different currency or company).",
+            )
+        return vals_list[0]
+
+    def _edit_draft_invoice(
+        self, invoice, payload, sale_lines, downpayment_lines, partner
+    ):
+        vals = self._edit_compute_invoice_vals(
+            payload, sale_lines, downpayment_lines, partner
+        )
+        invoice.invoice_line_ids.unlink()
+        write_vals = {
+            "partner_id": partner.id,
+            "narration": payload.narration,
+            "invoice_line_ids": vals["invoice_line_ids"],
+        }
+        if payload.invoiceDate:
+            write_vals["invoice_date"] = payload.invoiceDate
+        if payload.invoiceDateDue:
+            write_vals["invoice_date_due"] = payload.invoiceDateDue
+        invoice.write(write_vals)
+        return invoice
+
+    def _edit_posted_invoice(
+        self, invoice, payload, sale_lines, downpayment_lines, partner
+    ):
+        receivable_lines = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type
+            in ("asset_receivable", "liability_payable")
+        )
+        receivable_lines.remove_move_reconcile()
+        reversal_date = fields.Date.context_today(invoice)
+        invoice._reverse_moves(
+            default_values_list=[
+                {
+                    "ref": f"Reversal of: {invoice.name}",
+                    "date": reversal_date,
+                    "invoice_date": reversal_date,
+                    "invoice_date_due": reversal_date,
+                    "journal_id": invoice.journal_id.id,
+                }
+            ],
+            cancel=True,
+        )
+        vals = self._edit_compute_invoice_vals(
+            payload, sale_lines, downpayment_lines, partner
+        )
+        if payload.invoiceDate:
+            vals["invoice_date"] = payload.invoiceDate
+            vals["date"] = payload.invoiceDate
+        if payload.invoiceDateDue:
+            vals["invoice_date_due"] = payload.invoiceDateDue
+        vals["narration"] = payload.narration
+        vals["replaces_invoice_id"] = invoice.id
+        try:
+            new_invoice = self.env["account.move"].sudo().create(vals)
+        except UserError as e:
+            self._raise_edit_problem(
+                422,
+                "/errors/invoice-creation-failed",
+                "Invoice creation failed",
+                str(e),
+            )
+        return new_invoice
 
     def _validate_contact(self, pms_property_id: int, contact_id: int):
         partner = self.env["res.partner"].sudo().browse(contact_id)

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -525,42 +525,50 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 media_type="application/problem+json",
             )
         try:
-            if invoice.state == "cancel":
-                self._raise_edit_problem(
-                    409,
-                    "/errors/invoice-not-editable",
-                    _("Invoice not editable"),
-                    _("Cancelled invoices cannot be edited."),
+            # Savepoint so a failure after lines have been rewritten (draft) or
+            # after the refund has been posted (posted) does not leave the
+            # invoice half-edited: Odoo constraints run post-write, so the
+            # mutation is already in the cursor when a later _InvoiceEditProblem
+            # is raised and would otherwise be committed alongside the error.
+            with self.env.cr.savepoint():
+                if invoice.state == "cancel":
+                    self._raise_edit_problem(
+                        409,
+                        "/errors/invoice-not-editable",
+                        _("Invoice not editable"),
+                        _("Cancelled invoices cannot be edited."),
+                    )
+                if invoice.state == "posted" and not confirm_refund:
+                    self._raise_edit_problem(
+                        409,
+                        "/errors/invoice-refund-confirmation-required",
+                        _("Refund confirmation required"),
+                        _(
+                            "This invoice is validated. Editing it will generate "
+                            "a refund and a new corrected invoice. Confirm by "
+                            "passing confirmRefund=true."
+                        ),
+                    )
+                sale_lines = self._edit_resolve_sale_lines(payload)
+                downpayment_lines = self._edit_resolve_downpayment_lines(
+                    payload, sale_lines
                 )
-            if invoice.state == "posted" and not confirm_refund:
-                self._raise_edit_problem(
-                    409,
-                    "/errors/invoice-refund-confirmation-required",
-                    _("Refund confirmation required"),
-                    _(
-                        "This invoice is validated. Editing it will generate "
-                        "a refund and a new corrected invoice. Confirm by "
-                        "passing confirmRefund=true."
-                    ),
+                pms_property = self._edit_resolve_property(sale_lines)
+                partner = self._edit_resolve_partner(payload, pms_property)
+                self._edit_check_quantities(
+                    payload, sale_lines, current_invoice=invoice
                 )
-            sale_lines = self._edit_resolve_sale_lines(payload)
-            downpayment_lines = self._edit_resolve_downpayment_lines(
-                payload, sale_lines
-            )
-            pms_property = self._edit_resolve_property(sale_lines)
-            partner = self._edit_resolve_partner(payload, pms_property)
-            self._edit_check_quantities(payload, sale_lines, current_invoice=invoice)
-            self._edit_check_composition(
-                sale_lines, downpayment_lines, current_invoice=invoice
-            )
-            if invoice.state == "draft":
-                result = self._edit_draft_invoice(
-                    invoice, payload, sale_lines, downpayment_lines, partner
+                self._edit_check_composition(
+                    sale_lines, downpayment_lines, current_invoice=invoice
                 )
-            else:
-                result = self._edit_posted_invoice(
-                    invoice, payload, sale_lines, downpayment_lines, partner
-                )
+                if invoice.state == "draft":
+                    result = self._edit_draft_invoice(
+                        invoice, payload, sale_lines, downpayment_lines, partner
+                    )
+                else:
+                    result = self._edit_posted_invoice(
+                        invoice, payload, sale_lines, downpayment_lines, partner
+                    )
         except _InvoiceEditProblem as problem:
             return problem.response
         return InvoiceDetail.from_account_move(result)
@@ -1063,7 +1071,12 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 media_type="application/problem+json",
             )
         try:
-            invoice.action_post()
+            # Savepoint so a failed posting does not leave the move partially
+            # posted: action_post() writes and flushes before its constraints
+            # run, so without rollback the partial state would be committed
+            # even though we return an error to the caller.
+            with self.env.cr.savepoint():
+                invoice.action_post()
         except UserError as e:
             return JSONResponse(
                 status_code=400,
@@ -1122,82 +1135,91 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                 media_type="application/problem+json",
             )
         try:
-            payment_id = self._parse_payment_composite_id(payload.paymentId)
-            if invoice.state != "posted" or invoice.payment_state in (
-                "paid",
-                "reversed",
-            ):
-                self._raise_edit_problem(
-                    409,
-                    "/errors/invoice-not-editable",
-                    _("Invoice not editable"),
-                    _("The invoice state does not allow new reconciliations."),
+            # Savepoint so a reconcile() that mutates (creates partials /
+            # exchange-diff entries) and then raises does not leave a partial
+            # reconciliation committed while we return an error to the caller.
+            with self.env.cr.savepoint():
+                payment_id = self._parse_payment_composite_id(payload.paymentId)
+                if invoice.state != "posted" or invoice.payment_state in (
+                    "paid",
+                    "reversed",
+                ):
+                    self._raise_edit_problem(
+                        409,
+                        "/errors/invoice-not-editable",
+                        _("Invoice not editable"),
+                        _("The invoice state does not allow new reconciliations."),
+                    )
+                payment = (
+                    self.env["account.payment"]
+                    .sudo()
+                    .search(
+                        [
+                            ("id", "=", payment_id),
+                            ("company_id", "=", invoice.company_id.id),
+                        ],
+                        limit=1,
+                    )
                 )
-            payment = (
-                self.env["account.payment"]
-                .sudo()
-                .search(
-                    [
-                        ("id", "=", payment_id),
-                        ("company_id", "=", invoice.company_id.id),
-                    ],
-                    limit=1,
-                )
-            )
-            if not payment:
-                self._raise_edit_problem(
-                    404,
-                    "/errors/payment-not-found",
-                    _("Payment not found"),
-                    _("Payment %s not found.") % payment_id,
-                )
-            if invoice.folio_ids:
-                if not (payment.folio_ids & invoice.folio_ids):
+                if not payment:
+                    self._raise_edit_problem(
+                        404,
+                        "/errors/payment-not-found",
+                        _("Payment not found"),
+                        _("Payment %s not found.") % payment_id,
+                    )
+                if invoice.folio_ids:
+                    if not (payment.folio_ids & invoice.folio_ids):
+                        self._raise_edit_problem(
+                            409,
+                            "/errors/payment-not-applicable",
+                            _("Payment not applicable"),
+                            _(
+                                "Payment does not belong to any folio of this "
+                                "invoice."
+                            ),
+                        )
+                elif (
+                    payment.partner_id.commercial_partner_id
+                    != invoice.commercial_partner_id
+                ):
                     self._raise_edit_problem(
                         409,
                         "/errors/payment-not-applicable",
                         _("Payment not applicable"),
-                        _("Payment does not belong to any folio of this " "invoice."),
+                        _("Payment does not belong to the invoice's customer."),
                     )
-            elif (
-                payment.partner_id.commercial_partner_id
-                != invoice.commercial_partner_id
-            ):
-                self._raise_edit_problem(
-                    409,
-                    "/errors/payment-not-applicable",
-                    _("Payment not applicable"),
-                    _("Payment does not belong to the invoice's customer."),
-                )
-            invoice_recv, payment_recv, partials = self._get_reconciliation_partials(
-                invoice, payment
-            )
-            if partials:
-                self._raise_edit_problem(
-                    409,
-                    "/errors/payment-already-reconciled",
-                    _("Payment already reconciled"),
-                    _("Payment %s is already reconciled with invoice %s.")
-                    % (payment.id, invoice.id),
-                )
-            if not invoice_recv or not payment_recv:
-                self._raise_edit_problem(
-                    409,
-                    "/errors/payment-not-applicable",
-                    _("Payment not applicable"),
-                    _("Payment is not in a reconcilable state."),
-                )
-            try:
-                (invoice_recv + payment_recv).filtered(
-                    lambda line: not line.reconciled
-                ).reconcile()
-            except UserError as e:
-                self._raise_edit_problem(
-                    409,
-                    "/errors/payment-not-applicable",
-                    _("Payment not applicable"),
-                    str(e),
-                )
+                (
+                    invoice_recv,
+                    payment_recv,
+                    partials,
+                ) = self._get_reconciliation_partials(invoice, payment)
+                if partials:
+                    self._raise_edit_problem(
+                        409,
+                        "/errors/payment-already-reconciled",
+                        _("Payment already reconciled"),
+                        _("Payment %s is already reconciled with invoice %s.")
+                        % (payment.id, invoice.id),
+                    )
+                if not invoice_recv or not payment_recv:
+                    self._raise_edit_problem(
+                        409,
+                        "/errors/payment-not-applicable",
+                        _("Payment not applicable"),
+                        _("Payment is not in a reconcilable state."),
+                    )
+                try:
+                    (invoice_recv + payment_recv).filtered(
+                        lambda line: not line.reconciled
+                    ).reconcile()
+                except UserError as e:
+                    self._raise_edit_problem(
+                        409,
+                        "/errors/payment-not-applicable",
+                        _("Payment not applicable"),
+                        str(e),
+                    )
         except _InvoiceEditProblem as problem:
             return problem.response
         # Reconciling updated payment_state/amount_residual on the stored

--- a/pms_fastapi/routers/journal.py
+++ b/pms_fastapi/routers/journal.py
@@ -31,15 +31,15 @@ async def list_journals(
         Query(description="Filter journals of the given property."),
     ] = None,
     journalType: Annotated[
-        JournalType | None,
-        Query(description="Filter by journal type."),
+        list[JournalType] | None,
+        Query(description="Filter by journal type. Repeat to filter by several."),
     ] = None,
 ) -> list[JournalSummary]:
     """List journals, optionally filtered by type and property."""
     helper = env["pms_api_journal.journal_router.helper"].new()
     journals = helper.search_journals(
         pms_property_id=pmsPropertyId,
-        journal_type=journalType.value if journalType else None,
+        journal_type=[t.value for t in journalType] if journalType else None,
     )
     return [JournalSummary.from_account_journal(journal) for journal in journals]
 

--- a/pms_fastapi/routers/login.py
+++ b/pms_fastapi/routers/login.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException, Response, status
 
-from odoo import models
+from odoo import _, models
 from odoo.exceptions import AccessDenied
 
 from odoo.addons.pms_fastapi.dependencies import PublicEnv
@@ -27,19 +27,13 @@ async def login(user: PmsLoginInput, env: PublicEnv):
     user_record = env["res.users"].sudo().search([("login", "=", user.username)])
 
     if not user_record:
-        raise HTTPException(
-            status_code=401,
-            detail="wrong user/pass",
-        )
+        env["pms.fastapi.login.endpoint"]._raise_wrong_credentials()
     try:
         user_record.with_user(user_record)._check_credentials(
             user.password.get_secret_value(), {"interactive": False}
         )
-    except AccessDenied as e:
-        raise HTTPException(
-            status_code=401,
-            detail="wrong user/pass",
-        ) from e
+    except AccessDenied:
+        env["pms.fastapi.login.endpoint"]._raise_wrong_credentials()
     return env["pms.fastapi.login.endpoint"]._get_login_response_with_cookies(
         user_record
     )
@@ -48,6 +42,12 @@ async def login(user: PmsLoginInput, env: PublicEnv):
 class PmsFastapiLoginEndpoint(models.AbstractModel):
     _name = "pms.fastapi.login.endpoint"
     _description = "login endpoint helper"
+
+    def _raise_wrong_credentials(self):
+        raise HTTPException(
+            status_code=401,
+            detail=_("wrong user/pass"),
+        )
 
     def _get_login_response_with_cookies(self, user_record):
         validator = (

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -1,0 +1,76 @@
+from typing import Annotated
+
+from fastapi import Depends
+
+from odoo import models
+
+from odoo.addons.account.models.account_payment import AccountPayment
+from odoo.addons.extendable_fastapi.schemas import PagedCollection
+from odoo.addons.fastapi.dependencies import paging
+from odoo.addons.fastapi.schemas import Paging
+from odoo.addons.pms_fastapi.dependencies import (
+    AuthenticatedEnv,
+    create_order_dependency,
+)
+from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.schemas.payment import (
+    PAYMENT_ORDER_MAPPING,
+    PaymentOrderField,
+    PaymentSearch,
+    PaymentSummary,
+)
+from odoo.addons.pms_fastapi.utils import FilteredModelAdapter
+
+PaymentOrderDependency = create_order_dependency(
+    PaymentOrderField, PAYMENT_ORDER_MAPPING, ["-date"]
+)
+
+
+@pms_api_router.get(
+    "/payments",
+    response_model=PagedCollection[PaymentSummary],
+    tags=["payment"],
+)
+async def list_payments(
+    env: AuthenticatedEnv,
+    filters: Annotated[PaymentSearch, Depends()],
+    paging: Annotated[Paging, Depends(paging)],
+    orderBy: Annotated[str, Depends(PaymentOrderDependency)],
+) -> PagedCollection[PaymentSummary]:
+    """List payments (customer/supplier payments and refunds, internal
+    transfers) with pagination and filtering."""
+    count, payments = (
+        env["pms_api_payment.payment_router.helper"]
+        .new()
+        ._search(paging, filters, orderBy)
+    )
+    return PagedCollection[PaymentSummary](
+        count=count,
+        items=[PaymentSummary.from_account_payment(payment) for payment in payments],
+    )
+
+
+class PmsApiPaymentRouterHelper(models.AbstractModel):
+    _name = "pms_api_payment.payment_router.helper"
+    _description = "PMS API Payment Router Helper"
+
+    def _get_domain_adapter(self):
+        # Posted payments only. Internal transfers are stored as two paired
+        # account.payment records (inbound + outbound) and BOTH legs are
+        # returned, replicating the legacy API behaviour (no dedup).
+        return [("state", "=", "posted")]
+
+    @property
+    def model_adapter(self) -> FilteredModelAdapter[AccountPayment]:
+        return FilteredModelAdapter[AccountPayment](
+            self.env, self._get_domain_adapter()
+        )
+
+    def _search(self, paging, params, order) -> tuple[int, AccountPayment]:
+        return self.model_adapter.search_with_count(
+            params.to_odoo_domain(self.env),
+            limit=paging.limit,
+            offset=paging.offset,
+            order=order,
+            context=params.to_odoo_context(self.env),
+        )

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -336,6 +336,17 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                 self._not_found(
                     _("Journal %s does not exist.") % payload.destinationJournalId
                 )
+            invalid = (origin + destination).filtered(
+                lambda journal: journal.type not in ("bank", "cash")
+            )
+            if invalid:
+                self._validation_error(
+                    _(
+                        "Internal transfers only allow bank or cash journals. "
+                        "Invalid journals: %s."
+                    )
+                    % ", ".join(invalid.mapped("display_name"))
+                )
             PmsBaseModel.pms_api_check_access(self.env.user, origin + destination)
             statement_model = self.env["account.bank.statement"].sudo()
             statement_model._pms_ensure_open_cash_session(origin)

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -210,7 +210,10 @@ async def create_internal_transfer(
     env: AuthenticatedEnv,
     payload: InternalTransferInput,
 ) -> PaymentSummary:
-    """Register an internal transfer between two journals."""
+    """Register an internal transfer between two payment methods.
+
+    Takes an outbound origin and an inbound destination payment method (their
+    journals must differ); the journals are derived from them."""
     return (
         env["pms_api_payment.payment_router.helper"]
         .new()
@@ -560,33 +563,24 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
 
     def create_internal_transfer(self, payload: InternalTransferInput):
         try:
-            if payload.originJournalId == payload.destinationJournalId:
+            # Payment method lines only exist on bank/cash journals, so resolving
+            # the journal from the line implicitly guarantees a valid journal type.
+            origin_line = self._resolve_payment_method_line(
+                payload.originPaymentMethodId
+            )
+            destination_line = self._resolve_payment_method_line(
+                payload.destinationPaymentMethodId
+            )
+            origin = origin_line.journal_id
+            destination = destination_line.journal_id
+            if origin == destination:
                 self._validation_error(
                     _("Origin and destination journals cannot be the same.")
                 )
-            journals = self.env["account.journal"].sudo()
-            origin = journals.browse(payload.originJournalId).exists()
-            destination = journals.browse(payload.destinationJournalId).exists()
-            if not origin:
-                self._not_found(
-                    _("Journal %s does not exist.") % payload.originJournalId
-                )
-            if not destination:
-                self._not_found(
-                    _("Journal %s does not exist.") % payload.destinationJournalId
-                )
-            invalid = (origin + destination).filtered(
-                lambda journal: journal.type not in ("bank", "cash")
-            )
-            if invalid:
-                self._validation_error(
-                    _(
-                        "Internal transfers only allow bank or cash journals. "
-                        "Invalid journals: %s."
-                    )
-                    % ", ".join(invalid.mapped("display_name"))
-                )
-            PmsBaseModel.pms_api_check_access(self.env.user, origin + destination)
+            if origin_line.payment_type != "outbound":
+                self._validation_error(_("Origin payment method must be outbound."))
+            if destination_line.payment_type != "inbound":
+                self._validation_error(_("Destination payment method must be inbound."))
             statement_model = self.env["account.bank.statement"].sudo()
             statement_model._pms_ensure_open_cash_session(origin)
             statement_model._pms_ensure_open_cash_session(destination)
@@ -597,6 +591,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                     {
                         "amount": payload.amount,
                         "journal_id": origin.id,
+                        "payment_method_line_id": origin_line.id,
                         "date": payload.date,
                         "partner_id": origin.company_id.partner_id.id,
                         "ref": payload.reason,
@@ -609,9 +604,33 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                 )
             )
             payment.action_post()
+            self._apply_destination_method_line(payment, destination_line)
         except _PaymentProblem as problem:
             return problem.response
         return PaymentSummary.from_account_payment(payment)
+
+    def _apply_destination_method_line(self, payment, destination_line):
+        """Force the chosen inbound method line onto the auto-created counterpart.
+
+        Odoo pairs the transfer on post and assigns the destination journal's
+        default inbound line. When the front picked a different one, reassign it.
+        An internal transfer only reconciles its two legs against each other (no
+        invoice/folio reconciliation), so re-posting the counterpart is contained:
+        we just re-reconcile the pair afterwards (same as _update_internal_transfer).
+        """
+        counterpart = payment.paired_internal_transfer_payment_id
+        if counterpart.payment_method_line_id == destination_line:
+            return
+        counterpart.action_draft()
+        counterpart.write({"payment_method_line_id": destination_line.id})
+        counterpart.action_post()
+        # Re-posting won't re-pair (the pairing already exists), so reconcile the
+        # two transfer lines again.
+        lines = (payment.move_id.line_ids + counterpart.move_id.line_ids).filtered(
+            lambda line: line.account_id == payment.destination_account_id
+            and not line.reconciled
+        )
+        lines.reconcile()
 
     # -- partial update (PATCH /payments/{id}) --
 

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -4,6 +4,7 @@ from fastapi import Depends
 from fastapi.responses import JSONResponse
 
 from odoo import models
+from odoo.exceptions import AccessDenied, AccessError
 
 from odoo.addons.account.models.account_payment import AccountPayment
 from odoo.addons.extendable_fastapi.schemas import PagedCollection
@@ -67,6 +68,19 @@ async def list_payments(
         count=count,
         items=[PaymentSummary.from_account_payment(payment) for payment in payments],
     )
+
+
+@pms_api_router.get(
+    "/payments/{payment_id}",
+    response_model=PaymentSummary,
+    tags=["payment"],
+)
+async def get_payment(
+    env: AuthenticatedEnv,
+    payment_id: int,
+) -> PaymentSummary:
+    """Get a single payment by id (same model as the listing)."""
+    return env["pms_api_payment.payment_router.helper"].new().get(payment_id)
 
 
 @pms_api_router.post(
@@ -149,6 +163,29 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
 
     def _not_found(self, detail):
         self._problem(404, "/errors/record-not-found", "Record not found", detail)
+
+    def get(self, payment_id):
+        try:
+            payment = self.env["account.payment"].sudo().browse(payment_id).exists()
+            if not payment:
+                self._problem(
+                    404,
+                    "/errors/payment-not-found",
+                    "Payment not found",
+                    f"Payment {payment_id} does not exist.",
+                )
+            try:
+                PmsBaseModel.pms_api_check_access(self.env.user, payment)
+            except (AccessError, AccessDenied):
+                self._problem(
+                    404,
+                    "/errors/payment-not-found",
+                    "Payment not found",
+                    f"Payment {payment_id} does not exist.",
+                )
+        except _PaymentProblem as problem:
+            return problem.response
+        return PaymentSummary.from_account_payment(payment)
 
     def _validation_error(self, detail):
         self._problem(422, "/errors/validation-error", "Validation error", detail)

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -102,6 +102,23 @@ async def get_payment_report(
     )
 
 
+@pms_api_router.post(
+    "/payments/{payment_id}/cancel",
+    response_model=PaymentSummary,
+    tags=["payment"],
+)
+async def cancel_payment(
+    env: AuthenticatedEnv,
+    payment_id: int,
+) -> PaymentSummary:
+    """Cancel a registered payment.
+
+    Cancelling is a state transition (not a deletion): the related accounting
+    entry is reversed. It is blocked when the payment date falls within a
+    locked fiscal period."""
+    return env["pms_api_payment.payment_router.helper"].new().cancel_payment(payment_id)
+
+
 @pms_api_router.patch(
     "/payments/{payment_id}",
     response_model=PaymentSummary,
@@ -250,6 +267,43 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                 "Content-Disposition": f'attachment; filename="{filename}"',
             },
         )
+
+    def _ensure_not_locked(self, payments):
+        """A payment whose date falls within a locked fiscal period cannot be
+        cancelled: resetting it to draft would modify a locked entry. The
+        cancellation runs as superuser, so the effective lock date is the one
+        Odoo will enforce on the draft transition."""
+        for payment in payments:
+            lock_date = payment.company_id._get_user_fiscal_lock_date()
+            if payment.date and payment.date <= lock_date:
+                self._problem(
+                    409,
+                    "/errors/fiscal-lock-date",
+                    _("Fiscal lock date"),
+                    _(
+                        "The payment date falls within a locked fiscal period "
+                        "and cannot be cancelled."
+                    ),
+                )
+
+    def cancel_payment(self, payment_id):
+        try:
+            payment = self._resolve_payment_or_404(payment_id)
+            # An internal transfer is two paired payments reconciled against
+            # each other; both legs must move together.
+            legs = payment
+            if payment.is_internal_transfer:
+                legs = payment + payment.paired_internal_transfer_payment_id
+            self._ensure_not_bank_matched(payment)
+            self._ensure_not_locked(legs)
+            for leg in legs:
+                self._ensure_open_cash_session(leg.journal_id)
+            # draft first (un-reconciles and reopens the entry), then cancel.
+            legs.action_draft()
+            legs.action_cancel()
+        except _PaymentProblem as problem:
+            return problem.response
+        return PaymentSummary.from_account_payment(payment)
 
     def _validation_error(self, detail):
         self._problem(422, "/errors/validation-error", _("Validation error"), detail)

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 from fastapi import Depends
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 from odoo import _, models
 from odoo.exceptions import AccessDenied, AccessError
@@ -82,6 +82,24 @@ async def get_payment(
 ) -> PaymentSummary:
     """Get a single payment by id (same model as the listing)."""
     return env["pms_api_payment.payment_router.helper"].new().get(payment_id)
+
+
+@pms_api_router.get(
+    "/payments/{payment_id}/report",
+    tags=["payment"],
+    responses={
+        200: {"content": {"application/pdf": {}}},
+    },
+    response_class=Response,
+)
+async def get_payment_report(
+    env: AuthenticatedEnv,
+    payment_id: int,
+) -> Response:
+    """Download the PDF report for a specific payment."""
+    return (
+        env["pms_api_payment.payment_router.helper"].new().get_payment_pdf(payment_id)
+    )
 
 
 @pms_api_router.patch(
@@ -189,26 +207,49 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
 
     def get(self, payment_id):
         try:
-            payment = self.env["account.payment"].sudo().browse(payment_id).exists()
-            if not payment:
-                self._problem(
-                    404,
-                    "/errors/payment-not-found",
-                    _("Payment not found"),
-                    _("Payment %s does not exist.") % payment_id,
-                )
-            try:
-                PmsBaseModel.pms_api_check_access(self.env.user, payment)
-            except (AccessError, AccessDenied):
-                self._problem(
-                    404,
-                    "/errors/payment-not-found",
-                    _("Payment not found"),
-                    _("Payment %s does not exist.") % payment_id,
-                )
+            payment = self._resolve_payment_or_404(payment_id)
         except _PaymentProblem as problem:
             return problem.response
         return PaymentSummary.from_account_payment(payment)
+
+    def _resolve_payment_or_404(self, payment_id):
+        payment = self.env["account.payment"].sudo().browse(payment_id).exists()
+        if not payment:
+            self._problem(
+                404,
+                "/errors/payment-not-found",
+                _("Payment not found"),
+                _("Payment %s does not exist.") % payment_id,
+            )
+        try:
+            PmsBaseModel.pms_api_check_access(self.env.user, payment)
+        except (AccessError, AccessDenied):
+            self._problem(
+                404,
+                "/errors/payment-not-found",
+                _("Payment not found"),
+                _("Payment %s does not exist.") % payment_id,
+            )
+        return payment
+
+    def get_payment_pdf(self, payment_id):
+        try:
+            payment = self._resolve_payment_or_404(payment_id)
+        except _PaymentProblem as problem:
+            return problem.response
+        content, _report_type = (
+            self.env["ir.actions.report"]
+            .sudo()
+            ._render_qweb_pdf("account.action_report_payment_receipt", [payment.id])
+        )
+        filename = "%s.pdf" % (payment.name or _("payment")).replace("/", "-")
+        return Response(
+            content=content,
+            media_type="application/pdf",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+            },
+        )
 
     def _validation_error(self, detail):
         self._problem(422, "/errors/validation-error", _("Validation error"), detail)

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 
 from fastapi import Depends
+from fastapi.responses import JSONResponse
 
 from odoo import models
 
@@ -13,8 +14,12 @@ from odoo.addons.pms_fastapi.dependencies import (
     create_order_dependency,
 )
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.schemas.base import PmsBaseModel
 from odoo.addons.pms_fastapi.schemas.payment import (
     PAYMENT_ORDER_MAPPING,
+    InternalTransferInput,
+    PaymentCreateType,
+    PaymentInput,
     PaymentOrderField,
     PaymentSearch,
     PaymentSummary,
@@ -24,6 +29,20 @@ from odoo.addons.pms_fastapi.utils import FilteredModelAdapter
 PaymentOrderDependency = create_order_dependency(
     PaymentOrderField, PAYMENT_ORDER_MAPPING, ["-date"]
 )
+
+# (payment_type, partner_type) per creatable payment type.
+_CREATE_TYPE_FIELDS = {
+    PaymentCreateType.customerPayment: ("inbound", "customer"),
+    PaymentCreateType.supplierPayment: ("outbound", "supplier"),
+}
+
+
+class _PaymentProblem(Exception):
+    """Control-flow exception carrying an RFC 9457 JSONResponse."""
+
+    def __init__(self, response):
+        super().__init__()
+        self.response = response
 
 
 @pms_api_router.get(
@@ -47,6 +66,41 @@ async def list_payments(
     return PagedCollection[PaymentSummary](
         count=count,
         items=[PaymentSummary.from_account_payment(payment) for payment in payments],
+    )
+
+
+@pms_api_router.post(
+    "/payments",
+    response_model=PaymentSummary,
+    status_code=201,
+    tags=["payment"],
+)
+async def create_payment(
+    env: AuthenticatedEnv,
+    payload: PaymentInput,
+) -> PaymentSummary:
+    """Register a manual customer payment or supplier payment.
+
+    The journal is derived from the payment method (paymentMethodId). Customer
+    payments may carry a folio or invoice context (mutually exclusive)."""
+    return env["pms_api_payment.payment_router.helper"].new().create_payment(payload)
+
+
+@pms_api_router.post(
+    "/internal-transfers",
+    response_model=PaymentSummary,
+    status_code=201,
+    tags=["payment"],
+)
+async def create_internal_transfer(
+    env: AuthenticatedEnv,
+    payload: InternalTransferInput,
+) -> PaymentSummary:
+    """Register an internal transfer between two journals."""
+    return (
+        env["pms_api_payment.payment_router.helper"]
+        .new()
+        .create_internal_transfer(payload)
     )
 
 
@@ -74,3 +128,173 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
             order=order,
             context=params.to_odoo_context(self.env),
         )
+
+    # -- creation (ported from pms_api_rest pms.transaction.service /
+    #    pms.folio.do_payment) --
+
+    @staticmethod
+    def _problem(status_code, type_, title, detail):
+        raise _PaymentProblem(
+            JSONResponse(
+                status_code=status_code,
+                content={
+                    "type": type_,
+                    "title": title,
+                    "status": status_code,
+                    "detail": detail,
+                },
+                media_type="application/problem+json",
+            )
+        )
+
+    def _not_found(self, detail):
+        self._problem(404, "/errors/record-not-found", "Record not found", detail)
+
+    def _validation_error(self, detail):
+        self._problem(422, "/errors/validation-error", "Validation error", detail)
+
+    def _resolve_partner(self, partner_id):
+        partner = self.env["res.partner"].sudo().browse(partner_id).exists()
+        if not partner:
+            self._not_found(f"Partner {partner_id} does not exist.")
+        return partner
+
+    def create_payment(self, payload: PaymentInput):
+        try:
+            if payload.folioId and payload.invoiceId:
+                self._validation_error("folioId and invoiceId are mutually exclusive.")
+            line = (
+                self.env["account.payment.method.line"]
+                .sudo()
+                .browse(payload.paymentMethodId)
+                .exists()
+            )
+            if not line:
+                self._not_found(
+                    f"Payment method {payload.paymentMethodId} does not exist."
+                )
+            journal = line.journal_id
+            PmsBaseModel.pms_api_check_access(self.env.user, journal)
+            payment_type, partner_type = _CREATE_TYPE_FIELDS[payload.paymentType]
+            partner = (
+                self._resolve_partner(payload.partnerId)
+                if payload.partnerId
+                else self.env["res.partner"]
+            )
+            if payload.paymentType == PaymentCreateType.supplierPayment and not partner:
+                self._validation_error("supplierPayment requires partnerId.")
+
+            if journal.type == "cash":
+                self.env["account.bank.statement"].sudo()._pms_ensure_open_cash_session(
+                    journal
+                )
+
+            if payload.paymentType == PaymentCreateType.customerPayment and (
+                payload.folioId or payload.invoiceId
+            ):
+                payment = self._create_folio_payment(payload, line, partner)
+            else:
+                payment = self._create_simple_payment(
+                    payload, line, partner, payment_type, partner_type
+                )
+        except _PaymentProblem as problem:
+            return problem.response
+        return PaymentSummary.from_account_payment(payment)
+
+    def _resolve_context_folio(self, payload):
+        """Return the folio for a customer payment context (folio or invoice)."""
+        if payload.folioId:
+            folio = self.env["pms.folio"].sudo().browse(payload.folioId).exists()
+            if not folio:
+                self._not_found(f"Folio {payload.folioId} does not exist.")
+        else:
+            invoice = self.env["account.move"].sudo().browse(payload.invoiceId).exists()
+            if not invoice:
+                self._not_found(f"Invoice {payload.invoiceId} does not exist.")
+            folio = invoice.folio_ids[:1]
+            if not folio:
+                self._validation_error(
+                    f"Invoice {payload.invoiceId} has no associated folio."
+                )
+        PmsBaseModel.pms_api_check_access(self.env.user, folio)
+        return folio
+
+    def _create_folio_payment(self, payload, line, partner):
+        folio = self._resolve_context_folio(payload)
+        partner = partner or folio.partner_id
+        before = folio.payment_ids
+        self.env["pms.folio"].sudo().do_payment(
+            line,
+            self.env.user,
+            payload.amount,
+            folio,
+            partner=partner,
+            date=payload.date,
+            ref=payload.reference,
+        )
+        return folio.payment_ids - before
+
+    def _create_simple_payment(
+        self, payload, line, partner, payment_type, partner_type
+    ):
+        payment = (
+            self.env["account.payment"]
+            .sudo()
+            .create(
+                {
+                    "journal_id": line.journal_id.id,
+                    "payment_method_line_id": line.id,
+                    "partner_id": partner.id if partner else False,
+                    "amount": payload.amount,
+                    "date": payload.date,
+                    "ref": payload.reference,
+                    "payment_type": payment_type,
+                    "partner_type": partner_type,
+                    "state": "draft",
+                }
+            )
+        )
+        payment.action_post()
+        return payment
+
+    def create_internal_transfer(self, payload: InternalTransferInput):
+        try:
+            if payload.originJournalId == payload.destinationJournalId:
+                self._validation_error(
+                    "El diario de origen y el de destino no pueden ser el mismo."
+                )
+            journals = self.env["account.journal"].sudo()
+            origin = journals.browse(payload.originJournalId).exists()
+            destination = journals.browse(payload.destinationJournalId).exists()
+            if not origin:
+                self._not_found(f"Journal {payload.originJournalId} does not exist.")
+            if not destination:
+                self._not_found(
+                    f"Journal {payload.destinationJournalId} does not exist."
+                )
+            PmsBaseModel.pms_api_check_access(self.env.user, origin + destination)
+            statement_model = self.env["account.bank.statement"].sudo()
+            statement_model._pms_ensure_open_cash_session(origin)
+            statement_model._pms_ensure_open_cash_session(destination)
+            payment = (
+                self.env["account.payment"]
+                .sudo()
+                .create(
+                    {
+                        "amount": payload.amount,
+                        "journal_id": origin.id,
+                        "date": payload.date,
+                        "partner_id": origin.company_id.partner_id.id,
+                        "ref": payload.reason,
+                        "payment_type": "outbound",
+                        "partner_type": "customer",
+                        "is_internal_transfer": True,
+                        "destination_journal_id": destination.id,
+                        "partner_bank_id": destination.bank_account_id.id,
+                    }
+                )
+            )
+            payment.action_post()
+        except _PaymentProblem as problem:
+            return problem.response
+        return PaymentSummary.from_account_payment(payment)

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -24,6 +24,7 @@ from odoo.addons.pms_fastapi.schemas.payment import (
     PaymentOrderField,
     PaymentSearch,
     PaymentSummary,
+    PaymentUpdate,
 )
 from odoo.addons.pms_fastapi.utils import FilteredModelAdapter
 
@@ -81,6 +82,28 @@ async def get_payment(
 ) -> PaymentSummary:
     """Get a single payment by id (same model as the listing)."""
     return env["pms_api_payment.payment_router.helper"].new().get(payment_id)
+
+
+@pms_api_router.patch(
+    "/payments/{payment_id}",
+    response_model=PaymentSummary,
+    tags=["payment"],
+)
+async def update_payment(
+    env: AuthenticatedEnv,
+    payment_id: int,
+    payload: PaymentUpdate,
+) -> PaymentSummary:
+    """Partially update a registered payment (amount, date, payment method).
+
+    Only the modified fields are sent. If the payment is reconciled against an
+    invoice, the reconciliation is recomputed automatically when the amount
+    changes."""
+    return (
+        env["pms_api_payment.payment_router.helper"]
+        .new()
+        .update_payment(payment_id, payload)
+    )
 
 
 @pms_api_router.post(
@@ -335,3 +358,121 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
         except _PaymentProblem as problem:
             return problem.response
         return PaymentSummary.from_account_payment(payment)
+
+    # -- partial update (PATCH /payments/{id}) --
+
+    def update_payment(self, payment_id, payload: PaymentUpdate):
+        try:
+            payment = self.env["account.payment"].sudo().browse(payment_id).exists()
+            if not payment:
+                self._not_found(f"Payment {payment_id} does not exist.")
+            try:
+                PmsBaseModel.pms_api_check_access(self.env.user, payment)
+            except (AccessError, AccessDenied):
+                self._not_found(f"Payment {payment_id} does not exist.")
+            if payment.is_internal_transfer:
+                self._update_internal_transfer(payment, payload)
+            else:
+                # A journal change recreates the record (see below), so use the
+                # returned payment for the response.
+                payment = self._update_simple_payment(payment, payload)
+        except _PaymentProblem as problem:
+            return problem.response
+        return PaymentSummary.from_account_payment(payment)
+
+    def _resolve_payment_method_line(self, payment_method_id):
+        line = (
+            self.env["account.payment.method.line"]
+            .sudo()
+            .browse(payment_method_id)
+            .exists()
+        )
+        if not line:
+            self._not_found(f"Payment method {payment_method_id} does not exist.")
+        PmsBaseModel.pms_api_check_access(self.env.user, line.journal_id)
+        return line
+
+    def _common_update_vals(self, payment, payload):
+        """Vals for the fields shared by every payment type (amount, date)."""
+        vals = {}
+        currency = payment.currency_id or payment.company_id.currency_id
+        if (
+            payload.amount is not None
+            and currency.compare_amounts(payload.amount, payment.amount) != 0
+        ):
+            vals["amount"] = payload.amount
+        if payload.date is not None and payload.date != payment.date:
+            vals["date"] = payload.date
+        return vals
+
+    def _ensure_open_cash_session(self, journal):
+        if journal.type == "cash":
+            self.env["account.bank.statement"].sudo()._pms_ensure_open_cash_session(
+                journal
+            )
+
+    def _replace_payment_for_journal_change(self, payment, vals, journal):
+        """Odoo forbids changing the journal of an already-posted payment, so a
+        payment-method change that moves to another journal cancels the original
+        and recreates it (same approach as the legacy API). The id changes."""
+        self._ensure_open_cash_session(journal)
+        payment.action_draft()
+        payment.action_cancel()
+        new_payment = payment.copy({"folio_ids": [(6, 0, payment.folio_ids.ids)]})
+        new_payment.write(dict(vals, journal_id=journal.id))
+        new_payment.action_post()
+        return new_payment
+
+    def _update_simple_payment(self, payment, payload):
+        vals = self._common_update_vals(payment, payload)
+        new_journal = None
+        if payload.paymentMethodId is not None:
+            line = self._resolve_payment_method_line(payload.paymentMethodId)
+            if line.id != payment.payment_method_line_id.id:
+                vals["payment_method_line_id"] = line.id
+                if line.journal_id.id != payment.journal_id.id:
+                    new_journal = line.journal_id
+        if not vals:
+            return payment
+        if new_journal:
+            payment = self._replace_payment_for_journal_change(
+                payment, vals, new_journal
+            )
+        else:
+            self._ensure_open_cash_session(payment.journal_id)
+            payment.action_draft()
+            payment.write(vals)
+            payment.action_post()
+        # Re-posting posts the payment's own entry, not the invoice's, so the
+        # folio<->invoice reconciliation is recomputed explicitly (the same
+        # entry point do_payment uses).
+        for move in payment.folio_ids.move_ids:
+            move.sudo()._autoreconcile_folio_payments()
+        return payment
+
+    def _update_internal_transfer(self, payment, payload):
+        # An internal transfer has two journals (origin + destination), so the
+        # single 'payment mode' doesn't apply to it.
+        if payload.paymentMethodId is not None:
+            self._validation_error(
+                "paymentMethodId does not apply to an internal transfer."
+            )
+        # Both legs share amount and date; edit them together to keep the pair
+        # consistent (they are reconciled against each other).
+        counterpart = payment.paired_internal_transfer_payment_id
+        legs = payment + counterpart
+        vals = self._common_update_vals(payment, payload)
+        if not vals:
+            return
+        for leg in legs:
+            self._ensure_open_cash_session(leg.journal_id)
+        legs.action_draft()
+        legs.write(vals)
+        legs.action_post()
+        # action_post won't re-pair (the pairing already exists), so the two
+        # transfer lines stay unreconciled until we reconcile them again.
+        lines = (payment.move_id.line_ids + counterpart.move_id.line_ids).filtered(
+            lambda line: line.account_id == payment.destination_account_id
+            and not line.reconciled
+        )
+        lines.reconcile()

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -1,9 +1,9 @@
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Query
 from fastapi.responses import JSONResponse, Response
 
-from odoo import _, models
+from odoo import SUPERUSER_ID, _, models
 from odoo.exceptions import AccessDenied, AccessError
 
 from odoo.addons.account.models.account_payment import AccountPayment
@@ -25,12 +25,15 @@ from odoo.addons.pms_fastapi.schemas.payment import (
     PaymentSearch,
     PaymentSummary,
     PaymentUpdate,
+    ReportFormatEnum,
 )
 from odoo.addons.pms_fastapi.utils import FilteredModelAdapter
 
 PaymentOrderDependency = create_order_dependency(
     PaymentOrderField, PAYMENT_ORDER_MAPPING, ["-date"]
 )
+
+PAYMENT_REPORT_MAX_RECORDS = 5000
 
 # (payment_type, partner_type) per creatable payment type.
 _CREATE_TYPE_FIELDS = {
@@ -99,6 +102,45 @@ async def get_payment_report(
     """Download the PDF report for a specific payment."""
     return (
         env["pms_api_payment.payment_router.helper"].new().get_payment_pdf(payment_id)
+    )
+
+
+@pms_api_router.post(
+    "/payments/report",
+    tags=["payment"],
+    responses={
+        200: {
+            "content": {
+                "application/pdf": {},
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {},
+            }
+        },
+    },
+    response_class=Response,
+)
+async def payments_report(
+    env: AuthenticatedEnv,
+    report_format: Annotated[
+        ReportFormatEnum,
+        Query(alias="format", description="Output file format."),
+    ],
+    filters: Annotated[PaymentSearch, Depends()],
+    ids: Annotated[
+        list[int] | None,
+        Query(
+            description="Payment IDs to include in the report. "
+            "Mutually exclusive with filter parameters.",
+        ),
+    ] = None,
+) -> Response:
+    """Generate and download a payments report in PDF or Excel format.
+
+    Pass either an explicit list of `ids` or filter parameters (the same ones
+    accepted by GET /payments). They are mutually exclusive."""
+    return (
+        env["pms_api_payment.payment_router.helper"]
+        .new()
+        ._generate_report(report_format, filters, ids)
     )
 
 
@@ -265,6 +307,108 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
             media_type="application/pdf",
             headers={
                 "Content-Disposition": f'attachment; filename="{filename}"',
+            },
+        )
+
+    # -- report (POST /payments/report) --
+
+    @staticmethod
+    def _has_report_filters(filters):
+        return any(v is not None for v in filters.__dict__.values())
+
+    def _resolve_report_payments(self, filters, ids):
+        if ids and self._has_report_filters(filters):
+            return (
+                JSONResponse(
+                    status_code=400,
+                    content={
+                        "type": "/errors/mutually-exclusive-params",
+                        "title": _("Mutually exclusive parameters"),
+                        "status": 400,
+                        "detail": _(
+                            "Cannot specify both 'ids' and filter parameters. "
+                            "Use one or the other."
+                        ),
+                    },
+                    media_type="application/problem+json",
+                ),
+                None,
+            )
+        if ids:
+            domain = [("id", "in", ids)]
+            context = None
+        else:
+            domain = filters.to_odoo_domain(self.env)
+            context = filters.to_odoo_context(self.env)
+        count = (
+            self.model_adapter.count(domain)
+            if context is None
+            else self.model_adapter.count(domain, context=context)
+        )
+        if count > PAYMENT_REPORT_MAX_RECORDS:
+            return (
+                JSONResponse(
+                    status_code=400,
+                    content={
+                        "type": "/errors/record-limit-exceeded",
+                        "title": _("Record limit exceeded"),
+                        "status": 400,
+                        "detail": _(
+                            "The export requested %s records, "
+                            "but the maximum allowed is %s."
+                        )
+                        % (count, PAYMENT_REPORT_MAX_RECORDS),
+                        "requestedCount": count,
+                        "maxAllowed": PAYMENT_REPORT_MAX_RECORDS,
+                    },
+                    media_type="application/problem+json",
+                ),
+                None,
+            )
+        payments = (
+            self.model_adapter.search(domain)
+            if context is None
+            else self.model_adapter.search(domain, context=context)
+        )
+        return None, payments
+
+    def _generate_report(self, report_format, filters, ids):
+        error, payments = self._resolve_report_payments(filters, ids)
+        if error is not None:
+            return error
+        if report_format == ReportFormatEnum.xlsx:
+            return self._render_payments_xlsx(payments)
+        return self._render_payments_pdf(payments)
+
+    def _render_payments_pdf(self, payments):
+        content, _report_type = (
+            self.env["ir.actions.report"]
+            .sudo()
+            ._render_qweb_pdf("roomdoo_payments_exporter.report_payments", payments.ids)
+        )
+        return Response(
+            content=content,
+            media_type="application/pdf",
+            headers={
+                "Content-Disposition": 'attachment; filename="payments_report.pdf"',
+            },
+        )
+
+    def _render_payments_xlsx(self, payments):
+        # `report_xlsx._render_xlsx` forces `.sudo(False)` on the report model,
+        # so `.sudo()` here would not bypass ACL inside the export.
+        content, _report_type = (
+            self.env["ir.actions.report"]
+            .with_user(SUPERUSER_ID)
+            ._render("roomdoo_payments_exporter.payment_report", payments.ids)
+        )
+        return Response(
+            content=content,
+            media_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+            headers={
+                "Content-Disposition": 'attachment; filename="payments_report.xlsx"',
             },
         )
 

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -385,6 +385,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                 PmsBaseModel.pms_api_check_access(self.env.user, payment)
             except (AccessError, AccessDenied):
                 self._not_found(_("Payment %s does not exist.") % payment_id)
+            self._ensure_not_bank_matched(payment)
             if payment.is_internal_transfer:
                 self._update_internal_transfer(payment, payload)
             else:
@@ -394,6 +395,22 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
         except _PaymentProblem as problem:
             return problem.response
         return PaymentSummary.from_account_payment(payment)
+
+    def _ensure_not_bank_matched(self, payment):
+        """A payment reconciled against a bank statement cannot be modified:
+        editing it would break the bank reconciliation. Internal transfers move
+        both legs together, so the counterpart is checked as well."""
+        legs = payment + payment.paired_internal_transfer_payment_id
+        if any(legs.mapped("is_matched")):
+            self._problem(
+                409,
+                "/errors/payment-bank-matched",
+                _("Payment cannot be modified"),
+                _(
+                    "This payment is reconciled against a bank statement and "
+                    "cannot be modified."
+                ),
+            )
 
     def _resolve_payment_method_line(self, payment_method_id):
         line = (

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 from fastapi.responses import JSONResponse
 
-from odoo import models
+from odoo import _, models
 from odoo.exceptions import AccessDenied, AccessError
 
 from odoo.addons.account.models.account_payment import AccountPayment
@@ -185,7 +185,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
         )
 
     def _not_found(self, detail):
-        self._problem(404, "/errors/record-not-found", "Record not found", detail)
+        self._problem(404, "/errors/record-not-found", _("Record not found"), detail)
 
     def get(self, payment_id):
         try:
@@ -194,8 +194,8 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                 self._problem(
                     404,
                     "/errors/payment-not-found",
-                    "Payment not found",
-                    f"Payment {payment_id} does not exist.",
+                    _("Payment not found"),
+                    _("Payment %s does not exist.") % payment_id,
                 )
             try:
                 PmsBaseModel.pms_api_check_access(self.env.user, payment)
@@ -203,26 +203,28 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                 self._problem(
                     404,
                     "/errors/payment-not-found",
-                    "Payment not found",
-                    f"Payment {payment_id} does not exist.",
+                    _("Payment not found"),
+                    _("Payment %s does not exist.") % payment_id,
                 )
         except _PaymentProblem as problem:
             return problem.response
         return PaymentSummary.from_account_payment(payment)
 
     def _validation_error(self, detail):
-        self._problem(422, "/errors/validation-error", "Validation error", detail)
+        self._problem(422, "/errors/validation-error", _("Validation error"), detail)
 
     def _resolve_partner(self, partner_id):
         partner = self.env["res.partner"].sudo().browse(partner_id).exists()
         if not partner:
-            self._not_found(f"Partner {partner_id} does not exist.")
+            self._not_found(_("Partner %s does not exist.") % partner_id)
         return partner
 
     def create_payment(self, payload: PaymentInput):
         try:
             if payload.folioId and payload.invoiceId:
-                self._validation_error("folioId and invoiceId are mutually exclusive.")
+                self._validation_error(
+                    _("folioId and invoiceId are mutually exclusive.")
+                )
             line = (
                 self.env["account.payment.method.line"]
                 .sudo()
@@ -231,7 +233,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
             )
             if not line:
                 self._not_found(
-                    f"Payment method {payload.paymentMethodId} does not exist."
+                    _("Payment method %s does not exist.") % payload.paymentMethodId
                 )
             journal = line.journal_id
             PmsBaseModel.pms_api_check_access(self.env.user, journal)
@@ -242,7 +244,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
                 else self.env["res.partner"]
             )
             if payload.paymentType == PaymentCreateType.supplierPayment and not partner:
-                self._validation_error("supplierPayment requires partnerId.")
+                self._validation_error(_("supplierPayment requires partnerId."))
 
             if journal.type == "cash":
                 self.env["account.bank.statement"].sudo()._pms_ensure_open_cash_session(
@@ -266,15 +268,15 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
         if payload.folioId:
             folio = self.env["pms.folio"].sudo().browse(payload.folioId).exists()
             if not folio:
-                self._not_found(f"Folio {payload.folioId} does not exist.")
+                self._not_found(_("Folio %s does not exist.") % payload.folioId)
         else:
             invoice = self.env["account.move"].sudo().browse(payload.invoiceId).exists()
             if not invoice:
-                self._not_found(f"Invoice {payload.invoiceId} does not exist.")
+                self._not_found(_("Invoice %s does not exist.") % payload.invoiceId)
             folio = invoice.folio_ids[:1]
             if not folio:
                 self._validation_error(
-                    f"Invoice {payload.invoiceId} has no associated folio."
+                    _("Invoice %s has no associated folio.") % payload.invoiceId
                 )
         PmsBaseModel.pms_api_check_access(self.env.user, folio)
         return folio
@@ -321,16 +323,18 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
         try:
             if payload.originJournalId == payload.destinationJournalId:
                 self._validation_error(
-                    "El diario de origen y el de destino no pueden ser el mismo."
+                    _("Origin and destination journals cannot be the same.")
                 )
             journals = self.env["account.journal"].sudo()
             origin = journals.browse(payload.originJournalId).exists()
             destination = journals.browse(payload.destinationJournalId).exists()
             if not origin:
-                self._not_found(f"Journal {payload.originJournalId} does not exist.")
+                self._not_found(
+                    _("Journal %s does not exist.") % payload.originJournalId
+                )
             if not destination:
                 self._not_found(
-                    f"Journal {payload.destinationJournalId} does not exist."
+                    _("Journal %s does not exist.") % payload.destinationJournalId
                 )
             PmsBaseModel.pms_api_check_access(self.env.user, origin + destination)
             statement_model = self.env["account.bank.statement"].sudo()
@@ -365,11 +369,11 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
         try:
             payment = self.env["account.payment"].sudo().browse(payment_id).exists()
             if not payment:
-                self._not_found(f"Payment {payment_id} does not exist.")
+                self._not_found(_("Payment %s does not exist.") % payment_id)
             try:
                 PmsBaseModel.pms_api_check_access(self.env.user, payment)
             except (AccessError, AccessDenied):
-                self._not_found(f"Payment {payment_id} does not exist.")
+                self._not_found(_("Payment %s does not exist.") % payment_id)
             if payment.is_internal_transfer:
                 self._update_internal_transfer(payment, payload)
             else:
@@ -388,7 +392,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
             .exists()
         )
         if not line:
-            self._not_found(f"Payment method {payment_method_id} does not exist.")
+            self._not_found(_("Payment method %s does not exist.") % payment_method_id)
         PmsBaseModel.pms_api_check_access(self.env.user, line.journal_id)
         return line
 
@@ -455,7 +459,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
         # single 'payment mode' doesn't apply to it.
         if payload.paymentMethodId is not None:
             self._validation_error(
-                "paymentMethodId does not apply to an internal transfer."
+                _("paymentMethodId does not apply to an internal transfer.")
             )
         # Both legs share amount and date; edit them together to keep the pair
         # consistent (they are reconciled against each other).

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -496,7 +496,7 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
             if payload.paymentType == PaymentCreateType.customerPayment and (
                 payload.folioId or payload.invoiceId
             ):
-                payment = self._create_folio_payment(payload, line, partner)
+                payment = self._create_context_payment(payload, line, partner)
             else:
                 payment = self._create_simple_payment(
                     payload, line, partner, payment_type, partner_type
@@ -505,26 +505,44 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
             return problem.response
         return PaymentSummary.from_account_payment(payment)
 
-    def _resolve_context_folio(self, payload):
-        """Return the folio for a customer payment context (folio or invoice)."""
-        if payload.folioId:
-            folio = self.env["pms.folio"].sudo().browse(payload.folioId).exists()
-            if not folio:
-                self._not_found(_("Folio %s does not exist.") % payload.folioId)
-        else:
-            invoice = self.env["account.move"].sudo().browse(payload.invoiceId).exists()
-            if not invoice:
-                self._not_found(_("Invoice %s does not exist.") % payload.invoiceId)
-            folio = invoice.folio_ids[:1]
-            if not folio:
-                self._validation_error(
-                    _("Invoice %s has no associated folio.") % payload.invoiceId
-                )
+    def _create_context_payment(self, payload, line, partner):
+        """Register a customer payment from a folio or an invoice context.
+
+        When the context is an invoice we know exactly which document the
+        payment settles, so we register it against the invoice and let it
+        reconcile deterministically. When it is a folio (no specific invoice)
+        we fall back to the folio-level `do_payment`, whose reconciliation is
+        best-effort (see pms_autoreconcile_folio_payments)."""
+        if payload.invoiceId:
+            return self._create_invoice_payment(payload, line)
+        return self._create_folio_payment(payload, line, partner)
+
+    def _resolve_folio(self, payload):
+        folio = self.env["pms.folio"].sudo().browse(payload.folioId).exists()
+        if not folio:
+            self._not_found(_("Folio %s does not exist.") % payload.folioId)
         PmsBaseModel.pms_api_check_access(self.env.user, folio)
         return folio
 
+    def _resolve_context_invoice(self, payload):
+        invoice = self.env["account.move"].sudo().browse(payload.invoiceId).exists()
+        if not invoice:
+            self._not_found(_("Invoice %s does not exist.") % payload.invoiceId)
+        folio = invoice.folio_ids[:1]
+        if not folio:
+            self._validation_error(
+                _("Invoice %s has no associated folio.") % payload.invoiceId
+            )
+        # Access is granted through the folio, as in the folio-context path.
+        PmsBaseModel.pms_api_check_access(self.env.user, folio)
+        if invoice.state != "posted":
+            self._validation_error(
+                _("Invoice %s is not posted and cannot be paid.") % payload.invoiceId
+            )
+        return invoice
+
     def _create_folio_payment(self, payload, line, partner):
-        folio = self._resolve_context_folio(payload)
+        folio = self._resolve_folio(payload)
         partner = partner or folio.partner_id
         before = folio.payment_ids
         self.env["pms.folio"].sudo().do_payment(
@@ -537,6 +555,33 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
             ref=payload.reference,
         )
         return folio.payment_ids - before
+
+    def _create_invoice_payment(self, payload, line):
+        """Register the payment directly against the invoice.
+
+        `account.payment.register` creates, posts and reconciles the payment
+        against the invoice's receivable line in one shot. pms then recomputes
+        `folio_ids` from `reconciled_invoice_ids`
+        (account_payment._compute_folio_ids), so the folio link comes for free
+        and the payment is left properly reconciled — unlike the folio-level
+        `do_payment`, whose autoreconcile is heuristic and skips ambiguous
+        matches."""
+        invoice = self._resolve_context_invoice(payload)
+        vals = {
+            "amount": payload.amount,
+            "payment_date": payload.date,
+            "journal_id": line.journal_id.id,
+            "payment_method_line_id": line.id,
+        }
+        if payload.reference:
+            vals["communication"] = payload.reference
+        return (
+            self.env["account.payment.register"]
+            .sudo()
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create(vals)
+            ._create_payments()
+        )
 
     def _create_simple_payment(
         self, payload, line, partner, payment_type, partner_type

--- a/pms_fastapi/routers/payment.py
+++ b/pms_fastapi/routers/payment.py
@@ -463,44 +463,53 @@ class PmsApiPaymentRouterHelper(models.AbstractModel):
 
     def create_payment(self, payload: PaymentInput):
         try:
-            if payload.folioId and payload.invoiceId:
-                self._validation_error(
-                    _("folioId and invoiceId are mutually exclusive.")
+            # Savepoint so that if a later step raises (e.g. a cash journal
+            # auto-opens a session and then the folio/invoice resolution
+            # fails), the already-created records — the phantom empty cash
+            # session in particular — are rolled back instead of committed
+            # alongside the error response.
+            with self.env.cr.savepoint():
+                if payload.folioId and payload.invoiceId:
+                    self._validation_error(
+                        _("folioId and invoiceId are mutually exclusive.")
+                    )
+                line = (
+                    self.env["account.payment.method.line"]
+                    .sudo()
+                    .browse(payload.paymentMethodId)
+                    .exists()
                 )
-            line = (
-                self.env["account.payment.method.line"]
-                .sudo()
-                .browse(payload.paymentMethodId)
-                .exists()
-            )
-            if not line:
-                self._not_found(
-                    _("Payment method %s does not exist.") % payload.paymentMethodId
+                if not line:
+                    self._not_found(
+                        _("Payment method %s does not exist.") % payload.paymentMethodId
+                    )
+                journal = line.journal_id
+                PmsBaseModel.pms_api_check_access(self.env.user, journal)
+                payment_type, partner_type = _CREATE_TYPE_FIELDS[payload.paymentType]
+                partner = (
+                    self._resolve_partner(payload.partnerId)
+                    if payload.partnerId
+                    else self.env["res.partner"]
                 )
-            journal = line.journal_id
-            PmsBaseModel.pms_api_check_access(self.env.user, journal)
-            payment_type, partner_type = _CREATE_TYPE_FIELDS[payload.paymentType]
-            partner = (
-                self._resolve_partner(payload.partnerId)
-                if payload.partnerId
-                else self.env["res.partner"]
-            )
-            if payload.paymentType == PaymentCreateType.supplierPayment and not partner:
-                self._validation_error(_("supplierPayment requires partnerId."))
+                if (
+                    payload.paymentType == PaymentCreateType.supplierPayment
+                    and not partner
+                ):
+                    self._validation_error(_("supplierPayment requires partnerId."))
 
-            if journal.type == "cash":
-                self.env["account.bank.statement"].sudo()._pms_ensure_open_cash_session(
-                    journal
-                )
+                if journal.type == "cash":
+                    self.env[
+                        "account.bank.statement"
+                    ].sudo()._pms_ensure_open_cash_session(journal)
 
-            if payload.paymentType == PaymentCreateType.customerPayment and (
-                payload.folioId or payload.invoiceId
-            ):
-                payment = self._create_context_payment(payload, line, partner)
-            else:
-                payment = self._create_simple_payment(
-                    payload, line, partner, payment_type, partner_type
-                )
+                if payload.paymentType == PaymentCreateType.customerPayment and (
+                    payload.folioId or payload.invoiceId
+                ):
+                    payment = self._create_context_payment(payload, line, partner)
+                else:
+                    payment = self._create_simple_payment(
+                        payload, line, partner, payment_type, partner_type
+                    )
         except _PaymentProblem as problem:
             return problem.response
         return PaymentSummary.from_account_payment(payment)

--- a/pms_fastapi/routers/payment_method.py
+++ b/pms_fastapi/routers/payment_method.py
@@ -6,7 +6,10 @@ from odoo import models
 
 from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
-from odoo.addons.pms_fastapi.schemas.payment_method import PaymentMethodSummary
+from odoo.addons.pms_fastapi.schemas.payment_method import (
+    PaymentMethodSummary,
+    PaymentMethodTypeEnum,
+)
 
 
 @pms_api_router.get(
@@ -23,10 +26,17 @@ async def list_payment_methods(
             "available for the given property."
         ),
     ] = None,
+    type: Annotated[
+        PaymentMethodTypeEnum | None,
+        Query(description="Restrict to payment methods of the given type."),
+    ] = None,
 ) -> list[PaymentMethodSummary]:
-    """List inbound payment methods allowed on PMS, scoped through their journal."""
+    """List payment methods allowed on PMS, scoped through their journal."""
     helper = env["pms_api_payment_method.payment_method_router.helper"].new()
-    methods = helper.search_payment_methods(pms_property_id=pmsPropertyId)
+    methods = helper.search_payment_methods(
+        pms_property_id=pmsPropertyId,
+        payment_type=type.value if type else None,
+    )
     return [
         PaymentMethodSummary.from_account_payment_method_line(method)
         for method in methods
@@ -37,7 +47,7 @@ class PmsApiPaymentMethodRouterHelper(models.AbstractModel):
     _name = "pms_api_payment_method.payment_method_router.helper"
     _description = "PMS API Payment Method Router Helper"
 
-    def search_payment_methods(self, pms_property_id=None):
+    def search_payment_methods(self, pms_property_id=None, payment_type=None):
         # Payment method lines only exist on bank and cash journals; pass the
         # types down so the journal helper skips sale/purchase/general.
         journals = (
@@ -48,14 +58,10 @@ class PmsApiPaymentMethodRouterHelper(models.AbstractModel):
                 journal_type=("bank", "cash"),
             )
         )
-        return (
-            self.env["account.payment.method.line"]
-            .sudo()
-            .search(
-                [
-                    ("payment_type", "=", "inbound"),
-                    ("allowed_on_pms", "=", True),
-                    ("journal_id", "in", journals.ids),
-                ]
-            )
-        )
+        domain = [
+            ("allowed_on_pms", "=", True),
+            ("journal_id", "in", journals.ids),
+        ]
+        if payment_type:
+            domain.append(("payment_type", "=", payment_type))
+        return self.env["account.payment.method.line"].sudo().search(domain)

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -18,7 +18,7 @@ from odoo.addons.pms_fastapi.dependencies import (
     create_order_dependency,
 )
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
-from odoo.addons.pms_fastapi.schemas.contact import ContactIdImage
+from odoo.addons.pms_fastapi.schemas.contact import ContactIdImageEmail
 from odoo.addons.pms_fastapi.schemas.folio_sale_line import FolioSaleLine
 from odoo.addons.pms_fastapi.schemas.pms_folio import (
     FOLIO_ORDER_MAPPING,
@@ -164,13 +164,13 @@ async def get_folio_sale_lines(
 
 @pms_api_router.get(
     "/folios/{folio_id}/contacts",
-    response_model=list[ContactIdImage],
+    response_model=list[ContactIdImageEmail],
     tags=["folio"],
 )
 async def get_folio_contacts(
     env: AuthenticatedEnv,
     folio_id: int,
-) -> list[ContactIdImage]:
+) -> list[ContactIdImageEmail]:
     """Get all contacts associated with a folio.
 
     Collects unique contacts from the folio, its reservations, and guests.
@@ -260,7 +260,7 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
         )
         return [FolioSaleLine.from_folio_sale_line(line) for line in lines]
 
-    def get_contacts(self, folio) -> list[ContactIdImage]:
+    def get_contacts(self, folio) -> list[ContactIdImageEmail]:
         partners = folio.partner_id
         active_reservations = folio.reservation_ids.filtered(
             lambda r: r.cancelled_reason != "modified"
@@ -270,7 +270,7 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
         partners |= active_reservations.mapped(
             "checkin_partner_ids.partner_id"
         ).filtered("id")
-        return [ContactIdImage.from_res_partner(p) for p in partners]
+        return [ContactIdImageEmail.from_res_partner(p) for p in partners]
 
     @api.model
     def extra_features(self):

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, Response
 
-from odoo import api, models
+from odoo import _, api, models
 from odoo.exceptions import AccessDenied, AccessError, MissingError, UserError
 from odoo.osv import expression
 
@@ -168,13 +168,7 @@ async def get_folio(
     Includes totals and reservations with sale-line IDs.
     """
     helper = env["pms_api_folio.folio_router.helper"].new()
-    try:
-        folio = helper.get(folio_id)
-    except MissingError as err:
-        raise HTTPException(
-            status_code=404,
-            detail="folio not found",
-        ) from err
+    folio = helper.get_or_404(folio_id)
     return FolioDetail.from_pms_folio(folio)
 
 
@@ -189,13 +183,7 @@ async def get_folio_sale_lines(
 ) -> list[FolioSaleLine]:
     """Get the billable sale lines of a folio with invoice state and tax breakdown."""
     helper = env["pms_api_folio.folio_router.helper"].new()
-    try:
-        folio = helper.get(folio_id)
-    except MissingError as err:
-        raise HTTPException(
-            status_code=404,
-            detail="folio not found",
-        ) from err
+    folio = helper.get_or_404(folio_id)
     return helper.get_sale_lines(folio)
 
 
@@ -210,13 +198,7 @@ async def get_sale_line(
 ) -> FolioSaleLine:
     """Get a single billable sale line by its id, with invoice state and taxes."""
     helper = env["pms_api_folio.folio_router.helper"].new()
-    try:
-        line = helper.get_sale_line(line_id)
-    except MissingError as err:
-        raise HTTPException(
-            status_code=404,
-            detail="sale line not found",
-        ) from err
+    line = helper.get_sale_line_or_404(line_id)
     return FolioSaleLine.from_folio_sale_line(line)
 
 
@@ -231,13 +213,7 @@ async def get_folio_down_payment_invoices(
 ) -> list[InvoiceSummary]:
     """Get the list of down-payment invoices associated with a folio."""
     helper = env["pms_api_folio.folio_router.helper"].new()
-    try:
-        folio = helper.get(folio_id)
-    except MissingError as err:
-        raise HTTPException(
-            status_code=404,
-            detail="folio not found",
-        ) from err
+    folio = helper.get_or_404(folio_id)
     return helper.get_down_payment_invoices(folio)
 
 
@@ -255,13 +231,7 @@ async def get_folio_contacts(
     Collects unique contacts from the folio, its reservations, and guests.
     """
     helper = env["pms_api_folio.folio_router.helper"].new()
-    try:
-        folio = helper.get(folio_id)
-    except MissingError as err:
-        raise HTTPException(
-            status_code=404,
-            detail="folio not found",
-        ) from err
+    folio = helper.get_or_404(folio_id)
     return helper.get_contacts(folio)
 
 
@@ -292,6 +262,15 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
     def get(self, record_id) -> PmsFolio:
         return self.model_adapter.get(record_id)
 
+    def get_or_404(self, folio_id) -> PmsFolio:
+        try:
+            return self.get(folio_id)
+        except MissingError as err:
+            raise HTTPException(
+                status_code=404,
+                detail=_("folio not found"),
+            ) from err
+
     @property
     def sale_line_adapter(self) -> FilteredModelAdapter[FolioSaleLineModel]:
         # Same scope as the folio sale-line listing: only billable
@@ -306,6 +285,15 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
 
     def get_sale_line(self, line_id) -> FolioSaleLineModel:
         return self.sale_line_adapter.get(line_id)
+
+    def get_sale_line_or_404(self, line_id) -> FolioSaleLineModel:
+        try:
+            return self.get_sale_line(line_id)
+        except MissingError as err:
+            raise HTTPException(
+                status_code=404,
+                detail=_("sale line not found"),
+            ) from err
 
     def _search(self, paging, params, order) -> tuple[int, PmsFolio]:
         return self.model_adapter.search_with_count(
@@ -418,8 +406,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/duplicate-sale-lines",
-                "Duplicate sale lines",
-                "Each sale line can only appear once in the request.",
+                _("Duplicate sale lines"),
+                _("Each sale line can only appear once in the request."),
             )
         sale_lines = self.env["folio.sale.line"].sudo().browse(sale_line_ids).exists()
         missing = set(sale_line_ids) - set(sale_lines.ids)
@@ -427,8 +415,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 404,
                 "/errors/sale-lines-not-found",
-                "Sale lines not found",
-                "Some sale lines could not be found.",
+                _("Sale lines not found"),
+                _("Some sale lines could not be found."),
                 missingSaleLineIds=sorted(missing),
             )
         try:
@@ -437,17 +425,19 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 403,
                 "/errors/access-denied",
-                "Access denied",
-                "You are not allowed to access some of the requested sale lines.",
+                _("Access denied"),
+                _("You are not allowed to access some of the requested sale lines."),
             )
         invalid_kind = sale_lines.filtered(lambda r: r.display_type or r.is_downpayment)
         if invalid_kind:
             self._raise_problem(
                 422,
                 "/errors/invalid-sale-line",
-                "Invalid sale line",
-                "Sections, notes and down payments cannot be invoiced through "
-                "this endpoint.",
+                _("Invalid sale line"),
+                _(
+                    "Sections, notes and down payments cannot be invoiced through "
+                    "this endpoint."
+                ),
                 invalidSaleLineIds=invalid_kind.ids,
             )
         return sale_lines
@@ -460,8 +450,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/duplicate-downpayment-lines",
-                "Duplicate down-payment invoices",
-                "Each down-payment invoice can only appear once in the request.",
+                _("Duplicate down-payment invoices"),
+                _("Each down-payment invoice can only appear once in the request."),
             )
         dp_invoices = self.env["account.move"].sudo().browse(ids).exists()
         missing = set(ids) - set(dp_invoices.ids)
@@ -469,8 +459,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 404,
                 "/errors/downpayment-lines-not-found",
-                "Down-payment invoices not found",
-                "Some down-payment invoices could not be found.",
+                _("Down-payment invoices not found"),
+                _("Some down-payment invoices could not be found."),
                 missingDownpaymentLineIds=sorted(missing),
             )
         not_downpayment = dp_invoices.filtered(lambda m: not m._is_downpayment())
@@ -478,8 +468,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/invalid-downpayment-line",
-                "Invalid down-payment invoice",
-                "Only down-payment invoices are accepted as downpaymentLines.",
+                _("Invalid down-payment invoice"),
+                _("Only down-payment invoices are accepted as downpaymentLines."),
                 invalidDownpaymentLineIds=not_downpayment.ids,
             )
         folio_ids = set(sale_lines.folio_id.ids)
@@ -490,9 +480,11 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/downpayment-line-out-of-scope",
-                "Down-payment invoice out of scope",
-                "Down-payment invoices must belong to the same folios as the "
-                "invoiced lines.",
+                _("Down-payment invoice out of scope"),
+                _(
+                    "Down-payment invoices must belong to the same folios as the "
+                    "invoiced lines."
+                ),
                 outOfScopeDownpaymentLineIds=out_of_scope.ids,
             )
         return dp_invoices.invoice_line_ids.folio_line_ids.filtered("is_downpayment")
@@ -503,8 +495,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/multiple-properties",
-                "Sale lines from multiple properties",
-                "All sale lines must belong to the same property.",
+                _("Sale lines from multiple properties"),
+                _("All sale lines must belong to the same property."),
                 propertyIds=properties.ids,
             )
         return properties
@@ -526,9 +518,11 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/quantity-exceeds-pending",
-                "Quantity to invoice exceeds pending quantity",
-                "One or more sale lines were asked to invoice a quantity "
-                "greater than their pending quantity.",
+                _("Quantity to invoice exceeds pending quantity"),
+                _(
+                    "One or more sale lines were asked to invoice a quantity "
+                    "greater than their pending quantity."
+                ),
                 lines=qty_errors,
             )
 
@@ -540,8 +534,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 404,
                 "/errors/not-found",
-                "Contact not found",
-                "Customer not found.",
+                _("Contact not found"),
+                _("Customer not found."),
             )
         invoice_helper = self.env["pms_api_invoice.invoice_router.helper"].new()
         contact_errors = invoice_helper._get_contact_validation_errors(
@@ -551,8 +545,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/invoicing-validation-failed",
-                "Invoicing validation failed",
-                "Customer does not meet invoicing requirements.",
+                _("Invoicing validation failed"),
+                _("Customer does not meet invoicing requirements."),
                 errors=contact_errors,
             )
         return partner
@@ -573,9 +567,11 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/simplified-invoice-limit-exceeded",
-                "Simplified invoice limit exceeded",
-                "The invoice total exceeds the simplified invoice limit "
-                "configured for this property.",
+                _("Simplified invoice limit exceeded"),
+                _(
+                    "The invoice total exceeds the simplified invoice limit "
+                    "configured for this property."
+                ),
                 invoiceTotal=round(invoice_total, 2),
                 simplifiedInvoiceLimit=limit,
             )
@@ -623,23 +619,25 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/invoice-creation-failed",
-                "Invoice creation failed",
+                _("Invoice creation failed"),
                 str(e),
             )
         if not invoices:
             self._raise_problem(
                 422,
                 "/errors/invoice-creation-failed",
-                "Invoice creation failed",
-                "No invoice could be created from the provided sale lines.",
+                _("Invoice creation failed"),
+                _("No invoice could be created from the provided sale lines."),
             )
         if len(invoices) > 1:
             self._raise_problem(
                 422,
                 "/errors/multiple-invoices-created",
-                "Multiple invoices created",
-                "The provided sale lines could not be grouped into a single "
-                "invoice (different currency or company).",
+                _("Multiple invoices created"),
+                _(
+                    "The provided sale lines could not be grouped into a single "
+                    "invoice (different currency or company)."
+                ),
                 invoiceIds=invoices.ids,
             )
         invoices.narration = payload.narration
@@ -657,7 +655,7 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/invoice-posting-failed",
-                "Invoice posting failed",
+                _("Invoice posting failed"),
                 str(e),
             )
 
@@ -673,9 +671,9 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
                 status_code=400,
                 content={
                     "type": "/errors/mutually-exclusive-params",
-                    "title": "Mutually exclusive parameters",
+                    "title": _("Mutually exclusive parameters"),
                     "status": 400,
-                    "detail": (
+                    "detail": _(
                         "Cannot specify both 'ids' and filter parameters. "
                         "Use one or the other."
                     ),
@@ -694,12 +692,13 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
                 status_code=400,
                 content={
                     "type": "/errors/record-limit-exceeded",
-                    "title": "Record limit exceeded",
+                    "title": _("Record limit exceeded"),
                     "status": 400,
-                    "detail": (
-                        f"The export requested {count} records, "
-                        f"but the maximum allowed is {FOLIO_REPORT_MAX_RECORDS}."
-                    ),
+                    "detail": _(
+                        "The export requested %s records, "
+                        "but the maximum allowed is %s."
+                    )
+                    % (count, FOLIO_REPORT_MAX_RECORDS),
                     "requestedCount": count,
                     "maxAllowed": FOLIO_REPORT_MAX_RECORDS,
                 },

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -460,40 +460,42 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             self._raise_problem(
                 422,
                 "/errors/duplicate-downpayment-lines",
-                "Duplicate down-payment lines",
-                "Each down-payment line can only appear once in the request.",
+                "Duplicate down-payment invoices",
+                "Each down-payment invoice can only appear once in the request.",
             )
-        dp_lines = self.env["folio.sale.line"].sudo().browse(ids).exists()
-        missing = set(ids) - set(dp_lines.ids)
+        dp_invoices = self.env["account.move"].sudo().browse(ids).exists()
+        missing = set(ids) - set(dp_invoices.ids)
         if missing:
             self._raise_problem(
                 404,
                 "/errors/downpayment-lines-not-found",
-                "Down-payment lines not found",
-                "Some down-payment lines could not be found.",
+                "Down-payment invoices not found",
+                "Some down-payment invoices could not be found.",
                 missingDownpaymentLineIds=sorted(missing),
             )
-        not_downpayment = dp_lines.filtered(lambda r: not r.is_downpayment)
+        not_downpayment = dp_invoices.filtered(lambda m: not m._is_downpayment())
         if not_downpayment:
             self._raise_problem(
                 422,
                 "/errors/invalid-downpayment-line",
-                "Invalid down-payment line",
-                "Only down-payment lines are accepted as downpaymentLines.",
+                "Invalid down-payment invoice",
+                "Only down-payment invoices are accepted as downpaymentLines.",
                 invalidDownpaymentLineIds=not_downpayment.ids,
             )
         folio_ids = set(sale_lines.folio_id.ids)
-        out_of_scope = dp_lines.filtered(lambda r: r.folio_id.id not in folio_ids)
+        out_of_scope = dp_invoices.filtered(
+            lambda m: not set(m.folio_ids.ids) & folio_ids
+        )
         if out_of_scope:
             self._raise_problem(
                 422,
                 "/errors/downpayment-line-out-of-scope",
-                "Down-payment line out of scope",
-                "Down-payment lines must belong to the same folios as the "
+                "Down-payment invoice out of scope",
+                "Down-payment invoices must belong to the same folios as the "
                 "invoiced lines.",
                 outOfScopeDownpaymentLineIds=out_of_scope.ids,
             )
-        return dp_lines
+        return dp_invoices.invoice_line_ids.folio_line_ids.filtered("is_downpayment")
 
     def _resolve_property(self, sale_lines):
         properties = sale_lines.mapped("pms_property_id")

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -357,12 +357,15 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
     def _create_invoice(self, payload: FolioInvoiceCreate):
         try:
             sale_lines = self._resolve_sale_lines(payload)
+            downpayment_lines = self._resolve_downpayment_lines(payload, sale_lines)
             pms_property = self._resolve_property(sale_lines)
             self._check_quantities(payload, sale_lines)
             partner = self._resolve_invoice_partner(payload, pms_property)
             if payload.customerId is None:
                 self._check_simplified_limit(payload, sale_lines, pms_property)
-            invoice = self._build_and_create_invoice(payload, sale_lines, partner)
+            invoice = self._build_and_create_invoice(
+                payload, sale_lines, downpayment_lines, partner
+            )
             self._override_invoice_due_date(invoice, payload)
             if payload.validate_invoice:
                 self._post_invoice(invoice)
@@ -409,6 +412,49 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
                 invalidSaleLineIds=invalid_kind.ids,
             )
         return sale_lines
+
+    def _resolve_downpayment_lines(self, payload: FolioInvoiceCreate, sale_lines):
+        if not payload.downpaymentLines:
+            return self.env["folio.sale.line"]
+        ids = list(set(payload.downpaymentLines))
+        if len(ids) != len(payload.downpaymentLines):
+            self._raise_problem(
+                422,
+                "/errors/duplicate-downpayment-lines",
+                "Duplicate down-payment lines",
+                "Each down-payment line can only appear once in the request.",
+            )
+        dp_lines = self.env["folio.sale.line"].sudo().browse(ids).exists()
+        missing = set(ids) - set(dp_lines.ids)
+        if missing:
+            self._raise_problem(
+                404,
+                "/errors/downpayment-lines-not-found",
+                "Down-payment lines not found",
+                "Some down-payment lines could not be found.",
+                missingDownpaymentLineIds=sorted(missing),
+            )
+        not_downpayment = dp_lines.filtered(lambda r: not r.is_downpayment)
+        if not_downpayment:
+            self._raise_problem(
+                422,
+                "/errors/invalid-downpayment-line",
+                "Invalid down-payment line",
+                "Only down-payment lines are accepted as downpaymentLines.",
+                invalidDownpaymentLineIds=not_downpayment.ids,
+            )
+        folio_ids = set(sale_lines.folio_id.ids)
+        out_of_scope = dp_lines.filtered(lambda r: r.folio_id.id not in folio_ids)
+        if out_of_scope:
+            self._raise_problem(
+                422,
+                "/errors/downpayment-line-out-of-scope",
+                "Down-payment line out of scope",
+                "Down-payment lines must belong to the same folios as the "
+                "invoiced lines.",
+                outOfScopeDownpaymentLineIds=out_of_scope.ids,
+            )
+        return dp_lines
 
     def _resolve_property(self, sale_lines):
         properties = sale_lines.mapped("pms_property_id")
@@ -493,10 +539,14 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
                 simplifiedInvoiceLimit=limit,
             )
 
-    def _build_lines_to_invoice(self, payload: FolioInvoiceCreate, sale_lines) -> dict:
+    def _build_lines_to_invoice(
+        self, payload: FolioInvoiceCreate, sale_lines, downpayment_lines
+    ) -> dict:
         lines_to_invoice = {
             line.saleLineId: line.quantityToInvoice for line in payload.lines
         }
+        for dp in downpayment_lines:
+            lines_to_invoice[dp.id] = dp.qty_to_invoice or 1
         lines_with_sections = sale_lines
         for line in sale_lines:
             section = line.section_id
@@ -512,9 +562,11 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
         return lines_to_invoice
 
     def _build_and_create_invoice(
-        self, payload: FolioInvoiceCreate, sale_lines, partner
+        self, payload: FolioInvoiceCreate, sale_lines, downpayment_lines, partner
     ):
-        lines_to_invoice = self._build_lines_to_invoice(payload, sale_lines)
+        lines_to_invoice = self._build_lines_to_invoice(
+            payload, sale_lines, downpayment_lines
+        )
         descriptions = {line.saleLineId: line.description for line in payload.lines}
         folios = sale_lines.folio_id.with_context(
             **{FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX: descriptions}

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -642,6 +642,7 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
                 "invoice (different currency or company).",
                 invoiceIds=invoices.ids,
             )
+        invoices.narration = payload.narration
         return invoices
 
     @staticmethod

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -12,6 +12,9 @@ from odoo.addons.fastapi.dependencies import (
     paging,
 )
 from odoo.addons.fastapi.schemas import Paging
+from odoo.addons.pms.models.folio_sale_line import (
+    FolioSaleLine as FolioSaleLineModel,
+)
 from odoo.addons.pms.models.pms_folio import PmsFolio
 from odoo.addons.pms_fastapi.dependencies import (
     AuthenticatedEnv,
@@ -197,6 +200,27 @@ async def get_folio_sale_lines(
 
 
 @pms_api_router.get(
+    "/sale-lines/{line_id}",
+    response_model=FolioSaleLine,
+    tags=["folio"],
+)
+async def get_sale_line(
+    env: AuthenticatedEnv,
+    line_id: int,
+) -> FolioSaleLine:
+    """Get a single billable sale line by its id, with invoice state and taxes."""
+    helper = env["pms_api_folio.folio_router.helper"].new()
+    try:
+        line = helper.get_sale_line(line_id)
+    except MissingError as err:
+        raise HTTPException(
+            status_code=404,
+            detail="sale line not found",
+        ) from err
+    return FolioSaleLine.from_folio_sale_line(line)
+
+
+@pms_api_router.get(
     "/folios/{folio_id}/down-payment-invoices",
     response_model=list[InvoiceSummary],
     tags=["folio"],
@@ -267,6 +291,21 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
 
     def get(self, record_id) -> PmsFolio:
         return self.model_adapter.get(record_id)
+
+    @property
+    def sale_line_adapter(self) -> FilteredModelAdapter[FolioSaleLineModel]:
+        # Same scope as the folio sale-line listing: only billable
+        # room/service lines, excluding sections, notes and downpayments.
+        base_domain = [
+            ("display_type", "=", False),
+            ("is_downpayment", "=", False),
+        ]
+        multicompany_domain = self._get_multicompany_rule()
+        model_domain = expression.AND([base_domain, multicompany_domain])
+        return FilteredModelAdapter[FolioSaleLineModel](self.env, model_domain)
+
+    def get_sale_line(self, line_id) -> FolioSaleLineModel:
+        return self.sale_line_adapter.get(line_id)
 
     def _search(self, paging, params, order) -> tuple[int, PmsFolio]:
         return self.model_adapter.search_with_count(

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -255,7 +255,9 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
         return folios_count, reservations_count
 
     def get_sale_lines(self, folio) -> list[FolioSaleLine]:
-        lines = folio.sale_line_ids.filtered(lambda line: not line.display_type)
+        lines = folio.sale_line_ids.filtered(
+            lambda line: not line.display_type and not line.is_downpayment
+        )
         return [FolioSaleLine.from_folio_sale_line(line) for line in lines]
 
     def get_contacts(self, folio) -> list[ContactIdImage]:

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -4,7 +4,7 @@ from fastapi import Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, Response
 
 from odoo import api, models
-from odoo.exceptions import AccessError, MissingError, UserError
+from odoo.exceptions import AccessDenied, AccessError, MissingError, UserError
 from odoo.osv import expression
 
 from odoo.addons.extendable_fastapi.schemas import PagedCollection
@@ -21,6 +21,7 @@ from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
 from odoo.addons.pms_fastapi.models.folio_sale_line import (
     FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX,
 )
+from odoo.addons.pms_fastapi.schemas.base import PmsBaseModel
 from odoo.addons.pms_fastapi.schemas.contact import ContactIdImageEmail
 from odoo.addons.pms_fastapi.schemas.folio_sale_line import FolioSaleLine
 from odoo.addons.pms_fastapi.schemas.invoice import (
@@ -378,7 +379,7 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
                 "Duplicate sale lines",
                 "Each sale line can only appear once in the request.",
             )
-        sale_lines = self.env["folio.sale.line"].browse(sale_line_ids).exists()
+        sale_lines = self.env["folio.sale.line"].sudo().browse(sale_line_ids).exists()
         missing = set(sale_line_ids) - set(sale_lines.ids)
         if missing:
             self._raise_problem(
@@ -389,9 +390,8 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
                 missingSaleLineIds=sorted(missing),
             )
         try:
-            sale_lines.check_access_rights("read")
-            sale_lines.check_access_rule("read")
-        except AccessError:
+            PmsBaseModel.pms_api_check_access(self.env.user, sale_lines)
+        except (AccessError, AccessDenied):
             self._raise_problem(
                 403,
                 "/errors/access-denied",
@@ -448,7 +448,7 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
     def _resolve_invoice_partner(self, payload: FolioInvoiceCreate, pms_property):
         if payload.customerId is None:
             return self.env.ref("pms.various_pms_partner")
-        partner = self.env["res.partner"].browse(payload.customerId).exists()
+        partner = self.env["res.partner"].sudo().browse(payload.customerId).exists()
         if not partner:
             self._raise_problem(
                 404,

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -1,9 +1,10 @@
 from typing import Annotated
 
-from fastapi import Depends, Query
+from fastapi import Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, Response
 
 from odoo import api, models
+from odoo.exceptions import MissingError
 from odoo.osv import expression
 
 from odoo.addons.extendable_fastapi.schemas import PagedCollection
@@ -17,9 +18,12 @@ from odoo.addons.pms_fastapi.dependencies import (
     create_order_dependency,
 )
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.schemas.contact import ContactIdImage
+from odoo.addons.pms_fastapi.schemas.folio_sale_line import FolioSaleLine
 from odoo.addons.pms_fastapi.schemas.pms_folio import (
     FOLIO_ORDER_MAPPING,
     FolioCountSummary,
+    FolioDetail,
     FolioOrderField,
     FolioSearch,
     FolioSummary,
@@ -113,6 +117,75 @@ async def list_folios(
     )
 
 
+@pms_api_router.get(
+    "/folios/{folio_id}",
+    response_model=FolioDetail,
+    tags=["folio"],
+)
+async def get_folio(
+    env: AuthenticatedEnv,
+    folio_id: int,
+) -> FolioDetail:
+    """Get the billing detail of a folio.
+
+    Includes totals and reservations with sale-line IDs.
+    """
+    helper = env["pms_api_folio.folio_router.helper"].new()
+    try:
+        folio = helper.get(folio_id)
+    except MissingError as err:
+        raise HTTPException(
+            status_code=404,
+            detail="folio not found",
+        ) from err
+    return FolioDetail.from_pms_folio(folio)
+
+
+@pms_api_router.get(
+    "/folios/{folio_id}/sale-lines",
+    response_model=list[FolioSaleLine],
+    tags=["folio"],
+)
+async def get_folio_sale_lines(
+    env: AuthenticatedEnv,
+    folio_id: int,
+) -> list[FolioSaleLine]:
+    """Get the billable sale lines of a folio with invoice state and tax breakdown."""
+    helper = env["pms_api_folio.folio_router.helper"].new()
+    try:
+        folio = helper.get(folio_id)
+    except MissingError as err:
+        raise HTTPException(
+            status_code=404,
+            detail="folio not found",
+        ) from err
+    return helper.get_sale_lines(folio)
+
+
+@pms_api_router.get(
+    "/folios/{folio_id}/contacts",
+    response_model=list[ContactIdImage],
+    tags=["folio"],
+)
+async def get_folio_contacts(
+    env: AuthenticatedEnv,
+    folio_id: int,
+) -> list[ContactIdImage]:
+    """Get all contacts associated with a folio.
+
+    Collects unique contacts from the folio, its reservations, and guests.
+    """
+    helper = env["pms_api_folio.folio_router.helper"].new()
+    try:
+        folio = helper.get(folio_id)
+    except MissingError as err:
+        raise HTTPException(
+            status_code=404,
+            detail="folio not found",
+        ) from err
+    return helper.get_contacts(folio)
+
+
 class PmsApiFolioRouterHelper(models.AbstractModel):
     _name = "pms_api_folio.folio_router.helper"
     _description = "Pms api folio Service Helper"
@@ -180,6 +253,22 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
         )
         folios_count, reservations_count = self.env.cr.fetchone()
         return folios_count, reservations_count
+
+    def get_sale_lines(self, folio) -> list[FolioSaleLine]:
+        lines = folio.sale_line_ids.filtered(lambda line: not line.display_type)
+        return [FolioSaleLine.from_folio_sale_line(line) for line in lines]
+
+    def get_contacts(self, folio) -> list[ContactIdImage]:
+        partners = folio.partner_id
+        active_reservations = folio.reservation_ids.filtered(
+            lambda r: r.cancelled_reason != "modified"
+        )
+        partners |= active_reservations.mapped("partner_id").filtered("id")
+        partners |= active_reservations.mapped("agency_id").filtered("id")
+        partners |= active_reservations.mapped(
+            "checkin_partner_ids.partner_id"
+        ).filtered("id")
+        return [ContactIdImage.from_res_partner(p) for p in partners]
 
     @api.model
     def extra_features(self):

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -4,7 +4,7 @@ from fastapi import Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, Response
 
 from odoo import api, models
-from odoo.exceptions import MissingError
+from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.osv import expression
 
 from odoo.addons.extendable_fastapi.schemas import PagedCollection
@@ -18,8 +18,15 @@ from odoo.addons.pms_fastapi.dependencies import (
     create_order_dependency,
 )
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.models.folio_sale_line import (
+    FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX,
+)
 from odoo.addons.pms_fastapi.schemas.contact import ContactIdImageEmail
 from odoo.addons.pms_fastapi.schemas.folio_sale_line import FolioSaleLine
+from odoo.addons.pms_fastapi.schemas.invoice import (
+    FolioInvoiceCreate,
+    InvoiceSummary,
+)
 from odoo.addons.pms_fastapi.schemas.pms_folio import (
     FOLIO_ORDER_MAPPING,
     FolioCountSummary,
@@ -36,6 +43,14 @@ FOLIO_REPORT_MAX_RECORDS = 5000
 folio_order = create_order_dependency(
     FolioOrderField, FOLIO_ORDER_MAPPING, ["creationDate"]
 )
+
+
+class _InvoiceCreationProblem(Exception):
+    """Control-flow exception carrying an RFC 9457 JSONResponse."""
+
+    def __init__(self, response):
+        super().__init__()
+        self.response = response
 
 
 @pms_api_router.post(
@@ -117,6 +132,24 @@ async def list_folios(
     )
 
 
+@pms_api_router.post(
+    "/folios/invoices",
+    response_model=InvoiceSummary,
+    status_code=201,
+    tags=["folio"],
+)
+async def create_folio_invoice(
+    env: AuthenticatedEnv,
+    payload: FolioInvoiceCreate,
+) -> InvoiceSummary:
+    """Create an invoice from folio sale lines.
+
+    Supports grouping lines from multiple folios of the same property.
+    Optionally validates (posts) the invoice on creation.
+    """
+    return env["pms_api_folio.folio_router.helper"].new()._create_invoice(payload)
+
+
 @pms_api_router.get(
     "/folios/{folio_id}",
     response_model=FolioDetail,
@@ -160,6 +193,27 @@ async def get_folio_sale_lines(
             detail="folio not found",
         ) from err
     return helper.get_sale_lines(folio)
+
+
+@pms_api_router.get(
+    "/folios/{folio_id}/down-payment-invoices",
+    response_model=list[InvoiceSummary],
+    tags=["folio"],
+)
+async def get_folio_down_payment_invoices(
+    env: AuthenticatedEnv,
+    folio_id: int,
+) -> list[InvoiceSummary]:
+    """Get the list of down-payment invoices associated with a folio."""
+    helper = env["pms_api_folio.folio_router.helper"].new()
+    try:
+        folio = helper.get(folio_id)
+    except MissingError as err:
+        raise HTTPException(
+            status_code=404,
+            detail="folio not found",
+        ) from err
+    return helper.get_down_payment_invoices(folio)
 
 
 @pms_api_router.get(
@@ -260,6 +314,11 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
         )
         return [FolioSaleLine.from_folio_sale_line(line) for line in lines]
 
+    def get_down_payment_invoices(self, folio) -> list[InvoiceSummary]:
+        lines = folio.sale_line_ids.filtered("is_downpayment")
+        invoices = lines.invoice_lines.move_id
+        return [InvoiceSummary.from_account_move(inv) for inv in invoices]
+
     def get_contacts(self, folio) -> list[ContactIdImageEmail]:
         partners = folio.partner_id
         active_reservations = folio.reservation_ids.filtered(
@@ -275,6 +334,238 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
     @api.model
     def extra_features(self):
         return []
+
+    # -- Invoice creation --
+
+    @staticmethod
+    def _raise_problem(status, type_, title, detail, **extra):
+        raise _InvoiceCreationProblem(
+            JSONResponse(
+                status_code=status,
+                content={
+                    "type": type_,
+                    "title": title,
+                    "status": status,
+                    "detail": detail,
+                    **extra,
+                },
+                media_type="application/problem+json",
+            )
+        )
+
+    def _create_invoice(self, payload: FolioInvoiceCreate):
+        try:
+            sale_lines = self._resolve_sale_lines(payload)
+            pms_property = self._resolve_property(sale_lines)
+            self._check_quantities(payload, sale_lines)
+            partner = self._resolve_invoice_partner(payload, pms_property)
+            if payload.customerId is None:
+                self._check_simplified_limit(payload, sale_lines, pms_property)
+            invoice = self._build_and_create_invoice(payload, sale_lines, partner)
+            self._override_invoice_due_date(invoice, payload)
+            if payload.validate_invoice:
+                self._post_invoice(invoice)
+        except _InvoiceCreationProblem as problem:
+            return problem.response
+        return InvoiceSummary.from_account_move(invoice)
+
+    def _resolve_sale_lines(self, payload: FolioInvoiceCreate):
+        sale_line_ids = [line.saleLineId for line in payload.lines]
+        if len(sale_line_ids) != len(set(sale_line_ids)):
+            self._raise_problem(
+                422,
+                "/errors/duplicate-sale-lines",
+                "Duplicate sale lines",
+                "Each sale line can only appear once in the request.",
+            )
+        sale_lines = self.env["folio.sale.line"].browse(sale_line_ids).exists()
+        missing = set(sale_line_ids) - set(sale_lines.ids)
+        if missing:
+            self._raise_problem(
+                404,
+                "/errors/sale-lines-not-found",
+                "Sale lines not found",
+                "Some sale lines could not be found.",
+                missingSaleLineIds=sorted(missing),
+            )
+        try:
+            sale_lines.check_access_rights("read")
+            sale_lines.check_access_rule("read")
+        except AccessError:
+            self._raise_problem(
+                403,
+                "/errors/access-denied",
+                "Access denied",
+                "You are not allowed to access some of the requested sale lines.",
+            )
+        invalid_kind = sale_lines.filtered(lambda r: r.display_type or r.is_downpayment)
+        if invalid_kind:
+            self._raise_problem(
+                422,
+                "/errors/invalid-sale-line",
+                "Invalid sale line",
+                "Sections, notes and down payments cannot be invoiced through "
+                "this endpoint.",
+                invalidSaleLineIds=invalid_kind.ids,
+            )
+        return sale_lines
+
+    def _resolve_property(self, sale_lines):
+        properties = sale_lines.mapped("pms_property_id")
+        if len(properties) > 1:
+            self._raise_problem(
+                422,
+                "/errors/multiple-properties",
+                "Sale lines from multiple properties",
+                "All sale lines must belong to the same property.",
+                propertyIds=properties.ids,
+            )
+        return properties
+
+    def _check_quantities(self, payload: FolioInvoiceCreate, sale_lines):
+        sale_lines_by_id = {sl.id: sl for sl in sale_lines}
+        qty_errors = []
+        for payload_line in payload.lines:
+            sale_line = sale_lines_by_id[payload_line.saleLineId]
+            if payload_line.quantityToInvoice > sale_line.qty_to_invoice:
+                qty_errors.append(
+                    {
+                        "saleLineId": sale_line.id,
+                        "requested": payload_line.quantityToInvoice,
+                        "pending": sale_line.qty_to_invoice,
+                    }
+                )
+        if qty_errors:
+            self._raise_problem(
+                422,
+                "/errors/quantity-exceeds-pending",
+                "Quantity to invoice exceeds pending quantity",
+                "One or more sale lines were asked to invoice a quantity "
+                "greater than their pending quantity.",
+                lines=qty_errors,
+            )
+
+    def _resolve_invoice_partner(self, payload: FolioInvoiceCreate, pms_property):
+        if payload.customerId is None:
+            return self.env.ref("pms.various_pms_partner")
+        partner = self.env["res.partner"].browse(payload.customerId).exists()
+        if not partner:
+            self._raise_problem(
+                404,
+                "/errors/not-found",
+                "Contact not found",
+                "Customer not found.",
+            )
+        invoice_helper = self.env["pms_api_invoice.invoice_router.helper"].new()
+        contact_errors = invoice_helper._get_contact_validation_errors(
+            partner, pms_property
+        )
+        if contact_errors:
+            self._raise_problem(
+                422,
+                "/errors/invoicing-validation-failed",
+                "Invoicing validation failed",
+                "Customer does not meet invoicing requirements.",
+                errors=contact_errors,
+            )
+        return partner
+
+    def _check_simplified_limit(
+        self, payload: FolioInvoiceCreate, sale_lines, pms_property
+    ):
+        limit = pms_property.max_amount_simplified_invoice
+        if not limit:
+            return
+        sale_lines_by_id = {sl.id: sl for sl in sale_lines}
+        invoice_total = sum(
+            line.quantityToInvoice
+            * sale_lines_by_id[line.saleLineId].price_reduce_taxinc
+            for line in payload.lines
+        )
+        if invoice_total > limit:
+            self._raise_problem(
+                422,
+                "/errors/simplified-invoice-limit-exceeded",
+                "Simplified invoice limit exceeded",
+                "The invoice total exceeds the simplified invoice limit "
+                "configured for this property.",
+                invoiceTotal=round(invoice_total, 2),
+                simplifiedInvoiceLimit=limit,
+            )
+
+    def _build_lines_to_invoice(self, payload: FolioInvoiceCreate, sale_lines) -> dict:
+        lines_to_invoice = {
+            line.saleLineId: line.quantityToInvoice for line in payload.lines
+        }
+        lines_with_sections = sale_lines
+        for line in sale_lines:
+            section = line.section_id
+            if section and section.id not in lines_with_sections.ids:
+                lines_with_sections |= section
+                lines_to_invoice[section.id] = 0
+        line_notes = sale_lines.folio_id.sale_line_ids.filtered(
+            lambda r: r.display_type == "line_note"
+            and r.section_id in lines_with_sections
+        )
+        for note in line_notes:
+            lines_to_invoice.setdefault(note.id, 0)
+        return lines_to_invoice
+
+    def _build_and_create_invoice(
+        self, payload: FolioInvoiceCreate, sale_lines, partner
+    ):
+        lines_to_invoice = self._build_lines_to_invoice(payload, sale_lines)
+        descriptions = {line.saleLineId: line.description for line in payload.lines}
+        folios = sale_lines.folio_id.with_context(
+            **{FOLIO_INVOICE_LINE_DESCRIPTIONS_CTX: descriptions}
+        )
+        try:
+            invoices = folios._create_invoices(
+                lines_to_invoice=lines_to_invoice,
+                partner_invoice_id=partner.id,
+                date=payload.invoiceDate,
+                final=True,
+            )
+        except UserError as e:
+            self._raise_problem(
+                422,
+                "/errors/invoice-creation-failed",
+                "Invoice creation failed",
+                str(e),
+            )
+        if not invoices:
+            self._raise_problem(
+                422,
+                "/errors/invoice-creation-failed",
+                "Invoice creation failed",
+                "No invoice could be created from the provided sale lines.",
+            )
+        if len(invoices) > 1:
+            self._raise_problem(
+                422,
+                "/errors/multiple-invoices-created",
+                "Multiple invoices created",
+                "The provided sale lines could not be grouped into a single "
+                "invoice (different currency or company).",
+                invoiceIds=invoices.ids,
+            )
+        return invoices
+
+    @staticmethod
+    def _override_invoice_due_date(invoice, payload: FolioInvoiceCreate):
+        if payload.dueDate and payload.dueDate != invoice.invoice_date_due:
+            invoice.write({"invoice_date_due": payload.dueDate})
+
+    def _post_invoice(self, invoice):
+        try:
+            invoice.action_post()
+        except UserError as e:
+            self._raise_problem(
+                422,
+                "/errors/invoice-posting-failed",
+                "Invoice posting failed",
+                str(e),
+            )
 
     # -- Folio report helpers --
 

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -383,19 +383,27 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
 
     def _create_invoice(self, payload: FolioInvoiceCreate):
         try:
-            sale_lines = self._resolve_sale_lines(payload)
-            downpayment_lines = self._resolve_downpayment_lines(payload, sale_lines)
-            pms_property = self._resolve_property(sale_lines)
-            self._check_quantities(payload, sale_lines)
-            partner = self._resolve_invoice_partner(payload, pms_property)
-            if payload.customerId is None:
-                self._check_simplified_limit(payload, sale_lines, pms_property)
-            invoice = self._build_and_create_invoice(
-                payload, sale_lines, downpayment_lines, partner
-            )
-            self._override_invoice_due_date(invoice, payload)
-            if payload.validate_invoice:
-                self._post_invoice(invoice)
+            # Wrap the whole attempt in a savepoint so a failure after the
+            # move has been inserted does not leave an orphan invoice behind.
+            # Odoo constraints (@api.constrains) run after the INSERT, so the
+            # move is already in the cursor when they raise; without this the
+            # caught error would be returned to the caller while the partial
+            # move gets committed. The flushing savepoint also clears the ORM
+            # cache on rollback, so the dispatcher's final flush is a no-op.
+            with self.env.cr.savepoint():
+                sale_lines = self._resolve_sale_lines(payload)
+                downpayment_lines = self._resolve_downpayment_lines(payload, sale_lines)
+                pms_property = self._resolve_property(sale_lines)
+                self._check_quantities(payload, sale_lines)
+                partner = self._resolve_invoice_partner(payload, pms_property)
+                if payload.customerId is None:
+                    self._check_simplified_limit(payload, sale_lines, pms_property)
+                invoice = self._build_and_create_invoice(
+                    payload, sale_lines, downpayment_lines, partner
+                )
+                self._override_invoice_due_date(invoice, payload)
+                if payload.validate_invoice:
+                    self._post_invoice(invoice)
         except _InvoiceCreationProblem as problem:
             return problem.response
         return InvoiceSummary.from_account_move(invoice)

--- a/pms_fastapi/routers/pms_reservation.py
+++ b/pms_fastapi/routers/pms_reservation.py
@@ -1,7 +1,7 @@
 from fastapi import Response
 from fastapi.responses import JSONResponse
 
-from odoo import fields, models
+from odoo import _, fields, models
 from odoo.exceptions import MissingError
 from odoo.osv import expression
 
@@ -132,9 +132,9 @@ class PmsApiReservationRouterHelper(models.AbstractModel):
             status_code=404,
             content={
                 "type": "/errors/reservation-not-found",
-                "title": "Reservation not found",
+                "title": _("Reservation not found"),
                 "status": 404,
-                "detail": f"Reservation {reservation_id} does not exist.",
+                "detail": _("Reservation %s does not exist.") % reservation_id,
                 "instance": f"/reservations/{reservation_id}/{action}",
             },
             media_type="application/problem+json",
@@ -169,12 +169,12 @@ class PmsApiReservationRouterHelper(models.AbstractModel):
                 status_code=409,
                 content={
                     "type": "/errors/reservation-state-invalid",
-                    "title": ("Reservation state does not allow reverting arrival"),
+                    "title": _("Reservation state does not allow reverting arrival"),
                     "status": 409,
-                    "detail": (
-                        f"Reservation {reservation_id} cannot revert "
-                        f"arrival in its current state."
-                    ),
+                    "detail": _(
+                        "Reservation %s cannot revert " "arrival in its current state."
+                    )
+                    % reservation_id,
                     "instance": f"/reservations/{reservation_id}/onboarding",
                 },
                 media_type="application/problem+json",
@@ -194,15 +194,15 @@ class PmsApiReservationRouterHelper(models.AbstractModel):
                 status_code=409,
                 content={
                     "type": "/errors/reservation-state-invalid",
-                    "title": (
+                    "title": _(
                         "Reservation state does not allow " "confirming departures"
                     ),
                     "status": 409,
-                    "detail": (
-                        f"Reservation {reservation_id} is in "
-                        f"'{reservation.state}' state and cannot be "
-                        f"confirmed as departed."
-                    ),
+                    "detail": _(
+                        "Reservation %s cannot be confirmed as departed in "
+                        "its current state."
+                    )
+                    % reservation_id,
                     "instance": (f"/reservations/{reservation_id}/offboarding"),
                 },
                 media_type="application/problem+json",

--- a/pms_fastapi/routers/user.py
+++ b/pms_fastapi/routers/user.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 from fastapi import File, HTTPException, UploadFile
 
-from odoo import api, models
+from odoo import _, api, models
 
 from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
@@ -42,12 +42,9 @@ async def update_user_image(
     image: Annotated[UploadFile, File(description="User image")],
 ):
     contents = await image.read()
-    if not contents:
-        raise HTTPException(
-            status_code=400,
-            detail="Empty image file uploaded. Use DELETE to remove image.",
-        )
     helper = env["pms_api.user_router.helper"].new()
+    if not contents:
+        helper._raise_empty_image()
     helper.update_user_image(env.user.id, base64.b64encode(contents))
     return User.from_res_users(env.user)
 
@@ -85,10 +82,15 @@ class PmsApiUserRouterHelper(models.AbstractModel):
             if vals["lang"] not in available_langs:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Language '{vals['lang']}' is not available."
-                    f" Choose from {available_langs}",
+                    detail=_("Language %s is not available.") % vals["lang"],
                 )
         return self.env["res.users"].sudo().browse(user_id).write(vals)
+
+    def _raise_empty_image(self):
+        raise HTTPException(
+            status_code=400,
+            detail=_("Empty image file uploaded. Use DELETE to remove image."),
+        )
 
     def update_user_image(self, user_id: int, image_data: bytes):
         user = self.env["res.users"].sudo().browse(user_id)

--- a/pms_fastapi/schemas/__init__.py
+++ b/pms_fastapi/schemas/__init__.py
@@ -26,4 +26,5 @@ from . import invoice
 from . import payment_method
 from . import payment
 from . import journal
+from . import cash_session
 from . import reservation_guest

--- a/pms_fastapi/schemas/__init__.py
+++ b/pms_fastapi/schemas/__init__.py
@@ -24,5 +24,6 @@ from . import pms_service
 from . import pms_room
 from . import invoice
 from . import payment_method
+from . import payment
 from . import journal
 from . import reservation_guest

--- a/pms_fastapi/schemas/__init__.py
+++ b/pms_fastapi/schemas/__init__.py
@@ -19,6 +19,7 @@ from . import supplier
 from . import guest
 from . import pms_reservation
 from . import pms_folio
+from . import folio_sale_line
 from . import pms_service
 from . import pms_room
 from . import invoice

--- a/pms_fastapi/schemas/cash_session.py
+++ b/pms_fastapi/schemas/cash_session.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+
+from pydantic import Field
+
+from .base import CurrencyAmount, PmsBaseModel
+from .currency import CurrencySummary
+from .journal import JournalSummary
+from .user import UserId
+
+
+class CashSessionOpenInput(PmsBaseModel):
+    journalId: int = Field(description="Cash journal to open the session on.")
+    baseAmount: CurrencyAmount = Field(
+        description="Declared opening cash balance. 0 is valid."
+    )
+
+
+class CashSessionCloseInput(PmsBaseModel):
+    countedCash: CurrencyAmount = Field(
+        description="Physically counted cash at close. 0 is valid."
+    )
+    note: str = Field("", description="Note left for the next shift.")
+
+
+def _currency_of(statement):
+    return statement.currency_id or statement.company_id.currency_id
+
+
+class CashSessionSummary(PmsBaseModel):
+    id: int
+    journal: JournalSummary
+    openedBy: UserId
+    openedAt: datetime
+    baseAmount: CurrencyAmount = 0.0
+    incomeAmount: CurrencyAmount = 0.0
+    refundAmount: CurrencyAmount = 0.0
+    expenseAmount: CurrencyAmount = 0.0
+    internalTransferAmount: CurrencyAmount = 0.0
+    expectedAmount: CurrencyAmount = 0.0
+    currency: CurrencySummary
+
+    @classmethod
+    def from_account_bank_statement(cls, statement):
+        breakdown = statement._pms_cash_session_breakdown()
+        currency = _currency_of(statement)
+        return cls(
+            _decimal_places=currency.decimal_places,
+            id=statement.id,
+            journal=JournalSummary.from_account_journal(statement.journal_id),
+            openedBy=UserId.from_res_users(statement.create_uid),
+            openedAt=statement.create_date,
+            baseAmount=statement.balance_start,
+            incomeAmount=breakdown["income"],
+            refundAmount=breakdown["refund"],
+            expenseAmount=breakdown["expense"],
+            internalTransferAmount=breakdown["internal_transfer"],
+            expectedAmount=breakdown["expected"],
+            currency=CurrencySummary.from_res_currency(currency),
+        )
+
+
+class CashClosing(PmsBaseModel):
+    id: int
+    journal: JournalSummary
+    openedBy: UserId
+    openedAt: datetime
+    closedBy: UserId
+    closedAt: datetime
+    baseAmount: CurrencyAmount = 0.0
+    incomeAmount: CurrencyAmount = 0.0
+    refundAmount: CurrencyAmount = 0.0
+    expenseAmount: CurrencyAmount = 0.0
+    internalTransferAmount: CurrencyAmount = 0.0
+    countedCash: CurrencyAmount = 0.0
+    expectedAmount: CurrencyAmount = 0.0
+    difference: CurrencyAmount = 0.0
+    closingAmount: CurrencyAmount = 0.0
+    note: str = ""
+    currency: CurrencySummary
+
+    @classmethod
+    def from_account_bank_statement(cls, statement):
+        breakdown = statement._pms_cash_session_breakdown()
+        currency = _currency_of(statement)
+        counted_cash = statement.balance_end_real
+        return cls(
+            _decimal_places=currency.decimal_places,
+            id=statement.id,
+            journal=JournalSummary.from_account_journal(statement.journal_id),
+            openedBy=UserId.from_res_users(statement.create_uid),
+            openedAt=statement.create_date,
+            closedBy=UserId.from_res_users(statement.cash_session_closed_uid),
+            closedAt=statement.cash_session_closed_date,
+            baseAmount=statement.balance_start,
+            incomeAmount=breakdown["income"],
+            refundAmount=breakdown["refund"],
+            expenseAmount=breakdown["expense"],
+            internalTransferAmount=breakdown["internal_transfer"],
+            countedCash=counted_cash,
+            expectedAmount=breakdown["expected"],
+            difference=counted_cash - breakdown["expected"],
+            closingAmount=counted_cash,
+            note=statement.cash_session_note or "",
+            currency=CurrencySummary.from_res_currency(currency),
+        )
+
+
+class CashLastClosing(PmsBaseModel):
+    closedBy: UserId
+    closedAt: datetime
+    closingAmount: CurrencyAmount = 0.0
+    note: str = ""
+    currency: CurrencySummary
+
+    @classmethod
+    def from_account_bank_statement(cls, statement):
+        currency = _currency_of(statement)
+        return cls(
+            _decimal_places=currency.decimal_places,
+            closedBy=UserId.from_res_users(statement.cash_session_closed_uid),
+            closedAt=statement.cash_session_closed_date,
+            closingAmount=statement.balance_end_real,
+            note=statement.cash_session_note or "",
+            currency=CurrencySummary.from_res_currency(currency),
+        )

--- a/pms_fastapi/schemas/cash_session.py
+++ b/pms_fastapi/schemas/cash_session.py
@@ -115,10 +115,15 @@ class CashLastClosing(PmsBaseModel):
     @classmethod
     def from_account_bank_statement(cls, statement):
         currency = _currency_of(statement)
+        # Legacy cash sessions may carry the closed flag without the closing
+        # user/date recorded; fall back to the write metadata so the required
+        # closedBy/closedAt never break the response.
+        closed_uid = statement.cash_session_closed_uid or statement.write_uid
+        closed_at = statement.cash_session_closed_date or statement.write_date
         return cls(
             _decimal_places=currency.decimal_places,
-            closedBy=UserId.from_res_users(statement.cash_session_closed_uid),
-            closedAt=statement.cash_session_closed_date,
+            closedBy=UserId.from_res_users(closed_uid),
+            closedAt=closed_at,
             closingAmount=statement.balance_end_real,
             note=statement.cash_session_note or "",
             currency=CurrencySummary.from_res_currency(currency),

--- a/pms_fastapi/schemas/contact.py
+++ b/pms_fastapi/schemas/contact.py
@@ -114,6 +114,16 @@ class ContactIdImage(ContactId):
         return cls(**record_dict)
 
 
+class ContactIdImageEmail(ContactIdImage):
+    email: str = ""
+
+    @classmethod
+    def from_res_partner(cls, partner):
+        record = super().from_res_partner(partner)
+        record.email = partner.email or ""
+        return record
+
+
 class ContactBase(PmsBaseModel):
     id: int
     name: str

--- a/pms_fastapi/schemas/folio_sale_line.py
+++ b/pms_fastapi/schemas/folio_sale_line.py
@@ -4,7 +4,7 @@ from pydantic import Field
 
 from .base import CurrencyAmount, PmsBaseModel
 from .currency import CurrencySummary
-from .pms_reservation import ReservationId
+from .pms_reservation import reservationSummary
 
 
 class saleLineTypeEnum(str, Enum):
@@ -44,7 +44,7 @@ class FolioSaleLine(PmsBaseModel):
     id: int
     lineType: saleLineTypeEnum
     description: str = Field("")
-    reservation: ReservationId | None = None
+    reservation: reservationSummary | None = None
     quantity: float
     quantityInvoiced: float = Field(0.0)
     priceUnit: float = Field(0.0)
@@ -109,7 +109,7 @@ class FolioSaleLine(PmsBaseModel):
                 "lineType": line_type,
                 "description": line.name or "",
                 "reservation": (
-                    ReservationId.from_pms_reservation(line.reservation_id)
+                    reservationSummary.from_pms_reservation(line.reservation_id)
                     if line.reservation_id
                     else None
                 ),

--- a/pms_fastapi/schemas/folio_sale_line.py
+++ b/pms_fastapi/schemas/folio_sale_line.py
@@ -1,0 +1,128 @@
+from enum import Enum
+
+from pydantic import Field
+
+from .base import CurrencyAmount, PmsBaseModel
+from .currency import CurrencySummary
+from .pms_reservation import ReservationId
+
+
+class saleLineTypeEnum(str, Enum):
+    ROOM = "room"
+    SERVICE = "service"
+
+
+class saleLineInvoiceStateEnum(str, Enum):
+    PENDING = "pending"
+    PARTIALLY_INVOICED = "partiallyInvoiced"
+    INVOICED = "invoiced"
+
+
+class SaleLineTax(PmsBaseModel):
+    id: int
+    name: str
+    base: float
+    amount: float
+
+    @classmethod
+    def from_tax_data(cls, tax_data: dict):
+        return cls(
+            id=tax_data["id"],
+            name=tax_data["name"],
+            base=round(tax_data["base"], 2),
+            amount=round(tax_data["amount"], 2),
+        )
+
+
+class SaleLineInvoice(PmsBaseModel):
+    id: int
+    name: str
+    quantityInvoiced: float
+
+
+class FolioSaleLine(PmsBaseModel):
+    id: int
+    lineType: saleLineTypeEnum
+    description: str = Field("")
+    reservation: ReservationId | None = None
+    quantity: float
+    quantityInvoiced: float = Field(0.0)
+    priceUnit: float = Field(0.0)
+    discount: float = Field(0.0)
+    taxes: list[SaleLineTax] = Field(default_factory=list)
+    subtotal: CurrencyAmount = Field(0.0)
+    taxAmount: CurrencyAmount = Field(0.0)
+    total: CurrencyAmount = Field(0.0)
+    currency: CurrencySummary
+    invoiceState: saleLineInvoiceStateEnum
+    invoices: list[SaleLineInvoice] = Field(default_factory=list)
+
+    @classmethod
+    def from_folio_sale_line(cls, line):
+        line_type = (
+            saleLineTypeEnum.SERVICE if line.service_id else saleLineTypeEnum.ROOM
+        )
+
+        taxes = []
+        if line.tax_ids and line.product_uom_qty:
+            taxes_data = line.tax_ids.compute_all(
+                price_unit=line.price_unit * (1.0 - line.discount / 100.0),
+                currency=line.currency_id,
+                quantity=line.product_uom_qty,
+            )
+            for tax_data in taxes_data["taxes"]:
+                taxes.append(SaleLineTax.from_tax_data(tax_data))
+
+        invoice_by_move = {}
+        for inv_line in line.invoice_lines:
+            move = inv_line.move_id
+            if move.state == "cancel":
+                continue
+            if move.id not in invoice_by_move:
+                invoice_by_move[move.id] = {"move": move, "qty": 0.0}
+            if move.move_type in ("out_invoice", "out_receipt"):
+                invoice_by_move[move.id]["qty"] += inv_line.quantity
+            elif move.move_type == "out_refund":
+                invoice_by_move[move.id]["qty"] -= inv_line.quantity
+        invoices = [
+            SaleLineInvoice(
+                id=entry["move"].id,
+                name=entry["move"].name,
+                quantityInvoiced=entry["qty"],
+            )
+            for entry in invoice_by_move.values()
+        ]
+
+        if line.invoice_status == "invoiced":
+            invoice_state = saleLineInvoiceStateEnum.INVOICED
+        elif line.invoice_status == "to_invoice" and line.qty_invoiced > 0:
+            invoice_state = saleLineInvoiceStateEnum.PARTIALLY_INVOICED
+        else:
+            invoice_state = saleLineInvoiceStateEnum.PENDING
+
+        decimal_places = line.currency_id.decimal_places if line.currency_id else 2
+
+        return cls(
+            **{
+                "_decimal_places": decimal_places,
+                "id": line.id,
+                "lineType": line_type,
+                "description": line.name or "",
+                "reservation": (
+                    ReservationId.from_pms_reservation(line.reservation_id)
+                    if line.reservation_id
+                    else None
+                ),
+                "quantity": line.product_uom_qty,
+                "quantityInvoiced": line.qty_invoiced,
+                "priceUnit": round(line.price_unit, 2),
+                "discount": line.discount or 0.0,
+                "taxes": taxes,
+                "subtotal": line.price_subtotal,
+                "taxAmount": line.price_tax,
+                "total": line.price_total,
+                "currency": CurrencySummary.from_res_currency(line.currency_id),
+                "invoiceState": invoice_state,
+                "invoices": invoices,
+            }
+        )

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -81,7 +81,7 @@ class FolioInvoiceCreate(PmsBaseModel):
     downpaymentLines: list[int] = Field(
         default_factory=list,
         description=(
-            "Ids of down-payment folio lines to subtract from the invoice. "
+            "Ids of down-payment invoices to subtract from the invoice. "
             "Must belong to the same folios as the invoiced lines. Send [] "
             "to subtract no down payment."
         ),
@@ -397,7 +397,7 @@ class InvoiceInput(PmsBaseModel):
     )
     downpaymentLines: list[int] = Field(
         description=(
-            "Ids of down-payment lines to subtract. Full replacement of the "
+            "Ids of down-payment invoices to subtract. Full replacement of the "
             "previous composition."
         ),
     )
@@ -503,8 +503,10 @@ class InvoiceDetail(PmsBaseModel):
         folio_lines = invoice_lines.mapped("folio_line_ids").filtered(
             lambda fl: not fl.is_downpayment
         )
-        downpayment_lines = invoice_lines.mapped("folio_line_ids").filtered(
-            "is_downpayment"
+        downpayment_invoices = (
+            invoice_lines.mapped("folio_line_ids")
+            .filtered("is_downpayment")
+            .invoice_lines.move_id
         )
         data["folioLines"] = [
             FolioLineDetail(
@@ -514,7 +516,7 @@ class InvoiceDetail(PmsBaseModel):
             )
             for fl in folio_lines
         ]
-        data["downpaymentLines"] = downpayment_lines.ids
+        data["downpaymentLines"] = downpayment_invoices.ids
         data["lines"] = [
             InvoiceLine.from_account_move_line(line) for line in invoice_lines
         ]

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -13,11 +13,71 @@ from .contact import ContactId
 from .currency import CurrencySummary
 from .journal import JournalSummary
 from .payment_method import PaymentMethodSummary
+from .payment_term import PaymentTermId
 from .pms_folio import FolioId
 
 
 class ShareUrl(PmsBaseModel):
     url: str
+
+
+class FolioInvoiceLine(PmsBaseModel):
+    saleLineId: int = Field(
+        alias="saleLineId",
+        description="ID of the folio sale line to invoice.",
+    )
+    description: str = Field(
+        description=(
+            "Final description for the invoice line. May differ from the "
+            "original sale line description."
+        ),
+    )
+    quantityToInvoice: float = Field(
+        alias="quantityToInvoice",
+        gt=0,
+        description=(
+            "Quantity to invoice for this line. Must be greater than 0 and "
+            "less than or equal to the pending quantity of the sale line."
+        ),
+    )
+
+
+class FolioInvoiceCreate(PmsBaseModel):
+    validate_invoice: bool = Field(
+        alias="validate",
+        description=(
+            "If true, the invoice is posted immediately after creation. "
+            "If false, it is created as a draft."
+        ),
+    )
+    customerId: int | None = Field(
+        None,
+        alias="customerId",
+        description=(
+            "Customer for the invoice. Null creates a simplified invoice. "
+            "Subject to simplifiedInvoiceLimit validation server-side."
+        ),
+    )
+    invoiceDate: date | None = Field(
+        None,
+        alias="invoiceDate",
+        description="Invoice date. Server defaults to today if null/omitted.",
+    )
+    dueDate: date | None = Field(
+        None,
+        alias="dueDate",
+        description=(
+            "Invoice due date. Server defaults from payment terms if null/omitted."
+        ),
+    )
+    lines: list[FolioInvoiceLine] = Field(
+        min_length=1,
+        description=(
+            "Sale lines to invoice. Must contain at least one line. All "
+            "lines must belong to the same property. Lines can reference "
+            "sale lines from different folios."
+        ),
+    )
 
 
 class InvoiceOrderField(str, Enum):
@@ -183,6 +243,179 @@ class InvoiceSummary(PmsBaseModel):
                 account_move.payment_state, InvoicePaymentStateEnum.not_paid
             )
         return cls(**data)
+
+
+class FolioLineInput(PmsBaseModel):
+    id: int = Field(description="Id of the folio line being invoiced.")
+    quantity: float = Field(
+        gt=0,
+        description="Quantity of this line to invoice.",
+    )
+    description: str = Field(
+        description="Final description for the line on the invoice. May be empty."
+    )
+
+
+class InvoiceInput(PmsBaseModel):
+    partner: int = Field(description="Customer id the invoice is issued to.")
+    invoiceDate: date | None = Field(
+        description="Invoice date. Null lets the server set the current date.",
+    )
+    invoiceDateDue: date | None = Field(
+        description="Due date. Null lets the server compute it from payment terms.",
+    )
+    narration: str = Field(description="Internal notes. May be empty.")
+    folioLines: list[FolioLineInput] = Field(
+        description=(
+            "Folio lines to invoice. Full replacement of the previous composition."
+        ),
+    )
+    downpaymentLines: list[int] = Field(
+        description=(
+            "Ids of down-payment lines to subtract. Full replacement of the "
+            "previous composition."
+        ),
+    )
+
+
+class FolioLineDetail(PmsBaseModel):
+    id: int
+    quantity: float
+    description: str = ""
+
+
+class InvoiceLine(PmsBaseModel):
+    id: int
+    description: str = ""
+    quantity: float
+    priceUnit: float = Field(0.0, alias="priceUnit")
+    discount: float = 0.0
+    priceSubtotal: float = Field(0.0, alias="priceSubtotal")
+    priceTotal: float = Field(0.0, alias="priceTotal")
+
+    @classmethod
+    def from_account_move_line(cls, line):
+        return cls(
+            id=line.id,
+            description=line.name or "",
+            quantity=line.quantity,
+            priceUnit=line.price_unit,
+            discount=line.discount,
+            priceSubtotal=line.price_subtotal,
+            priceTotal=line.price_total,
+        )
+
+
+class InvoiceRef(PmsBaseModel):
+    id: int
+    name: str
+
+    @classmethod
+    def from_account_move(cls, move):
+        return cls(id=move.id, name=move.name or "")
+
+
+class InvoiceDetail(PmsBaseModel):
+    id: int
+    name: str = ""
+    move_type: InvoiceTypeEnum = Field(alias="invoiceType")
+    state: InvoiceStateEnum
+    paymentState: InvoicePaymentStateEnum
+    partner_id: ContactId | None = Field(None, alias="partner")
+    invoice_date: date | None = Field(None, alias="invoiceDate")
+    invoice_date_due: date | None = Field(None, alias="invoiceDateDue")
+    paymentTerm: PaymentTermId | None = None
+    journal: JournalSummary | None = None
+    ref: str = Field("", alias="reference")
+    narration: str = ""
+    amount_total_signed: CurrencyAmount = Field(0.0, alias="totalAmount")
+    currency_id: CurrencySummary = Field(alias="currency")
+    folioLines: list[FolioLineDetail] = Field(default_factory=list)
+    downpaymentLines: list[int] = Field(default_factory=list)
+    lines: list[InvoiceLine] = Field(default_factory=list)
+    refundedInvoice: InvoiceRef | None = None
+    refundedBy: InvoiceRef | None = None
+    replaces: InvoiceRef | None = None
+    replacedBy: InvoiceRef | None = None
+
+    @classmethod
+    def from_account_move(cls, account_move):
+        data = cls._read_odoo_record(account_move)
+        data["move_type"] = ODOO_INVOICE_TYPE_REVERSE_MAP.get(account_move.move_type)
+        data["narration"] = account_move.narration or ""
+        data["ref"] = account_move.ref or ""
+        if account_move.partner_id:
+            data["partner_id"] = ContactId.from_res_partner(account_move.partner_id)
+        if account_move.currency_id:
+            data["_decimal_places"] = account_move.currency_id.decimal_places
+            data["currency_id"] = CurrencySummary.from_res_currency(
+                account_move.currency_id
+            )
+        if account_move.invoice_payment_term_id:
+            data["paymentTerm"] = PaymentTermId.from_account_payment_term(
+                account_move.invoice_payment_term_id
+            )
+        if account_move.journal_id:
+            data["journal"] = JournalSummary.from_account_journal(
+                account_move.journal_id
+            )
+        if account_move.has_overdue_payments:
+            data["paymentState"] = InvoicePaymentStateEnum.overdue
+        else:
+            data["paymentState"] = ODOO_PAYMENT_STATE_MAP.get(
+                account_move.payment_state, InvoicePaymentStateEnum.not_paid
+            )
+        invoice_lines = account_move.invoice_line_ids.filtered(
+            lambda line: not line.display_type
+        )
+        folio_lines = invoice_lines.mapped("folio_line_ids").filtered(
+            lambda fl: not fl.is_downpayment
+        )
+        downpayment_lines = invoice_lines.mapped("folio_line_ids").filtered(
+            "is_downpayment"
+        )
+        data["folioLines"] = [
+            FolioLineDetail(
+                id=fl.id,
+                quantity=cls._invoiced_quantity(fl, invoice_lines),
+                description=cls._invoiced_description(fl, invoice_lines),
+            )
+            for fl in folio_lines
+        ]
+        data["downpaymentLines"] = downpayment_lines.ids
+        data["lines"] = [
+            InvoiceLine.from_account_move_line(line) for line in invoice_lines
+        ]
+        if account_move.reversed_entry_id:
+            data["refundedInvoice"] = InvoiceRef.from_account_move(
+                account_move.reversed_entry_id
+            )
+        refund = account_move.reversal_move_id[:1]
+        if refund:
+            data["refundedBy"] = InvoiceRef.from_account_move(refund)
+        if account_move.replaces_invoice_id:
+            data["replaces"] = InvoiceRef.from_account_move(
+                account_move.replaces_invoice_id
+            )
+        replacement = account_move.replaced_by_invoice_ids[:1]
+        if replacement:
+            data["replacedBy"] = InvoiceRef.from_account_move(replacement)
+        return cls(**data)
+
+    @staticmethod
+    def _invoiced_quantity(folio_line, invoice_lines):
+        return sum(
+            line.quantity for line in invoice_lines if folio_line in line.folio_line_ids
+        )
+
+    @staticmethod
+    def _invoiced_description(folio_line, invoice_lines):
+        descriptions = [
+            line.name
+            for line in invoice_lines
+            if folio_line in line.folio_line_ids and line.name
+        ]
+        return descriptions[0] if descriptions else ""
 
 
 class InvoiceSearch(BaseSearch):

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -78,6 +78,14 @@ class FolioInvoiceCreate(PmsBaseModel):
             "sale lines from different folios."
         ),
     )
+    downpaymentLines: list[int] = Field(
+        default_factory=list,
+        description=(
+            "Ids of down-payment folio lines to subtract from the invoice. "
+            "Must belong to the same folios as the invoiced lines. Send [] "
+            "to subtract no down payment."
+        ),
+    )
 
 
 class InvoiceOrderField(str, Enum):

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -150,13 +150,24 @@ MOVE_TYPE_TO_PAYMENT_TYPE = {
 
 
 class InvoicePayment(PmsBaseModel):
+    id: str = Field(
+        description=(
+            "Composite identifier of the reconciliation entry in the form "
+            "'{type}_{id}'. Used as {reconciliation_id} when calling DELETE "
+            "/invoices/{invoice_id}/reconciliations/{reconciliation_id} "
+            "(only entries with paymentType='payment' can be removed manually)."
+        ),
+    )
     paymentType: InvoicePaymentTypeEnum = Field(alias="paymentType")
     paymentDate: date
     paymentMethod: PaymentMethodSummary | None = None
     journal: JournalSummary | None = None
+    paymentAmount: float = Field(0.0, alias="paymentAmount")
     amount: float = Field(0.0, alias="amount")
     currency_id: CurrencySummary = Field(alias="currency")
-    ref: str
+    paymentAmountCompany: float = Field(0.0, alias="paymentAmountCompany")
+    companyCurrency: CurrencySummary = Field(alias="companyCurrency")
+    ref: str = ""
 
     @classmethod
     def from_widget_item(cls, widget_item, env):
@@ -174,14 +185,46 @@ class InvoicePayment(PmsBaseModel):
                 counterpart_move.move_type, InvoicePaymentTypeEnum.entry
             )
 
+        partial = env["account.partial.reconcile"].browse(widget_item["partial_id"])
+        widget_currency = env["res.currency"].browse(widget_item["currency_id"])
+        company_currency = partial.company_currency_id
+        company = partial.company_id
+
+        if payment_id:
+            payment = env["account.payment"].browse(payment_id)
+            composite_id = f"payment_{payment.id}"
+            total_currency = payment.currency_id or company_currency
+            total_amount = payment.amount
+            total_date = payment.date
+        else:
+            composite_id = f"{payment_type.value}_{counterpart_move.id}"
+            total_currency = counterpart_move.currency_id or company_currency
+            total_amount = counterpart_move.amount_total
+            total_date = counterpart_move.invoice_date or counterpart_move.date
+
+        if total_currency == widget_currency:
+            payment_amount_widget = total_amount
+        else:
+            payment_amount_widget = total_currency._convert(
+                total_amount, widget_currency, company, total_date
+            )
+        if total_currency == company_currency:
+            payment_amount_company = total_amount
+        else:
+            payment_amount_company = total_currency._convert(
+                total_amount, company_currency, company, total_date
+            )
+
         data = {
+            "id": composite_id,
             "paymentType": payment_type,
             "paymentDate": widget_item["date"],
-            "amount": widget_item["amount"],
-            "ref": counterpart_move.name,
-            "currency_id": CurrencySummary.from_res_currency(
-                env["res.currency"].browse(widget_item["currency_id"])
-            ),
+            "paymentAmount": widget_currency.round(payment_amount_widget),
+            "amount": widget_currency.round(widget_item["amount"]),
+            "ref": counterpart_move.name or "",
+            "currency_id": CurrencySummary.from_res_currency(widget_currency),
+            "paymentAmountCompany": company_currency.round(payment_amount_company),
+            "companyCurrency": CurrencySummary.from_res_currency(company_currency),
         }
 
         if counterpart_move.journal_id:
@@ -198,6 +241,80 @@ class InvoicePayment(PmsBaseModel):
                     payment.payment_method_line_id
                 )
 
+        return cls(**data)
+
+
+class ReconciliationCreate(PmsBaseModel):
+    paymentId: str = Field(
+        alias="paymentId",
+        pattern=r"^payment_\d+$",
+        description=(
+            "Composite identifier of the reconcilable payment, in the form "
+            "'{type}_{id}'. Today only 'payment_{id}' is accepted. Obtained "
+            "from GET /invoices/{invoice_id}/reconcilable-payments."
+        ),
+    )
+
+
+class ReconcilablePayment(PmsBaseModel):
+    id: str = Field(
+        description=(
+            "Composite identifier '{type}_{id}'. Today only 'payment_{id}' "
+            "is returned. The type prefix is reserved so the contract can "
+            "grow to other reconcilable document types without breaking."
+        ),
+    )
+    paymentType: InvoicePaymentTypeEnum = Field(alias="paymentType")
+    paymentDate: date = Field(alias="paymentDate")
+    paymentMethod: PaymentMethodSummary | None = None
+    journal: JournalSummary | None = None
+    paymentAmount: float = Field(alias="paymentAmount")
+    availableAmount: float = Field(alias="availableAmount")
+    currency: CurrencySummary
+    paymentAmountCompany: float = Field(alias="paymentAmountCompany")
+    availableAmountCompany: float = Field(alias="availableAmountCompany")
+    companyCurrency: CurrencySummary = Field(alias="companyCurrency")
+    ref: str = ""
+
+    @classmethod
+    def from_account_payment(
+        cls,
+        payment,
+        available_currency: float,
+        available_company: float,
+    ):
+        company_currency = payment.company_id.currency_id
+        pay_currency = payment.currency_id or company_currency
+        payment_amount = payment.amount
+        if pay_currency == company_currency:
+            payment_amount_company = payment_amount
+        else:
+            payment_amount_company = pay_currency._convert(
+                payment_amount,
+                company_currency,
+                payment.company_id,
+                payment.date,
+            )
+        data = {
+            "id": f"payment_{payment.id}",
+            "paymentType": InvoicePaymentTypeEnum.payment,
+            "paymentDate": payment.date,
+            "paymentAmount": pay_currency.round(payment_amount),
+            "availableAmount": pay_currency.round(available_currency),
+            "currency": CurrencySummary.from_res_currency(pay_currency),
+            "paymentAmountCompany": company_currency.round(payment_amount_company),
+            "availableAmountCompany": company_currency.round(available_company),
+            "companyCurrency": CurrencySummary.from_res_currency(company_currency),
+            "ref": payment.ref or "",
+        }
+        if payment.journal_id:
+            data["journal"] = JournalSummary.from_account_journal(payment.journal_id)
+        if payment.payment_method_line_id:
+            data[
+                "paymentMethod"
+            ] = PaymentMethodSummary.from_account_payment_method_line(
+                payment.payment_method_line_id
+            )
         return cls(**data)
 
 
@@ -333,6 +450,7 @@ class InvoiceDetail(PmsBaseModel):
     folioLines: list[FolioLineDetail] = Field(default_factory=list)
     downpaymentLines: list[int] = Field(default_factory=list)
     lines: list[InvoiceLine] = Field(default_factory=list)
+    payments: list[InvoicePayment] = Field(default_factory=list)
     refundedInvoice: InvoiceRef | None = None
     refundedBy: InvoiceRef | None = None
     replaces: InvoiceRef | None = None
@@ -366,7 +484,7 @@ class InvoiceDetail(PmsBaseModel):
                 account_move.payment_state, InvoicePaymentStateEnum.not_paid
             )
         invoice_lines = account_move.invoice_line_ids.filtered(
-            lambda line: not line.display_type
+            lambda line: line.display_type == "product"
         )
         folio_lines = invoice_lines.mapped("folio_line_ids").filtered(
             lambda fl: not fl.is_downpayment
@@ -386,6 +504,11 @@ class InvoiceDetail(PmsBaseModel):
         data["lines"] = [
             InvoiceLine.from_account_move_line(line) for line in invoice_lines
         ]
+        if account_move.invoice_payments_widget:
+            data["payments"] = [
+                InvoicePayment.from_widget_item(item, account_move.env)
+                for item in account_move.invoice_payments_widget["content"]
+            ]
         if account_move.reversed_entry_id:
             data["refundedInvoice"] = InvoiceRef.from_account_move(
                 account_move.reversed_entry_id

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -134,7 +134,7 @@ class InvoicePaymentStateEnum(str, Enum):
 
 ODOO_PAYMENT_STATE_MAP = {
     "not_paid": InvoicePaymentStateEnum.not_paid,
-    "in_payment": InvoicePaymentStateEnum.not_paid,
+    "in_payment": InvoicePaymentStateEnum.paid,
     "paid": InvoicePaymentStateEnum.paid,
     "partial": InvoicePaymentStateEnum.partial,
     "reversed": InvoicePaymentStateEnum.reversed,

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -70,6 +70,7 @@ class FolioInvoiceCreate(PmsBaseModel):
             "Invoice due date. Server defaults from payment terms if null/omitted."
         ),
     )
+    narration: str = Field(description="Internal notes. May be empty.")
     lines: list[FolioInvoiceLine] = Field(
         min_length=1,
         description=(

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -417,6 +417,11 @@ class InvoiceLine(PmsBaseModel):
     discount: float = 0.0
     priceSubtotal: float = Field(0.0, alias="priceSubtotal")
     priceTotal: float = Field(0.0, alias="priceTotal")
+    folioLineIds: list[int] = Field(
+        default_factory=list,
+        alias="folioLineIds",
+        description="Ids of the folio sale lines this invoice line was billed from.",
+    )
 
     @classmethod
     def from_account_move_line(cls, line):
@@ -428,6 +433,7 @@ class InvoiceLine(PmsBaseModel):
             discount=line.discount,
             priceSubtotal=line.price_subtotal,
             priceTotal=line.price_total,
+            folioLineIds=line.folio_line_ids.ids,
         )
 
 

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -70,7 +70,7 @@ class FolioInvoiceCreate(PmsBaseModel):
             "Invoice due date. Server defaults from payment terms if null/omitted."
         ),
     )
-    narration: str = Field(description="Internal notes. May be empty.")
+    narration: str = Field("", description="Internal notes. Optional on create.")
     lines: list[FolioInvoiceLine] = Field(
         min_length=1,
         description=(

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -1,3 +1,4 @@
+import datetime
 from datetime import date
 from enum import Enum
 from typing import Annotated
@@ -75,6 +76,25 @@ class PaymentInput(PmsBaseModel):
         None, description="Invoice context. Mutually exclusive with folioId."
     )
     reference: str = ""
+
+
+class PaymentUpdate(PmsBaseModel):
+    """Partial edit of a registered payment (amount, date, payment method).
+
+    Only the modified fields are sent; omitted fields are left untouched.
+    """
+
+    amount: CurrencyAmount | None = Field(
+        None, gt=0, description="New amount. Always positive; > 0 (422 otherwise)."
+    )
+    # `datetime.date` (not the bare `date` name) to avoid the field name
+    # shadowing the type when the default value is assigned.
+    date: datetime.date | None = Field(None, description="New payment date.")
+    paymentMethodId: int | None = Field(
+        None,
+        description="New payment method (the front's 'payment mode'). The journal "
+        "is derived from it.",
+    )
 
 
 class InternalTransferInput(PmsBaseModel):

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -100,8 +100,14 @@ class PaymentUpdate(PmsBaseModel):
 class InternalTransferInput(PmsBaseModel):
     amount: CurrencyAmount = Field(gt=0, description="Always positive; > 0.")
     date: date
-    originJournalId: int = Field(description="Journal the money leaves from.")
-    destinationJournalId: int = Field(description="Journal the money goes to.")
+    originPaymentMethodId: int = Field(
+        description="account.payment.method.line id (outbound) the money leaves "
+        "from. The origin journal is derived from it."
+    )
+    destinationPaymentMethodId: int = Field(
+        description="account.payment.method.line id (inbound) the money goes to. "
+        "The destination journal is derived from it."
+    )
     reason: str = ""
 
 

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -44,6 +44,47 @@ _TRANSACTION_TYPE_TO_FIELDS = {
 }
 
 
+class PaymentCreateType(str, Enum):
+    """Payment types accepted on manual creation via POST /payments.
+
+    Refunds and internal transfers are NOT created here (transfers have their
+    own endpoint); the response enum (PaymentTypeEnum) still returns all five.
+    """
+
+    customerPayment = "customerPayment"
+    supplierPayment = "supplierPayment"
+
+
+class PaymentInput(PmsBaseModel):
+    paymentType: PaymentCreateType
+    amount: CurrencyAmount = Field(gt=0, description="Always positive; > 0.")
+    date: date
+    paymentMethodId: int = Field(
+        description="account.payment.method.line id (the front's 'payment mode'). "
+        "The journal is derived from it."
+    )
+    partnerId: int | None = Field(
+        None,
+        description="Required for supplierPayment; for customerPayment may be "
+        "null and derived from the folio/invoice context.",
+    )
+    folioId: int | None = Field(
+        None, description="Folio context. Mutually exclusive with invoiceId."
+    )
+    invoiceId: int | None = Field(
+        None, description="Invoice context. Mutually exclusive with folioId."
+    )
+    reference: str = ""
+
+
+class InternalTransferInput(PmsBaseModel):
+    amount: CurrencyAmount = Field(gt=0, description="Always positive; > 0.")
+    date: date
+    originJournalId: int = Field(description="Journal the money leaves from.")
+    destinationJournalId: int = Field(description="Journal the money goes to.")
+    reason: str = ""
+
+
 class PaymentOrderField(str, Enum):
     date = "date"
 
@@ -79,7 +120,9 @@ class PaymentSummary(PmsBaseModel):
         currency = payment.currency_id or payment.company_id.currency_id
         data["_decimal_places"] = currency.decimal_places
         data["currency"] = CurrencySummary.from_res_currency(currency)
-        if payment.partner_id:
+        # Internal transfers carry the company partner internally (accounting),
+        # but the contract reports no contact for them ('Sin asignar').
+        if payment.partner_id and not payment.is_internal_transfer:
             data["partner_id"] = ContactId.from_res_partner(payment.partner_id)
         if payment.folio_ids:
             data["folio"] = FolioId.from_pms_folio(payment.folio_ids[:1])

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -105,6 +105,11 @@ class InternalTransferInput(PmsBaseModel):
     reason: str = ""
 
 
+class ReportFormatEnum(str, Enum):
+    pdf = "pdf"
+    xlsx = "xlsx"
+
+
 class PaymentOrderField(str, Enum):
     date = "date"
 

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -201,6 +201,10 @@ class PaymentSearch(BaseSearch):
             default=None,
             description="Filter exclusively by reference.",
         ),
+        contact: str | None = Query(
+            default=None,
+            description="Filter by the name of the contact (partner) of the payment.",
+        ),
         createdBy: str | None = Query(
             default=None,
             description="Filter by the name of the user who registered the payment.",
@@ -236,6 +240,7 @@ class PaymentSearch(BaseSearch):
         self.paymentType = paymentType
         self.paymentMethod = paymentMethod
         self.reference = reference
+        self.contact = contact
         self.createdBy = createdBy
         self.amountEq = amountEq
         self.amountGt = amountGt
@@ -306,6 +311,10 @@ class PaymentSearch(BaseSearch):
             )
         if self.reference:
             domain = expression.AND([domain, [("ref", "ilike", self.reference)]])
+        if self.contact:
+            domain = expression.AND(
+                [domain, [("partner_id.display_name", "ilike", self.contact)]]
+            )
         if self.createdBy:
             domain = expression.AND(
                 [domain, [("create_uid.name", "ilike", self.createdBy)]]

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -125,6 +125,35 @@ PAYMENT_ORDER_MAPPING = {
 }
 
 
+class ReconciledInvoiceTypeEnum(str, Enum):
+    outInvoice = "outInvoice"
+    outRefund = "outRefund"
+    inInvoice = "inInvoice"
+    inRefund = "inRefund"
+
+
+ODOO_MOVE_TYPE_TO_RECONCILED_ENUM = {
+    "out_invoice": ReconciledInvoiceTypeEnum.outInvoice,
+    "out_refund": ReconciledInvoiceTypeEnum.outRefund,
+    "in_invoice": ReconciledInvoiceTypeEnum.inInvoice,
+    "in_refund": ReconciledInvoiceTypeEnum.inRefund,
+}
+
+
+class ReconciledInvoice(PmsBaseModel):
+    id: int
+    name: str = ""
+    move_type: ReconciledInvoiceTypeEnum = Field(alias="invoiceType")
+
+    @classmethod
+    def from_account_move(cls, move):
+        return cls(
+            id=move.id,
+            name=move.name or "",
+            move_type=ODOO_MOVE_TYPE_TO_RECONCILED_ENUM[move.move_type],
+        )
+
+
 class PaymentSummary(PmsBaseModel):
     id: int
     name: str = ""
@@ -137,6 +166,10 @@ class PaymentSummary(PmsBaseModel):
     paymentMethod: PaymentMethodSummary | None = None
     amount: CurrencyAmount = 0.0
     currency: CurrencySummary
+    invoices: list[ReconciledInvoice] = Field(
+        default_factory=list,
+        description="Invoices and refunds this payment is reconciled against.",
+    )
 
     @classmethod
     def from_account_payment(cls, payment):
@@ -165,6 +198,14 @@ class PaymentSummary(PmsBaseModel):
             ] = PaymentMethodSummary.from_account_payment_method_line(
                 payment.payment_method_line_id
             )
+        reconciled_invoices = (
+            payment.reconciled_invoice_ids | payment.reconciled_bill_ids
+        )
+        if reconciled_invoices:
+            data["invoices"] = [
+                ReconciledInvoice.from_account_move(move)
+                for move in reconciled_invoices
+            ]
         return cls(**data)
 
 

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -1,0 +1,256 @@
+from datetime import date
+from enum import Enum
+from typing import Annotated
+
+from fastapi import HTTPException, Query
+from pydantic import Field
+
+from odoo import api
+from odoo.osv import expression
+
+from .base import BaseSearch, CurrencyAmount, PmsBaseModel
+from .contact import ContactId
+from .currency import CurrencySummary
+from .payment_method import PaymentMethodSummary
+from .pms_folio import FolioId
+from .user import UserId
+
+
+class PaymentTypeEnum(str, Enum):
+    customerPayment = "customerPayment"
+    customerRefund = "customerRefund"
+    supplierPayment = "supplierPayment"
+    supplierRefund = "supplierRefund"
+    internalTransfer = "internalTransfer"
+
+
+# Maps the API payment type to the internal `pms_api_transaction_type`
+# computed on account.payment (see pms_api_rest/models/account_payment.py).
+ENUM_TO_TRANSACTION_TYPE = {
+    PaymentTypeEnum.customerPayment: "customer_inbound",
+    PaymentTypeEnum.customerRefund: "customer_outbound",
+    PaymentTypeEnum.supplierPayment: "supplier_outbound",
+    PaymentTypeEnum.supplierRefund: "supplier_inbound",
+    PaymentTypeEnum.internalTransfer: "internal_transfer",
+}
+TRANSACTION_TYPE_TO_ENUM = {v: k for k, v in ENUM_TO_TRANSACTION_TYPE.items()}
+
+# (payment_type, partner_type) for the non-transfer transaction types.
+_TRANSACTION_TYPE_TO_FIELDS = {
+    "customer_inbound": ("inbound", "customer"),
+    "customer_outbound": ("outbound", "customer"),
+    "supplier_outbound": ("outbound", "supplier"),
+    "supplier_inbound": ("inbound", "supplier"),
+}
+
+
+class PaymentOrderField(str, Enum):
+    date = "date"
+
+
+PAYMENT_ORDER_MAPPING = {
+    "date": "date",
+}
+
+
+class PaymentSummary(PmsBaseModel):
+    id: int
+    name: str = ""
+    date: date
+    partner_id: ContactId | None = Field(None, alias="partner")
+    ref: str = Field("", alias="reference")
+    folio: FolioId | None = None
+    createdBy: UserId | None = None
+    paymentType: PaymentTypeEnum
+    paymentMethod: PaymentMethodSummary | None = None
+    amount: CurrencyAmount = 0.0
+    currency: CurrencySummary
+
+    @classmethod
+    def from_account_payment(cls, payment):
+        data = {
+            "id": payment.id,
+            "name": payment.name or "",
+            "date": payment.date,
+            "ref": payment.ref or "",
+            "paymentType": TRANSACTION_TYPE_TO_ENUM[payment.pms_api_transaction_type],
+            "amount": abs(payment.amount),
+        }
+        currency = payment.currency_id or payment.company_id.currency_id
+        data["_decimal_places"] = currency.decimal_places
+        data["currency"] = CurrencySummary.from_res_currency(currency)
+        if payment.partner_id:
+            data["partner_id"] = ContactId.from_res_partner(payment.partner_id)
+        if payment.folio_ids:
+            data["folio"] = FolioId.from_pms_folio(payment.folio_ids[:1])
+        if payment.create_uid:
+            data["createdBy"] = UserId.from_res_users(payment.create_uid)
+        if payment.payment_method_line_id:
+            data[
+                "paymentMethod"
+            ] = PaymentMethodSummary.from_account_payment_method_line(
+                payment.payment_method_line_id
+            )
+        return cls(**data)
+
+
+class PaymentSearch(BaseSearch):
+    def __init__(
+        self,
+        pmsPropertyId: int | None = Query(
+            default=None,
+            description="Filter payments of the given property. Defaults to the "
+            "active property of the session.",
+        ),
+        globalSearch: str | None = Query(
+            default=None,
+            description="Free-text search across reference, contact and created by.",
+        ),
+        dateFrom: Annotated[
+            date | None,
+            Query(
+                description="Start of the payment date range "
+                "(only applies if dateTo is also set).",
+            ),
+        ] = None,
+        dateTo: Annotated[
+            date | None,
+            Query(
+                description="End of the payment date range "
+                "(only applies if dateFrom is also set).",
+            ),
+        ] = None,
+        paymentType: Annotated[
+            list[PaymentTypeEnum] | None,
+            Query(
+                description="Filter by payment type. Use repeated query parameters, "
+                "e.g., ?paymentType=customerPayment&paymentType=supplierPayment",
+            ),
+        ] = None,
+        paymentMethod: Annotated[
+            list[int] | None,
+            Query(
+                description="Filter by payment method id. Use repeated query "
+                "parameters, e.g., ?paymentMethod=3&paymentMethod=9",
+            ),
+        ] = None,
+        reference: str | None = Query(
+            default=None,
+            description="Filter exclusively by reference.",
+        ),
+        createdBy: str | None = Query(
+            default=None,
+            description="Filter by the name of the user who registered the payment.",
+        ),
+        amountEq: Annotated[
+            float | None,
+            Query(ge=0, description="Filter payments whose amount equals this value."),
+        ] = None,
+        amountGt: Annotated[
+            float | None,
+            Query(
+                ge=0,
+                description="Filter payments whose amount is greater than this value.",
+            ),
+        ] = None,
+        amountLt: Annotated[
+            float | None,
+            Query(
+                ge=0,
+                description="Filter payments whose amount is less than this value.",
+            ),
+        ] = None,
+    ):
+        if dateFrom and dateTo and dateTo < dateFrom:
+            raise HTTPException(
+                status_code=422,
+                detail="dateTo cannot be earlier than dateFrom.",
+            )
+        self.pmsPropertyId = pmsPropertyId
+        self.globalSearch = globalSearch
+        self.dateFrom = dateFrom
+        self.dateTo = dateTo
+        self.paymentType = paymentType
+        self.paymentMethod = paymentMethod
+        self.reference = reference
+        self.createdBy = createdBy
+        self.amountEq = amountEq
+        self.amountGt = amountGt
+        self.amountLt = amountLt
+
+    def _property_journal_ids(self, env: api.Environment) -> list:
+        if self.pmsPropertyId:
+            properties = env["pms.property"].sudo().browse(self.pmsPropertyId)
+            PmsBaseModel.pms_api_check_access(env.user, properties)
+        else:
+            properties = env.user.pms_property_id or env.user.pms_property_ids
+        journals = env["account.journal"]
+        for prop in properties:
+            journals |= prop._get_payment_methods(automatic_included=True).journal_id
+        # Avoid exposing generic company journals not tied to any property.
+        journals = journals.sudo().filtered(lambda j: j.pms_property_ids)
+        return journals.ids
+
+    def _payment_type_domain(self) -> list:
+        type_domains = []
+        for pt in self.paymentType:
+            transaction_type = ENUM_TO_TRANSACTION_TYPE[pt]
+            if transaction_type == "internal_transfer":
+                type_domains.append([("is_internal_transfer", "=", True)])
+            else:
+                payment_type, partner_type = _TRANSACTION_TYPE_TO_FIELDS[
+                    transaction_type
+                ]
+                type_domains.append(
+                    [
+                        ("is_internal_transfer", "=", False),
+                        ("partner_type", "=", partner_type),
+                        ("payment_type", "=", payment_type),
+                    ]
+                )
+        return expression.OR(type_domains)
+
+    def to_odoo_domain(self, env: api.Environment) -> list:
+        domain = [("journal_id", "in", self._property_journal_ids(env))]
+        if self.globalSearch:
+            domain = expression.AND(
+                [
+                    domain,
+                    [
+                        "|",
+                        "|",
+                        ("ref", "ilike", self.globalSearch),
+                        ("partner_id.display_name", "ilike", self.globalSearch),
+                        ("create_uid.name", "ilike", self.globalSearch),
+                    ],
+                ]
+            )
+        if self.dateFrom and self.dateTo:
+            domain = expression.AND(
+                [
+                    domain,
+                    [
+                        ("date", ">=", self.dateFrom),
+                        ("date", "<=", self.dateTo),
+                    ],
+                ]
+            )
+        if self.paymentType:
+            domain = expression.AND([domain, self._payment_type_domain()])
+        if self.paymentMethod:
+            domain = expression.AND(
+                [domain, [("payment_method_line_id", "in", self.paymentMethod)]]
+            )
+        if self.reference:
+            domain = expression.AND([domain, [("ref", "ilike", self.reference)]])
+        if self.createdBy:
+            domain = expression.AND(
+                [domain, [("create_uid.name", "ilike", self.createdBy)]]
+            )
+        if self.amountEq is not None:
+            domain = expression.AND([domain, [("amount", "=", self.amountEq)]])
+        if self.amountGt is not None:
+            domain = expression.AND([domain, [("amount", ">", self.amountGt)]])
+        if self.amountLt is not None:
+            domain = expression.AND([domain, [("amount", "<", self.amountLt)]])
+        return domain

--- a/pms_fastapi/schemas/payment.py
+++ b/pms_fastapi/schemas/payment.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from odoo import api
 from odoo.osv import expression
 
-from .base import BaseSearch, CurrencyAmount, PmsBaseModel
+from .base import BaseSearch, CurrencyAmount, PmsBaseModel, SearchText
 from .contact import ContactId
 from .currency import CurrencySummary
 from .payment_method import PaymentMethodSummary
@@ -217,10 +217,13 @@ class PaymentSearch(BaseSearch):
             description="Filter payments of the given property. Defaults to the "
             "active property of the session.",
         ),
-        globalSearch: str | None = Query(
-            default=None,
-            description="Free-text search across reference, contact and created by.",
-        ),
+        globalSearch: Annotated[
+            SearchText,
+            Query(
+                description="Free-text search across reference, contact "
+                "and created by.",
+            ),
+        ] = None,
         dateFrom: Annotated[
             date | None,
             Query(
@@ -249,18 +252,26 @@ class PaymentSearch(BaseSearch):
                 "parameters, e.g., ?paymentMethod=3&paymentMethod=9",
             ),
         ] = None,
-        reference: str | None = Query(
-            default=None,
-            description="Filter exclusively by reference.",
-        ),
-        contact: str | None = Query(
-            default=None,
-            description="Filter by the name of the contact (partner) of the payment.",
-        ),
-        createdBy: str | None = Query(
-            default=None,
-            description="Filter by the name of the user who registered the payment.",
-        ),
+        reference: Annotated[
+            SearchText,
+            Query(
+                description="Filter exclusively by reference.",
+            ),
+        ] = None,
+        contact: Annotated[
+            SearchText,
+            Query(
+                description="Filter by the name of the contact (partner) "
+                "of the payment.",
+            ),
+        ] = None,
+        createdBy: Annotated[
+            SearchText,
+            Query(
+                description="Filter by the name of the user who registered "
+                "the payment.",
+            ),
+        ] = None,
         amountEq: Annotated[
             float | None,
             Query(ge=0, description="Filter payments whose amount equals this value."),

--- a/pms_fastapi/schemas/payment_method.py
+++ b/pms_fastapi/schemas/payment_method.py
@@ -1,15 +1,23 @@
+from enum import Enum
+
 from pydantic import Field
 
 from .base import PmsBaseModel
 
 
+class PaymentMethodTypeEnum(str, Enum):
+    inbound = "inbound"
+    outbound = "outbound"
+
+
 class PaymentMethodSummary(PmsBaseModel):
     id: int
     name: str = Field(alias="name")
+    type: PaymentMethodTypeEnum = Field(alias="type")
 
     @classmethod
     def from_account_payment_method_line(cls, account_payment_method_line):
         line = account_payment_method_line
         name = f"{line.journal_id.name} - {line.name}"
-        data = {"id": line.id, "name": name}
+        data = {"id": line.id, "name": name, "type": line.payment_type}
         return cls(**data)

--- a/pms_fastapi/schemas/pms_folio.py
+++ b/pms_fastapi/schemas/pms_folio.py
@@ -145,7 +145,7 @@ class FolioSummary(PmsBaseModel):
         )
 
         # Invoice state
-        if folio.invoice_status in ("to_invoice", "to_confirm"):
+        if folio.invoice_status == "to_invoice":
             filtered_data["invoiceState"] = invoiceStateEnum.TO_INVOICE
         else:
             filtered_data["invoiceState"] = invoiceStateEnum.INVOICED

--- a/pms_fastapi/schemas/pms_folio.py
+++ b/pms_fastapi/schemas/pms_folio.py
@@ -9,14 +9,12 @@ from pydantic import Field, field_validator
 from odoo import api
 from odoo.osv import expression
 
-from .agency import AgencyIdImage
 from .base import BaseSearch, CurrencyAmount, PmsBaseModel, SearchText
 from .contact import ContactId, ContactIdImage
 from .country import CountrySummary
 from .currency import CurrencySummary
+from .pms_reservation import reservationStateEnum, reservationSummary
 from .pms_room import RoomId
-from .pms_sale_channel import SaleChannelDetail
-from .pms_service import ServiceId
 from .reservation_guest import CheckinStateEnum
 
 
@@ -40,17 +38,6 @@ FOLIO_ORDER_MAPPING = {
 }
 
 
-class reservationStateEnum(str, Enum):
-    DRAFT = "draft"
-    ARRIVAL = "arrival"
-    IN_HOUSE = "inHouse"
-    COMPLETED = "completed"
-    CANCELLED = "cancelled"
-    NO_SHOW = "noShow"
-    OVERBOOKING = "overbooking"
-    RESELLING = "reselling"
-
-
 class folioPaymentStateEnum(str, Enum):
     PAID = "paid"
     NOT_PAID = "notPaid"
@@ -66,83 +53,6 @@ preCheckinStateEnum = CheckinStateEnum
 class invoiceStateEnum(str, Enum):
     TO_INVOICE = "toInvoice"
     INVOICED = "invoiced"
-
-
-class reservationSummary(PmsBaseModel):
-    id: int
-    name: str
-    splitted: bool = Field(False, alias="isSplitted")
-    partner_internal_comment: str = Field("", alias="notes")
-    checkin_datetime: datetime | None = Field(None, alias="checkinDate")
-    checkout_datetime: datetime | None = Field(None, alias="checkoutDate")
-    adults: int = Field(0)
-    children: int = Field(0)
-    nights: int = Field(0)
-    to_assign: bool = Field(False, alias="toAssign")
-    rooms: list[RoomId]
-    services: list[ServiceId]
-    saleChannel: SaleChannelDetail | None = None
-    agency: AgencyIdImage | None = None
-    state: reservationStateEnum
-    price_room_services_set: CurrencyAmount = Field(0.0, alias="totalAmount")
-    currency: CurrencySummary | None = None
-    incompleteCheckinsCount: int = Field(0)
-    completeCheckinsCount: int = Field(0)
-
-    @classmethod
-    def from_pms_reservation(cls, reservation):
-        filtered_data = cls._read_odoo_record(reservation)
-        filtered_data["rooms"] = [
-            RoomId.from_pms_room(room)
-            for room in reservation.reservation_line_ids.mapped("room_id")
-        ]
-        filtered_data["services"] = [
-            ServiceId.from_pms_service(service) for service in reservation.service_ids
-        ]
-        if reservation.currency_id:
-            filtered_data["_decimal_places"] = reservation.currency_id.decimal_places
-            filtered_data["currency"] = CurrencySummary.from_res_currency(
-                reservation.currency_id
-            )
-        if reservation.sale_channel_origin_id:
-            filtered_data["saleChannel"] = SaleChannelDetail.from_pms_sale_channel(
-                reservation.sale_channel_origin_id
-            )
-        if reservation.agency_id:
-            filtered_data["agency"] = AgencyIdImage.from_res_partner(
-                reservation.agency_id
-            )
-        if reservation.overbooking and reservation.state != "cancel":
-            filtered_data["state"] = reservationStateEnum.OVERBOOKING
-        elif (
-            reservation.is_reselling
-            or any(reservation.reservation_line_ids.mapped("is_reselling"))
-        ) and reservation.state != "cancel":
-            filtered_data["state"] = reservationStateEnum.RESELLING
-        elif reservation.state == "draft":
-            filtered_data["state"] = reservationStateEnum.DRAFT
-        elif reservation.state == "cancel":
-            if reservation.cancelled_reason == "noshow":
-                filtered_data["state"] = reservationStateEnum.NO_SHOW
-            else:
-                filtered_data["state"] = reservationStateEnum.CANCELLED
-        elif reservation.state in ("confirm", "arrival_delayed"):
-            filtered_data["state"] = reservationStateEnum.ARRIVAL
-        elif reservation.state in ("onboard", "departure_delayed"):
-            filtered_data["state"] = reservationStateEnum.IN_HOUSE
-        elif reservation.state == "done":
-            filtered_data["state"] = reservationStateEnum.COMPLETED
-
-        checkin_partners = reservation.checkin_partner_ids
-        filtered_data["incompleteCheckinsCount"] = len(
-            checkin_partners.filtered(lambda c: c.state in ("dummy", "draft"))
-        )
-        filtered_data["completeCheckinsCount"] = len(
-            checkin_partners.filtered(
-                lambda c: c.state in ("precheckin", "onboard", "done")
-            )
-        )
-        return cls(**filtered_data)
 
 
 class FolioId(PmsBaseModel):

--- a/pms_fastapi/schemas/pms_folio.py
+++ b/pms_fastapi/schemas/pms_folio.py
@@ -11,7 +11,7 @@ from odoo.osv import expression
 
 from .agency import AgencyIdImage
 from .base import BaseSearch, CurrencyAmount, PmsBaseModel, SearchText
-from .contact import ContactIdImage
+from .contact import ContactId, ContactIdImage
 from .country import CountrySummary
 from .currency import CurrencySummary
 from .pms_room import RoomId
@@ -248,6 +248,117 @@ class FolioSummary(PmsBaseModel):
             ContactIdImage.from_res_partner(partner) for partner in payer_partners
         ]
 
+        return cls(**filtered_data)
+
+
+class FolioReservation(PmsBaseModel):
+    id: int
+    name: str = Field("", alias="name")
+    checkin_datetime: datetime | None = Field(None, alias="checkinDate")
+    checkout_datetime: datetime | None = Field(None, alias="checkoutDate")
+    rooms: list[RoomId] = Field(default_factory=list)
+    state: reservationStateEnum
+    saleLineIds: list[int] = Field(default_factory=list)
+
+    @classmethod
+    def from_pms_reservation(cls, reservation):
+        filtered_data = cls._read_odoo_record(reservation)
+        filtered_data["rooms"] = [
+            RoomId.from_pms_room(room)
+            for room in reservation.reservation_line_ids.mapped("room_id")
+        ]
+        if reservation.overbooking and reservation.state != "cancel":
+            filtered_data["state"] = reservationStateEnum.OVERBOOKING
+        elif reservation.state == "draft":
+            filtered_data["state"] = reservationStateEnum.DRAFT
+        elif reservation.state == "cancel":
+            filtered_data["state"] = reservationStateEnum.CANCELLED
+        elif reservation.state in ("confirm", "arrival_delayed"):
+            filtered_data["state"] = reservationStateEnum.ARRIVAL
+        elif reservation.state in ("onboard", "departure_delayed"):
+            filtered_data["state"] = reservationStateEnum.IN_HOUSE
+        elif reservation.state == "done":
+            filtered_data["state"] = reservationStateEnum.COMPLETED
+        filtered_data["saleLineIds"] = reservation.sale_line_ids.ids
+        return cls(**filtered_data)
+
+
+class FolioDetail(PmsBaseModel):
+    id: int
+    name: str = Field("", alias="name")
+    external_reference: str = Field("", alias="externalReference")
+    create_date: date = Field(alias="creationDate")
+    customer: ContactId | None = None
+    reference: str = Field("", alias="paymentReference")
+    amount_total: CurrencyAmount = Field(0.0, alias="totalAmount")
+    amount_untaxed: CurrencyAmount = Field(0.0, alias="totalBase")
+    amount_tax: CurrencyAmount = Field(0.0, alias="totalTax")
+    totalToInvoice: CurrencyAmount = Field(0.0, alias="totalToInvoice")
+    totalBaseToInvoice: CurrencyAmount = Field(0.0, alias="totalBaseToInvoice")
+    totalTaxToInvoice: CurrencyAmount = Field(0.0, alias="totalTaxToInvoice")
+    currency: CurrencySummary
+    paymentState: folioPaymentStateEnum
+    invoiceState: invoiceStateEnum
+    nationality: CountrySummary | None = None
+    payers: list[ContactIdImage] = Field(default_factory=list)
+    reservations: list[FolioReservation] = Field(default_factory=list)
+
+    @field_validator("create_date", mode="before")
+    @classmethod
+    def convert_datetime_to_date(cls, v):
+        if isinstance(v, datetime):
+            return v.date()
+        return v
+
+    @classmethod
+    def from_pms_folio(cls, folio):
+        filtered_data = cls._read_odoo_record(folio)
+        if folio.partner_id:
+            filtered_data["customer"] = ContactId.from_res_partner(folio.partner_id)
+        if folio.currency_id:
+            filtered_data["_decimal_places"] = folio.currency_id.decimal_places
+            filtered_data["currency"] = CurrencySummary.from_res_currency(
+                folio.currency_id
+            )
+        if folio.partner_id and folio.partner_id.nationality_id:
+            filtered_data["nationality"] = CountrySummary.from_res_country(
+                folio.partner_id.nationality_id
+            )
+        if any(move.has_overdue_payments for move in folio.move_ids):
+            filtered_data["paymentState"] = folioPaymentStateEnum.OVERDUE
+        elif folio.payment_state in ("paid", "nothing_to_pay"):
+            filtered_data["paymentState"] = folioPaymentStateEnum.PAID
+        elif folio.payment_state == "not_paid":
+            filtered_data["paymentState"] = folioPaymentStateEnum.NOT_PAID
+        elif folio.payment_state == "partial":
+            filtered_data["paymentState"] = folioPaymentStateEnum.PARTIALLY_PAID
+        elif folio.payment_state == "overpayment":
+            filtered_data["paymentState"] = folioPaymentStateEnum.OVERPAID
+        if folio.invoice_status in ("to_invoice", "to_confirm"):
+            filtered_data["invoiceState"] = invoiceStateEnum.TO_INVOICE
+        else:
+            filtered_data["invoiceState"] = invoiceStateEnum.INVOICED
+        payer_partners = folio.sale_line_ids.mapped("default_invoice_to").filtered(
+            lambda p: p.id
+        )
+        filtered_data["payers"] = [
+            ContactIdImage.from_res_partner(partner) for partner in payer_partners
+        ]
+        total_base_to_invoice = folio.untaxed_amount_to_invoice
+        tax_to_invoice = sum(
+            line.untaxed_amount_to_invoice * line.price_tax / line.price_subtotal
+            if line.price_subtotal
+            else 0.0
+            for line in folio.sale_line_ids.filtered(lambda sl: not sl.display_type)
+        )
+        filtered_data["totalBaseToInvoice"] = total_base_to_invoice
+        filtered_data["totalTaxToInvoice"] = tax_to_invoice
+        filtered_data["totalToInvoice"] = total_base_to_invoice + tax_to_invoice
+        filtered_data["reservations"] = [
+            FolioReservation.from_pms_reservation(res)
+            for res in folio.reservation_ids
+            if res.cancelled_reason != "modified"
+        ]
         return cls(**filtered_data)
 
 

--- a/pms_fastapi/schemas/pms_reservation.py
+++ b/pms_fastapi/schemas/pms_reservation.py
@@ -1,4 +1,14 @@
-from .base import PmsBaseModel
+from datetime import datetime
+from enum import Enum
+
+from pydantic import Field
+
+from .agency import AgencyIdImage
+from .base import CurrencyAmount, PmsBaseModel
+from .currency import CurrencySummary
+from .pms_room import RoomId
+from .pms_sale_channel import SaleChannelDetail
+from .pms_service import ServiceId
 
 
 class ReservationId(PmsBaseModel):
@@ -8,3 +18,91 @@ class ReservationId(PmsBaseModel):
     @classmethod
     def from_pms_reservation(cls, reservation):
         return ReservationId(id=reservation.id, name=reservation.name)
+
+
+class reservationStateEnum(str, Enum):
+    DRAFT = "draft"
+    ARRIVAL = "arrival"
+    IN_HOUSE = "inHouse"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    NO_SHOW = "noShow"
+    OVERBOOKING = "overbooking"
+    RESELLING = "reselling"
+
+
+class reservationSummary(PmsBaseModel):
+    id: int
+    name: str
+    splitted: bool = Field(False, alias="isSplitted")
+    partner_internal_comment: str = Field("", alias="notes")
+    checkin_datetime: datetime | None = Field(None, alias="checkinDate")
+    checkout_datetime: datetime | None = Field(None, alias="checkoutDate")
+    adults: int = Field(0)
+    children: int = Field(0)
+    nights: int = Field(0)
+    to_assign: bool = Field(False, alias="toAssign")
+    rooms: list[RoomId]
+    services: list[ServiceId]
+    saleChannel: SaleChannelDetail | None = None
+    agency: AgencyIdImage | None = None
+    state: reservationStateEnum
+    price_room_services_set: CurrencyAmount = Field(0.0, alias="totalAmount")
+    currency: CurrencySummary | None = None
+    incompleteCheckinsCount: int = Field(0)
+    completeCheckinsCount: int = Field(0)
+
+    @classmethod
+    def from_pms_reservation(cls, reservation):
+        filtered_data = cls._read_odoo_record(reservation)
+        filtered_data["rooms"] = [
+            RoomId.from_pms_room(room)
+            for room in reservation.reservation_line_ids.mapped("room_id")
+        ]
+        filtered_data["services"] = [
+            ServiceId.from_pms_service(service) for service in reservation.service_ids
+        ]
+        if reservation.currency_id:
+            filtered_data["_decimal_places"] = reservation.currency_id.decimal_places
+            filtered_data["currency"] = CurrencySummary.from_res_currency(
+                reservation.currency_id
+            )
+        if reservation.sale_channel_origin_id:
+            filtered_data["saleChannel"] = SaleChannelDetail.from_pms_sale_channel(
+                reservation.sale_channel_origin_id
+            )
+        if reservation.agency_id:
+            filtered_data["agency"] = AgencyIdImage.from_res_partner(
+                reservation.agency_id
+            )
+        if reservation.overbooking and reservation.state != "cancel":
+            filtered_data["state"] = reservationStateEnum.OVERBOOKING
+        elif (
+            reservation.is_reselling
+            or any(reservation.reservation_line_ids.mapped("is_reselling"))
+        ) and reservation.state != "cancel":
+            filtered_data["state"] = reservationStateEnum.RESELLING
+        elif reservation.state == "draft":
+            filtered_data["state"] = reservationStateEnum.DRAFT
+        elif reservation.state == "cancel":
+            if reservation.cancelled_reason == "noshow":
+                filtered_data["state"] = reservationStateEnum.NO_SHOW
+            else:
+                filtered_data["state"] = reservationStateEnum.CANCELLED
+        elif reservation.state in ("confirm", "arrival_delayed"):
+            filtered_data["state"] = reservationStateEnum.ARRIVAL
+        elif reservation.state in ("onboard", "departure_delayed"):
+            filtered_data["state"] = reservationStateEnum.IN_HOUSE
+        elif reservation.state == "done":
+            filtered_data["state"] = reservationStateEnum.COMPLETED
+
+        checkin_partners = reservation.checkin_partner_ids
+        filtered_data["incompleteCheckinsCount"] = len(
+            checkin_partners.filtered(lambda c: c.state in ("dummy", "draft"))
+        )
+        filtered_data["completeCheckinsCount"] = len(
+            checkin_partners.filtered(
+                lambda c: c.state in ("precheckin", "onboard", "done")
+            )
+        )
+        return cls(**filtered_data)

--- a/pms_fastapi/schemas/user.py
+++ b/pms_fastapi/schemas/user.py
@@ -4,6 +4,15 @@ from .base import PmsBaseModel
 from .pms_property import PropertyId
 
 
+class UserId(PmsBaseModel):
+    id: int
+    name: str = Field(alias="name")
+
+    @classmethod
+    def from_res_users(cls, user):
+        return cls(id=user.id, name=user.name or "")
+
+
 class User(PmsBaseModel):
     id: int = Field(alias="id")
     name: str = Field(alias="name")

--- a/pms_fastapi/tests/__init__.py
+++ b/pms_fastapi/tests/__init__.py
@@ -2,7 +2,9 @@ from . import common
 from . import test_contacts
 from . import test_countries
 from . import test_folios
+from . import test_folio_billing
 from . import test_invoices
+from . import test_invoice_contact_validation
 from . import test_journals
 from . import test_languages
 from . import test_payment_methods

--- a/pms_fastapi/tests/__init__.py
+++ b/pms_fastapi/tests/__init__.py
@@ -3,8 +3,10 @@ from . import test_contacts
 from . import test_countries
 from . import test_folios
 from . import test_folio_billing
+from . import test_folio_invoicing
 from . import test_invoices
 from . import test_invoice_contact_validation
+from . import test_invoice_reconciliation
 from . import test_journals
 from . import test_languages
 from . import test_payment_methods

--- a/pms_fastapi/tests/__init__.py
+++ b/pms_fastapi/tests/__init__.py
@@ -10,6 +10,7 @@ from . import test_invoice_reconciliation
 from . import test_journals
 from . import test_languages
 from . import test_payment_methods
+from . import test_payments
 from . import test_user
 from . import test_properties
 from . import test_contact_id_numbers

--- a/pms_fastapi/tests/__init__.py
+++ b/pms_fastapi/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_invoices
 from . import test_invoice_contact_validation
 from . import test_invoice_reconciliation
 from . import test_journals
+from . import test_cash_session
 from . import test_languages
 from . import test_payment_methods
 from . import test_payments

--- a/pms_fastapi/tests/__init__.py
+++ b/pms_fastapi/tests/__init__.py
@@ -12,6 +12,8 @@ from . import test_cash_session
 from . import test_languages
 from . import test_payment_methods
 from . import test_payments
+from . import test_payment_creation
+from . import test_cash_payments_flow
 from . import test_user
 from . import test_properties
 from . import test_contact_id_numbers

--- a/pms_fastapi/tests/test_cash_payments_flow.py
+++ b/pms_fastapi/tests/test_cash_payments_flow.py
@@ -1,0 +1,136 @@
+from fastapi import status
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+@tagged("post_install", "-at_install")
+class TestCashAndPaymentsFlow(CommonTestPmsApi):
+    """End-to-end: open cash session -> create payment on the cash journal ->
+    current breakdown -> close (with the shift payment reconciled)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.test_company
+        if not company.chart_template_id:
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            if not coa:
+                cls.skipTest(cls, "No chart of accounts available.")
+            coa.try_loading(company=company, install_demo=False)
+        cls.env.user.write(
+            {
+                "company_ids": [Command.link(company.id)],
+                "company_id": company.id,
+            }
+        )
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=company.ids)
+        )
+        income_account = cls.env["account.account"].search(
+            [("company_id", "=", company.id), ("account_type", "=", "income_other")],
+            limit=1,
+        ) or cls.env["account.account"].search(
+            [("company_id", "=", company.id), ("account_type", "=", "income")], limit=1
+        )
+        expense_account = cls.env["account.account"].search(
+            [("company_id", "=", company.id), ("account_type", "=", "expense")], limit=1
+        )
+        cls.journal_cash = cls.env["account.journal"].create(
+            {
+                "name": "Cash Reception",
+                "type": "cash",
+                "code": "CSHP",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+                "profit_account_id": income_account.id,
+                "loss_account_id": expense_account.id,
+            }
+        )
+        cls.cash_inbound = cls.journal_cash.inbound_payment_method_line_ids[:1]
+        cls.customer = cls.env["res.partner"].create({"name": "Flow Customer"})
+
+    def _folio(self):
+        return self.env["pms.folio"].create(
+            {
+                "pms_property_id": self.test_property.id,
+                "partner_name": self.customer.name,
+                "partner_id": self.customer.id,
+            }
+        )
+
+    def test_open_pay_close_flow(self):
+        folio = self._folio()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+
+            # 1. Open the cash session with a declared base of 200.
+            opened = test_client.post(
+                "/cash-sessions",
+                json={"journalId": self.journal_cash.id, "baseAmount": 200.0},
+            )
+            self.assertEqual(opened.status_code, status.HTTP_201_CREATED, opened.text)
+            session_id = opened.json()["id"]
+            self.assertEqual(opened.json()["expectedAmount"], 200.0)
+
+            # 2. Register a customer payment of 120 on the cash journal.
+            paid = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": 120.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.cash_inbound.id,
+                    "folioId": folio.id,
+                    "reference": "",
+                },
+            )
+            self.assertEqual(paid.status_code, status.HTTP_201_CREATED, paid.text)
+            payment_id = paid.json()["id"]
+
+            # 3. current reflects the payment in the breakdown.
+            current = test_client.get(
+                f"/cash-sessions/current?journalId={self.journal_cash.id}"
+            )
+            self.assertEqual(current.status_code, status.HTTP_200_OK, current.text)
+            self.assertEqual(current.json()["id"], session_id)
+            self.assertEqual(current.json()["incomeAmount"], 120.0)
+            self.assertEqual(current.json()["expectedAmount"], 320.0)
+
+            # 4. Close counting exactly the expected cash -> no mismatch.
+            closed = test_client.post(
+                f"/cash-sessions/{session_id}/closing",
+                json={"countedCash": 320.0, "note": "shift handover"},
+            )
+            self.assertEqual(closed.status_code, status.HTTP_200_OK, closed.text)
+            body = closed.json()
+            self.assertEqual(body["expectedAmount"], 320.0)
+            self.assertEqual(body["countedCash"], 320.0)
+            self.assertEqual(body["difference"], 0.0)
+            self.assertEqual(body["closingAmount"], 320.0)
+
+            # 5. last-closing returns it; current is now empty.
+            last_closing = test_client.get(
+                f"/cash-sessions/last-closing?journalId={self.journal_cash.id}"
+            )
+            self.assertEqual(
+                last_closing.status_code, status.HTTP_200_OK, last_closing.text
+            )
+            self.assertEqual(last_closing.json()["closingAmount"], 320.0)
+            after = test_client.get(
+                f"/cash-sessions/current?journalId={self.journal_cash.id}"
+            )
+            self.assertEqual(after.status_code, status.HTTP_204_NO_CONTENT, after.text)
+
+        # The close must have created the statement line for the shift payment
+        # and reconciled it (the accounting close ran end-to-end).
+        session = self.env["account.bank.statement"].browse(session_id)
+        self.assertTrue(session.cash_session_closed)
+        self.assertTrue(session.line_ids)
+        self.assertTrue(self.env["account.payment"].browse(payment_id).is_matched)

--- a/pms_fastapi/tests/test_cash_session.py
+++ b/pms_fastapi/tests/test_cash_session.py
@@ -1,0 +1,253 @@
+from datetime import date
+
+from fastapi import status
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+@tagged("post_install", "-at_install")
+class TestCashSessionEndpoints(CommonTestPmsApi):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.test_company
+        if not company.chart_template_id:
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            if not coa:
+                cls.skipTest(cls, "No chart of accounts available.")
+            coa.try_loading(company=company, install_demo=False)
+        cls.env.user.write(
+            {
+                "company_ids": [Command.link(company.id)],
+                "company_id": company.id,
+            }
+        )
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=company.ids)
+        )
+        income_account = cls.env["account.account"].search(
+            [("company_id", "=", company.id), ("account_type", "=", "income_other")],
+            limit=1,
+        ) or cls.env["account.account"].search(
+            [("company_id", "=", company.id), ("account_type", "=", "income")], limit=1
+        )
+        expense_account = cls.env["account.account"].search(
+            [("company_id", "=", company.id), ("account_type", "=", "expense")], limit=1
+        )
+        cls.journal_cash = cls.env["account.journal"].create(
+            {
+                "name": "Cash Reception",
+                "type": "cash",
+                "code": "CSHP",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+                "profit_account_id": income_account.id,
+                "loss_account_id": expense_account.id,
+            }
+        )
+        cls.journal_bank = cls.env["account.journal"].create(
+            {
+                "name": "Bank PMS",
+                "type": "bank",
+                "code": "BNKP",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+            }
+        )
+        cls.customer = cls.env["res.partner"].create({"name": "Cash Customer"})
+        cls.supplier = cls.env["res.partner"].create({"name": "Cash Supplier"})
+
+    def _create_payment(
+        self,
+        amount,
+        payment_type="inbound",
+        partner_type="customer",
+        is_internal_transfer=False,
+        destination_journal=None,
+    ):
+        vals = {
+            "amount": amount,
+            "payment_type": payment_type,
+            "partner_type": partner_type,
+            "journal_id": self.journal_cash.id,
+            "partner_id": (
+                self.customer if partner_type == "customer" else self.supplier
+            ).id,
+            "date": date(2025, 12, 22),
+            "is_internal_transfer": is_internal_transfer,
+        }
+        if is_internal_transfer:
+            vals["destination_journal_id"] = (
+                destination_journal or self.journal_bank
+            ).id
+        payment = self.env["account.payment"].create(vals)
+        payment.action_post()
+        return payment
+
+    def _open(self, test_client, base_amount=200.0, journal=None):
+        return test_client.post(
+            "/cash-sessions",
+            json={
+                "journalId": (journal or self.journal_cash).id,
+                "baseAmount": base_amount,
+            },
+        )
+
+    # -- open --
+
+    def test_open_creates_session(self):
+        """POST /cash-sessions opens a session; expected equals baseAmount."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._open(test_client, base_amount=200.0)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        body = response.json()
+        self.assertEqual(body["journal"]["id"], self.journal_cash.id)
+        self.assertEqual(body["baseAmount"], 200.0)
+        self.assertEqual(body["incomeAmount"], 0.0)
+        self.assertEqual(body["expectedAmount"], 200.0)
+        self.assertIsNotNone(body["openedBy"]["id"])
+        self.assertTrue(body["currency"]["code"])
+
+    def test_double_open_returns_409(self):
+        """A second open on the same journal is rejected with 409."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            self._open(test_client)
+            response = self._open(test_client)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(response.json()["type"], "/errors/cash-session-already-open")
+
+    def test_open_on_non_cash_journal_returns_409(self):
+        """Opening a session on a non-cash journal returns 409."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = self._open(test_client, journal=self.journal_bank)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(response.json()["type"], "/errors/journal-not-cash")
+
+    # -- current / breakdown --
+
+    def test_current_breakdown(self):
+        """GET current returns the shift breakdown computed from payments.
+
+        income = inbound non-transfer; refund = customer outbound;
+        expense = supplier outbound; internalTransfer = net money leaving.
+        """
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            self._open(test_client, base_amount=200.0)
+            self._create_payment(120.0, "inbound", "customer")  # income
+            self._create_payment(20.0, "outbound", "customer")  # refund
+            self._create_payment(50.0, "outbound", "supplier")  # expense
+            self._create_payment(  # transfer OUT (lowers cash)
+                30.0, "outbound", is_internal_transfer=True
+            )
+            self._create_payment(  # transfer IN (raises cash)
+                10.0, "inbound", is_internal_transfer=True
+            )
+            response = test_client.get(
+                f"/cash-sessions/current?journalId={self.journal_cash.id}"
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        body = response.json()
+        self.assertEqual(body["incomeAmount"], 120.0)
+        self.assertEqual(body["refundAmount"], 20.0)
+        self.assertEqual(body["expenseAmount"], 50.0)
+        self.assertEqual(body["internalTransferAmount"], 20.0)  # 30 out - 10 in
+        # expected = 200 + 120 - 20 - 50 - 20 = 230
+        self.assertEqual(body["expectedAmount"], 230.0)
+
+    def test_current_without_session_returns_204(self):
+        """GET current returns 204 when there is no open session."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                f"/cash-sessions/current?journalId={self.journal_cash.id}"
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_204_NO_CONTENT, response.text
+        )
+
+    # -- last-closing --
+
+    def test_last_closing_without_close_returns_204(self):
+        """GET last-closing returns 204 when the journal never had a close."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                f"/cash-sessions/last-closing?journalId={self.journal_cash.id}"
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_204_NO_CONTENT, response.text
+        )
+
+    # -- close --
+
+    def test_close_records_difference_and_transitions(self):
+        """Closing records the mismatch, flips the session to closed, and
+        last-closing then returns it while current becomes 204."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            opened = self._open(test_client, base_amount=200.0).json()
+            session_id = opened["id"]
+            # No payments: expected == baseAmount == 200; count 180 -> -20 diff.
+            close = test_client.post(
+                f"/cash-sessions/{session_id}/closing",
+                json={"countedCash": 180.0, "note": "short on cash"},
+            )
+            current_after = test_client.get(
+                f"/cash-sessions/current?journalId={self.journal_cash.id}"
+            )
+            last_closing = test_client.get(
+                f"/cash-sessions/last-closing?journalId={self.journal_cash.id}"
+            )
+        self.assertEqual(close.status_code, status.HTTP_200_OK, close.text)
+        body = close.json()
+        self.assertEqual(body["expectedAmount"], 200.0)
+        self.assertEqual(body["countedCash"], 180.0)
+        self.assertEqual(body["closingAmount"], 180.0)
+        self.assertEqual(body["difference"], -20.0)
+        self.assertEqual(body["note"], "short on cash")
+        self.assertIsNotNone(body["closedBy"]["id"])
+        self.assertEqual(
+            current_after.status_code, status.HTTP_204_NO_CONTENT, current_after.text
+        )
+        self.assertEqual(
+            last_closing.status_code, status.HTTP_200_OK, last_closing.text
+        )
+        self.assertEqual(last_closing.json()["closingAmount"], 180.0)
+        self.assertEqual(last_closing.json()["note"], "short on cash")
+
+    def test_close_missing_session_returns_404(self):
+        """Closing a non-existent session returns 404."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/cash-sessions/999999/closing",
+                json={"countedCash": 0.0, "note": ""},
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+
+    def test_close_already_closed_returns_409(self):
+        """Closing an already closed session returns 409."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            session_id = self._open(test_client, base_amount=200.0).json()["id"]
+            test_client.post(
+                f"/cash-sessions/{session_id}/closing",
+                json={"countedCash": 200.0, "note": ""},
+            )
+            response = test_client.post(
+                f"/cash-sessions/{session_id}/closing",
+                json={"countedCash": 200.0, "note": ""},
+            )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(response.json()["type"], "/errors/cash-session-already-closed")

--- a/pms_fastapi/tests/test_cash_session.py
+++ b/pms_fastapi/tests/test_cash_session.py
@@ -189,6 +189,29 @@ class TestCashSessionEndpoints(CommonTestPmsApi):
             response.status_code, status.HTTP_204_NO_CONTENT, response.text
         )
 
+    def test_last_closing_with_missing_metadata_does_not_500(self):
+        """A legacy session flagged closed without closing date/uid must not
+        break last-closing; it falls back to the write metadata."""
+        statement = self.env["account.bank.statement"].create(
+            {
+                "journal_id": self.journal_cash.id,
+                "cash_session_closed": True,
+                "balance_end_real": 100.0,
+            }
+        )
+        self.assertFalse(statement.cash_session_closed_date)
+        self.assertFalse(statement.cash_session_closed_uid)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                f"/cash-sessions/last-closing?journalId={self.journal_cash.id}"
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        body = response.json()
+        self.assertEqual(body["closingAmount"], 100.0)
+        self.assertIsNotNone(body["closedAt"])
+        self.assertIsNotNone(body["closedBy"]["id"])
+
     # -- close --
 
     def test_close_records_difference_and_transitions(self):
@@ -241,13 +264,36 @@ class TestCashSessionEndpoints(CommonTestPmsApi):
         with self._create_test_client(raise_server_exceptions=False) as test_client:
             self._login(test_client)
             session_id = self._open(test_client, base_amount=200.0).json()["id"]
+            # Close with a mismatch so the statement persists; a movement-less
+            # close would be discarded (see test_close_without_movements_*).
             test_client.post(
                 f"/cash-sessions/{session_id}/closing",
-                json={"countedCash": 200.0, "note": ""},
+                json={"countedCash": 180.0, "note": ""},
             )
             response = test_client.post(
                 f"/cash-sessions/{session_id}/closing",
-                json={"countedCash": 200.0, "note": ""},
+                json={"countedCash": 180.0, "note": ""},
             )
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
         self.assertEqual(response.json()["type"], "/errors/cash-session-already-closed")
+
+    def test_close_without_movements_discards_and_returns_204(self):
+        """A shift with no payments and a count matching the base leaves no
+        accounting trace, so the empty statement is discarded and the close
+        responds 204."""
+        Statement = self.env["account.bank.statement"]
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            session_id = self._open(test_client, base_amount=200.0).json()["id"]
+            close = test_client.post(
+                f"/cash-sessions/{session_id}/closing",
+                json={"countedCash": 200.0, "note": "nothing happened"},
+            )
+            current_after = test_client.get(
+                f"/cash-sessions/current?journalId={self.journal_cash.id}"
+            )
+        self.assertEqual(close.status_code, status.HTTP_204_NO_CONTENT, close.text)
+        self.assertFalse(Statement.browse(session_id).exists())
+        self.assertEqual(
+            current_after.status_code, status.HTTP_204_NO_CONTENT, current_after.text
+        )

--- a/pms_fastapi/tests/test_folio_billing.py
+++ b/pms_fastapi/tests/test_folio_billing.py
@@ -1,0 +1,325 @@
+import datetime
+
+from fastapi import status
+
+from odoo import Command, fields
+from odoo.tests import tagged
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+@tagged("post_install", "-at_install")
+class TestFolioBilling(CommonTestPmsApi):
+    """Billing-related folio endpoints: sale-lines, detail and contacts.
+
+    Covers the module's own transformation logic (sale-line invoice
+    aggregation, reservation state mapping, contact collection) rather than
+    plain ORM/serialization behaviour.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.test_company
+        if not company.chart_template_id:
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            if not coa:
+                cls.skipTest(cls, "No chart of accounts available.")
+            coa.try_loading(company=company, install_demo=False)
+        cls.env.user.write(
+            {
+                "company_ids": [Command.link(company.id)],
+                "company_id": company.id,
+            }
+        )
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=company.ids)
+        )
+        cls.journal_sale = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", company.id)], limit=1
+        )
+
+        cls.room_type_class = cls.env["pms.room.type.class"].create(
+            {"name": "Standard", "default_code": "STD"}
+        )
+        cls.room_type = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.test_property.id],
+                "name": "Double Test",
+                "default_code": "DBL_Test",
+                "class_id": cls.room_type_class.id,
+            }
+        )
+        cls.room1 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.test_property.id,
+                "name": "101",
+                "room_type_id": cls.room_type.id,
+                "capacity": 2,
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {"firstname": "John", "lastname": "Doe"}
+        )
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Direct Test", "channel_type": "direct"}
+        )
+        cls.agency_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Agency Channel", "channel_type": "indirect"}
+        )
+        cls.agency = cls.env["res.partner"].create(
+            {
+                "name": "Test Agency",
+                "is_agency": True,
+                "sale_channel_id": cls.agency_channel.id,
+            }
+        )
+
+    def _create_folio_with_reservation(self, partner=None, agency=None):
+        today = fields.date.today()
+        partner = partner or self.partner
+        folio_vals = {
+            "pms_property_id": self.test_property.id,
+            "partner_name": partner.name,
+            "partner_id": partner.id,
+        }
+        if agency:
+            folio_vals["agency_id"] = agency.id
+        folio = self.env["pms.folio"].create(folio_vals)
+        channel = self.agency_channel if agency else self.sale_channel
+        self.env["pms.reservation"].create(
+            {
+                "folio_id": folio.id,
+                "room_type_id": self.room_type.id,
+                "partner_id": partner.id,
+                "adults": 1,
+                "sale_channel_origin_id": channel.id,
+                "reservation_line_ids": [
+                    (0, False, {"date": today + datetime.timedelta(days=i)})
+                    for i in range(2)
+                ],
+            }
+        )
+        return folio
+
+    def _room_sale_line(self, folio):
+        return folio.sale_line_ids.filtered(
+            lambda line: not line.display_type and not line.is_downpayment
+        )[:1]
+
+    def _invoice_sale_line(self, sale_line, move_type="out_invoice", qty=1.0):
+        move = self.env["account.move"].create(
+            {
+                "move_type": move_type,
+                "partner_id": sale_line.folio_id.partner_id.id,
+                "pms_property_id": self.test_property.id,
+                "journal_id": self.journal_sale.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Invoiced room",
+                            "quantity": qty,
+                            "price_unit": 100.0,
+                            "tax_ids": [Command.clear()],
+                            "folio_line_ids": [Command.set(sale_line.ids)],
+                        }
+                    )
+                ],
+            }
+        )
+        move.action_post()
+        return move
+
+    # ------------------------------------------------------------------
+    # GET /folios/{id}/sale-lines
+    # ------------------------------------------------------------------
+    def test_sale_lines_exclude_sections_notes_and_downpayments(self):
+        folio = self._create_folio_with_reservation()
+        section = self.env["folio.sale.line"].create(
+            {"folio_id": folio.id, "display_type": "line_section", "name": "Section"}
+        )
+        note = self.env["folio.sale.line"].create(
+            {"folio_id": folio.id, "display_type": "line_note", "name": "Note"}
+        )
+        downpayment = self.env["folio.sale.line"].create(
+            {
+                "folio_id": folio.id,
+                "name": "Down payment",
+                "is_downpayment": True,
+                "product_uom_qty": 1,
+                "price_unit": 50.0,
+            }
+        )
+        expected_ids = set(
+            folio.sale_line_ids.filtered(
+                lambda line: not line.display_type and not line.is_downpayment
+            ).ids
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}/sale-lines")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        returned_ids = {line["id"] for line in response.json()}
+        self.assertEqual(returned_ids, expected_ids)
+        self.assertNotIn(section.id, returned_ids)
+        self.assertNotIn(note.id, returned_ids)
+        self.assertNotIn(downpayment.id, returned_ids)
+
+    def test_sale_line_room_type_and_pending_state(self):
+        folio = self._create_folio_with_reservation()
+        room_line = self._room_sale_line(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}/sale-lines")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        line = next(d for d in response.json() if d["id"] == room_line.id)
+        self.assertEqual(line["lineType"], "room")
+        self.assertEqual(line["invoiceState"], "pending")
+        self.assertEqual(line["invoices"], [])
+
+    def test_sale_line_invoice_and_refund_net_quantity(self):
+        folio = self._create_folio_with_reservation()
+        room_line = self._room_sale_line(folio)
+        invoice = self._invoice_sale_line(room_line, "out_invoice", qty=1.0)
+        refund = self._invoice_sale_line(room_line, "out_refund", qty=1.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}/sale-lines")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        line = next(d for d in response.json() if d["id"] == room_line.id)
+        invoices_by_id = {inv["id"]: inv for inv in line["invoices"]}
+        self.assertEqual(set(invoices_by_id), {invoice.id, refund.id})
+        self.assertEqual(invoices_by_id[invoice.id]["quantityInvoiced"], 1.0)
+        self.assertEqual(invoices_by_id[refund.id]["quantityInvoiced"], -1.0)
+        # invoice (+1) and refund (-1) net to zero invoiced quantity
+        self.assertEqual(line["quantityInvoiced"], 0.0)
+
+    def test_sale_line_cancelled_invoice_is_excluded(self):
+        folio = self._create_folio_with_reservation()
+        room_line = self._room_sale_line(folio)
+        invoice = self._invoice_sale_line(room_line, "out_invoice", qty=1.0)
+        invoice.button_cancel()
+        self.assertEqual(invoice.state, "cancel")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}/sale-lines")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        line = next(d for d in response.json() if d["id"] == room_line.id)
+        self.assertEqual(line["invoices"], [])
+        self.assertEqual(line["quantityInvoiced"], 0.0)
+
+    # ------------------------------------------------------------------
+    # GET /folios/{id} (detail)
+    # ------------------------------------------------------------------
+    def _create_extra_reservation(self, folio, partner=None, days_ahead=30):
+        # A reservation in dates that do not overlap the folio's main one, to
+        # avoid availability conflicts with the single test room.
+        start = fields.date.today() + datetime.timedelta(days=days_ahead)
+        return self.env["pms.reservation"].create(
+            {
+                "folio_id": folio.id,
+                "room_type_id": self.room_type.id,
+                "partner_id": (partner or self.partner).id,
+                "adults": 1,
+                "sale_channel_origin_id": self.sale_channel.id,
+                "reservation_line_ids": [(0, False, {"date": start})],
+            }
+        )
+
+    def test_detail_excludes_modified_reservations(self):
+        folio = self._create_folio_with_reservation()
+        kept = folio.reservation_ids
+        modified = self._create_extra_reservation(folio)
+        modified.with_context(action_cancel=True).write(
+            {"state": "cancel", "cancelled_reason": "modified"}
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        reservation_ids = {r["id"] for r in response.json()["reservations"]}
+        self.assertIn(kept.id, reservation_ids)
+        self.assertNotIn(modified.id, reservation_ids)
+
+    def test_detail_cancelled_state(self):
+        folio = self._create_folio_with_reservation()
+        reservation = folio.reservation_ids
+        reservation.with_context(action_cancel=True).write(
+            {"state": "cancel", "cancelled_reason": "late"}
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        res_data = next(
+            r for r in response.json()["reservations"] if r["id"] == reservation.id
+        )
+        self.assertEqual(res_data["state"], "cancelled")
+
+    def test_detail_payers_from_default_invoice_to(self):
+        folio = self._create_folio_with_reservation()
+        payer = self.env["res.partner"].create({"name": "Payer Partner"})
+        self._room_sale_line(folio).write({"default_invoice_to": payer.id})
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        payer_ids = {p["id"] for p in response.json()["payers"]}
+        self.assertIn(payer.id, payer_ids)
+
+    # ------------------------------------------------------------------
+    # GET /folios/{id}/contacts
+    # ------------------------------------------------------------------
+    def test_contacts_aggregate_and_deduplicate(self):
+        folio = self._create_folio_with_reservation(agency=self.agency)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}/contacts")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        contacts = response.json()
+        contact_ids = [c["id"] for c in contacts]
+        self.assertIn(self.partner.id, contact_ids)
+        self.assertIn(self.agency.id, contact_ids)
+        # partner is both the folio customer and the reservation guest: deduped
+        self.assertEqual(len(contact_ids), len(set(contact_ids)))
+
+    def test_contacts_exclude_modified_reservation_partners(self):
+        folio = self._create_folio_with_reservation()
+        other_guest = self.env["res.partner"].create(
+            {"firstname": "Modified", "lastname": "Guest"}
+        )
+        modified = self._create_extra_reservation(folio, partner=other_guest)
+        modified.with_context(action_cancel=True).write(
+            {"state": "cancel", "cancelled_reason": "modified"}
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios/{folio.id}/contacts")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        contact_ids = {c["id"] for c in response.json()}
+        self.assertNotIn(other_guest.id, contact_ids)
+
+    # ------------------------------------------------------------------
+    # Reservation NO_SHOW state mapping (via /folios list summary)
+    # ------------------------------------------------------------------
+    def test_reservation_no_show_state(self):
+        folio = self._create_folio_with_reservation()
+        reservation = folio.reservation_ids
+        reservation.with_context(action_cancel=True).write(
+            {"state": "cancel", "cancelled_reason": "noshow"}
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/folios?pmsPropertyId={self.test_property.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        folio_data = next(
+            item for item in response.json()["items"] if item["id"] == folio.id
+        )
+        res_data = next(
+            r for r in folio_data["reservations"] if r["id"] == reservation.id
+        )
+        self.assertEqual(res_data["state"], "noShow")

--- a/pms_fastapi/tests/test_folio_invoicing.py
+++ b/pms_fastapi/tests/test_folio_invoicing.py
@@ -62,6 +62,20 @@ class TestFolioInvoicing(CommonTestPmsApi):
         cls.sale_channel = cls.env["pms.sale.channel"].create(
             {"name": "Direct Test", "channel_type": "direct"}
         )
+        # Simplified invoices need a dedicated sale journal; linking it as the
+        # property's simplified journal flags it as such (is_simplified_invoice).
+        cls.journal_simplified = cls.env["account.journal"].create(
+            {
+                "name": "Simplified Sales",
+                "code": "SIMP",
+                "type": "sale",
+                "company_id": company.id,
+                "pms_property_ids": [(6, 0, [cls.test_property.id])],
+            }
+        )
+        cls.test_property.write(
+            {"journal_simplified_invoice_id": cls.journal_simplified.id}
+        )
         cls.guest = cls.env["res.partner"].create(
             {"firstname": "John", "lastname": "Doe"}
         )
@@ -151,6 +165,17 @@ class TestFolioInvoicing(CommonTestPmsApi):
             )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
         self.assertEqual(response.json()["state"], "posted")
+
+    def test_create_simplified_invoice_without_customer(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client, self._create_payload(line, customer_id=None)
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        self.assertEqual(response.json()["invoiceType"], "outInvoice")
 
     # ------------------------------------------------------------------
     # POST /folios/invoices — validation branches

--- a/pms_fastapi/tests/test_folio_invoicing.py
+++ b/pms_fastapi/tests/test_folio_invoicing.py
@@ -137,11 +137,14 @@ class TestFolioInvoicing(CommonTestPmsApi):
         # Mirror the structure the down-payment wizard produces: an invoice
         # tied to the folio whose line points at a down-payment folio.sale.line.
         # This is what account.move._is_downpayment() keys off.
+        product = self.room_type.product_id
         line = self.env["folio.sale.line"].create(
             {
                 "folio_id": folio.id,
                 "name": "Down payment",
                 "is_downpayment": True,
+                "product_id": product.id,
+                "product_uom": product.uom_id.id,
                 "product_uom_qty": 1,
                 "price_unit": amount,
             }
@@ -157,6 +160,7 @@ class TestFolioInvoicing(CommonTestPmsApi):
                         0,
                         {
                             "name": "Down payment",
+                            "product_id": product.id,
                             "quantity": 1,
                             "price_unit": amount,
                             "folio_line_ids": [(6, 0, line.ids)],

--- a/pms_fastapi/tests/test_folio_invoicing.py
+++ b/pms_fastapi/tests/test_folio_invoicing.py
@@ -133,6 +133,17 @@ class TestFolioInvoicing(CommonTestPmsApi):
             ],
         }
 
+    def _downpayment_line(self, folio, amount=50.0):
+        return self.env["folio.sale.line"].create(
+            {
+                "folio_id": folio.id,
+                "name": "Down payment",
+                "is_downpayment": True,
+                "product_uom_qty": 1,
+                "price_unit": amount,
+            }
+        )
+
     def _post_invoice(self, test_client, payload):
         return test_client.post("/folios/invoices", json=payload)
 
@@ -349,6 +360,81 @@ class TestFolioInvoicing(CommonTestPmsApi):
             response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
         )
         self.assertEqual(response.json()["type"], "/errors/multiple-properties")
+
+    # ------------------------------------------------------------------
+    # POST /folios/invoices — downpaymentLines
+    # ------------------------------------------------------------------
+    def test_create_invoice_with_downpayment_line(self):
+        # A valid down-payment line passes resolution/validation and reaches
+        # invoice creation. The actual deduction is folio invoicing machinery
+        # (pms), not asserted here.
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        downpayment = self._downpayment_line(folio)
+        payload = self._create_payload(line, customer_id=self.customer.id)
+        payload["downpaymentLines"] = [downpayment.id]
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        self.assertEqual(response.json()["state"], "draft")
+
+    def test_create_invoice_downpayment_not_found(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        payload = self._create_payload(line, customer_id=self.customer.id)
+        payload["downpaymentLines"] = [999999999]
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/downpayment-lines-not-found")
+
+    def test_create_invoice_rejects_non_downpayment_as_downpayment(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        payload = self._create_payload(line, customer_id=self.customer.id)
+        # A regular room line is not a down payment.
+        payload["downpaymentLines"] = [line.id]
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/invalid-downpayment-line")
+
+    def test_create_invoice_downpayment_out_of_scope(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        # Different dates so the single test room stays available.
+        other_folio = self._confirmed_folio(days_ahead=30)
+        downpayment = self._downpayment_line(other_folio)
+        payload = self._create_payload(line, customer_id=self.customer.id)
+        payload["downpaymentLines"] = [downpayment.id]
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(
+            response.json()["type"], "/errors/downpayment-line-out-of-scope"
+        )
+
+    def test_create_invoice_duplicate_downpayment_lines(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        downpayment = self._downpayment_line(folio)
+        payload = self._create_payload(line, customer_id=self.customer.id)
+        payload["downpaymentLines"] = [downpayment.id, downpayment.id]
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/duplicate-downpayment-lines")
 
     # ------------------------------------------------------------------
     # PUT /invoices/{id} — edit

--- a/pms_fastapi/tests/test_folio_invoicing.py
+++ b/pms_fastapi/tests/test_folio_invoicing.py
@@ -133,14 +133,36 @@ class TestFolioInvoicing(CommonTestPmsApi):
             ],
         }
 
-    def _downpayment_line(self, folio, amount=50.0):
-        return self.env["folio.sale.line"].create(
+    def _downpayment_invoice(self, folio, amount=50.0):
+        # Mirror the structure the down-payment wizard produces: an invoice
+        # tied to the folio whose line points at a down-payment folio.sale.line.
+        # This is what account.move._is_downpayment() keys off.
+        line = self.env["folio.sale.line"].create(
             {
                 "folio_id": folio.id,
                 "name": "Down payment",
                 "is_downpayment": True,
                 "product_uom_qty": 1,
                 "price_unit": amount,
+            }
+        )
+        return self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.customer.id,
+                "folio_ids": [(6, 0, folio.ids)],
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Down payment",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "folio_line_ids": [(6, 0, line.ids)],
+                        },
+                    )
+                ],
             }
         )
 
@@ -364,13 +386,13 @@ class TestFolioInvoicing(CommonTestPmsApi):
     # ------------------------------------------------------------------
     # POST /folios/invoices — downpaymentLines
     # ------------------------------------------------------------------
-    def test_create_invoice_with_downpayment_line(self):
-        # A valid down-payment line passes resolution/validation and reaches
+    def test_create_invoice_with_downpayment_invoice(self):
+        # A valid down-payment invoice passes resolution/validation and reaches
         # invoice creation. The actual deduction is folio invoicing machinery
         # (pms), not asserted here.
         folio = self._confirmed_folio()
         line = self._room_line(folio)
-        downpayment = self._downpayment_line(folio)
+        downpayment = self._downpayment_invoice(folio)
         payload = self._create_payload(line, customer_id=self.customer.id)
         payload["downpaymentLines"] = [downpayment.id]
         with self._create_test_client() as test_client:
@@ -393,9 +415,16 @@ class TestFolioInvoicing(CommonTestPmsApi):
     def test_create_invoice_rejects_non_downpayment_as_downpayment(self):
         folio = self._confirmed_folio()
         line = self._room_line(folio)
+        # A regular invoice (no down-payment lines) is not a down payment.
+        regular_invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.customer.id,
+                "folio_ids": [(6, 0, folio.ids)],
+            }
+        )
         payload = self._create_payload(line, customer_id=self.customer.id)
-        # A regular room line is not a down payment.
-        payload["downpaymentLines"] = [line.id]
+        payload["downpaymentLines"] = [regular_invoice.id]
         with self._create_test_client() as test_client:
             self._login(test_client)
             response = self._post_invoice(test_client, payload)
@@ -409,7 +438,7 @@ class TestFolioInvoicing(CommonTestPmsApi):
         line = self._room_line(folio)
         # Different dates so the single test room stays available.
         other_folio = self._confirmed_folio(days_ahead=30)
-        downpayment = self._downpayment_line(other_folio)
+        downpayment = self._downpayment_invoice(other_folio)
         payload = self._create_payload(line, customer_id=self.customer.id)
         payload["downpaymentLines"] = [downpayment.id]
         with self._create_test_client() as test_client:
@@ -425,7 +454,7 @@ class TestFolioInvoicing(CommonTestPmsApi):
     def test_create_invoice_duplicate_downpayment_lines(self):
         folio = self._confirmed_folio()
         line = self._room_line(folio)
-        downpayment = self._downpayment_line(folio)
+        downpayment = self._downpayment_invoice(folio)
         payload = self._create_payload(line, customer_id=self.customer.id)
         payload["downpaymentLines"] = [downpayment.id, downpayment.id]
         with self._create_test_client() as test_client:

--- a/pms_fastapi/tests/test_folio_invoicing.py
+++ b/pms_fastapi/tests/test_folio_invoicing.py
@@ -1,0 +1,437 @@
+import datetime
+
+from fastapi import status
+
+from odoo import Command, fields
+from odoo.tests import tagged
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+@tagged("post_install", "-at_install")
+class TestFolioInvoicing(CommonTestPmsApi):
+    """POST /folios/invoices (create) and PUT /invoices/{id} (edit).
+
+    Exercises the module's invoicing orchestration: sale-line resolution,
+    validation branches (RFC 9457 problems), draft rewrite and posted-invoice
+    refund flow.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.test_company
+        if not company.chart_template_id:
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            if not coa:
+                cls.skipTest(cls, "No chart of accounts available.")
+            coa.try_loading(company=company, install_demo=False)
+        cls.env.user.write(
+            {
+                "company_ids": [Command.link(company.id)],
+                "company_id": company.id,
+            }
+        )
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=company.ids)
+        )
+
+        cls.room_type_class = cls.env["pms.room.type.class"].create(
+            {"name": "Standard", "default_code": "STD"}
+        )
+        cls.room_type = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.test_property.id],
+                "name": "Double Test",
+                "default_code": "DBL_Test",
+                "class_id": cls.room_type_class.id,
+            }
+        )
+        cls.room1 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.test_property.id,
+                "name": "101",
+                "room_type_id": cls.room_type.id,
+                "capacity": 2,
+            }
+        )
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Direct Test", "channel_type": "direct"}
+        )
+        cls.guest = cls.env["res.partner"].create(
+            {"firstname": "John", "lastname": "Doe"}
+        )
+        cls.customer = cls.env["res.partner"].create(
+            {"firstname": "Bill", "lastname": "Payer", "vat": "ES12345678Z"}
+        )
+        cls.customer_no_id = cls.env["res.partner"].create(
+            {"firstname": "No", "lastname": "Fiscal"}
+        )
+
+    # -- helpers -------------------------------------------------------
+    def _confirmed_folio(self, nights=2, days_ahead=0, price=100.0):
+        start = fields.date.today() + datetime.timedelta(days=days_ahead)
+        folio = self.env["pms.folio"].create(
+            {
+                "pms_property_id": self.test_property.id,
+                "partner_name": self.guest.name,
+                "partner_id": self.guest.id,
+            }
+        )
+        self.env["pms.reservation"].create(
+            {
+                "folio_id": folio.id,
+                "room_type_id": self.room_type.id,
+                "partner_id": self.guest.id,
+                "adults": 1,
+                "sale_channel_origin_id": self.sale_channel.id,
+                "reservation_line_ids": [
+                    (0, False, {"date": start + datetime.timedelta(days=i)})
+                    for i in range(nights)
+                ],
+            }
+        )
+        folio.action_confirm()
+        folio.reservation_ids.reservation_line_ids.write({"price": price})
+        return folio
+
+    def _room_line(self, folio):
+        return folio.sale_line_ids.filtered(
+            lambda line: not line.display_type and not line.is_downpayment
+        )[:1]
+
+    def _create_payload(self, line, qty=None, customer_id=None, validate=False):
+        return {
+            "validate": validate,
+            "customerId": customer_id,
+            "lines": [
+                {
+                    "saleLineId": line.id,
+                    "description": "Room nights",
+                    "quantityToInvoice": qty
+                    if qty is not None
+                    else line.qty_to_invoice,
+                }
+            ],
+        }
+
+    def _post_invoice(self, test_client, payload):
+        return test_client.post("/folios/invoices", json=payload)
+
+    # ------------------------------------------------------------------
+    # POST /folios/invoices — happy paths
+    # ------------------------------------------------------------------
+    def test_create_invoice_draft_with_customer(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        self.assertGreater(line.qty_to_invoice, 0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client,
+                self._create_payload(line, customer_id=self.customer.id),
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        data = response.json()
+        self.assertEqual(data["state"], "draft")
+        self.assertIn(folio.id, [f["id"] for f in data["folios"]])
+
+    def test_create_invoice_posted_when_validate_true(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client,
+                self._create_payload(line, customer_id=self.customer.id, validate=True),
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        self.assertEqual(response.json()["state"], "posted")
+
+    # ------------------------------------------------------------------
+    # POST /folios/invoices — validation branches
+    # ------------------------------------------------------------------
+    def test_create_invoice_duplicate_sale_lines(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        payload = {
+            "validate": False,
+            "customerId": self.customer.id,
+            "lines": [
+                {"saleLineId": line.id, "description": "a", "quantityToInvoice": 1},
+                {"saleLineId": line.id, "description": "b", "quantityToInvoice": 1},
+            ],
+        }
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/duplicate-sale-lines")
+
+    def test_create_invoice_sale_line_not_found(self):
+        payload = {
+            "validate": False,
+            "customerId": self.customer.id,
+            "lines": [
+                {
+                    "saleLineId": 999999999,
+                    "description": "x",
+                    "quantityToInvoice": 1,
+                }
+            ],
+        }
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/sale-lines-not-found")
+
+    def test_create_invoice_rejects_section_line(self):
+        folio = self._confirmed_folio()
+        section = self.env["folio.sale.line"].create(
+            {"folio_id": folio.id, "display_type": "line_section", "name": "Section"}
+        )
+        payload = {
+            "validate": False,
+            "customerId": self.customer.id,
+            "lines": [
+                {"saleLineId": section.id, "description": "s", "quantityToInvoice": 1}
+            ],
+        }
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/invalid-sale-line")
+
+    def test_create_invoice_quantity_exceeds_pending(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client,
+                self._create_payload(line, qty=999, customer_id=self.customer.id),
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/quantity-exceeds-pending")
+
+    def test_create_invoice_customer_not_found(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client, self._create_payload(line, customer_id=999999999)
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+
+    def test_create_invoice_customer_fails_validation(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client,
+                self._create_payload(line, customer_id=self.customer_no_id.id),
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/invoicing-validation-failed")
+
+    def test_create_invoice_simplified_limit_exceeded(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        self.test_property.write({"max_amount_simplified_invoice": 1.0})
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client, self._create_payload(line, customer_id=None)
+            )
+        self.test_property.write({"max_amount_simplified_invoice": 0.0})
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(
+            response.json()["type"], "/errors/simplified-invoice-limit-exceeded"
+        )
+
+    def test_create_invoice_multiple_properties(self):
+        folio_a = self._confirmed_folio()
+        line_a = self._room_line(folio_a)
+
+        property_b = self.env["pms.property"].create(
+            {
+                "name": "Property B",
+                "company_id": self.test_company.id,
+                "default_pricelist_id": self.test_pricelist.id,
+                "user_ids": [(6, 0, [self.test_user.id])],
+            }
+        )
+        self.room_type.write({"pms_property_ids": [(4, property_b.id)]})
+        self.env["pms.room"].create(
+            {
+                "pms_property_id": property_b.id,
+                "name": "201",
+                "room_type_id": self.room_type.id,
+                "capacity": 2,
+            }
+        )
+        folio_b = self.env["pms.folio"].create(
+            {
+                "pms_property_id": property_b.id,
+                "partner_name": self.guest.name,
+                "partner_id": self.guest.id,
+            }
+        )
+        self.env["pms.reservation"].create(
+            {
+                "folio_id": folio_b.id,
+                "room_type_id": self.room_type.id,
+                "partner_id": self.guest.id,
+                "adults": 1,
+                "sale_channel_origin_id": self.sale_channel.id,
+                "reservation_line_ids": [(0, False, {"date": fields.date.today()})],
+            }
+        )
+        folio_b.action_confirm()
+        folio_b.reservation_ids.reservation_line_ids.write({"price": 100.0})
+        line_b = self._room_line(folio_b)
+
+        payload = {
+            "validate": False,
+            "customerId": self.customer.id,
+            "lines": [
+                {"saleLineId": line_a.id, "description": "a", "quantityToInvoice": 1},
+                {"saleLineId": line_b.id, "description": "b", "quantityToInvoice": 1},
+            ],
+        }
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(test_client, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/multiple-properties")
+
+    # ------------------------------------------------------------------
+    # PUT /invoices/{id} — edit
+    # ------------------------------------------------------------------
+    def _create_draft_invoice(self, test_client, folio, qty=1):
+        line = self._room_line(folio)
+        response = self._post_invoice(
+            test_client,
+            self._create_payload(line, qty=qty, customer_id=self.customer.id),
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        return response.json()["id"], line
+
+    def _edit_payload(self, line, quantity=1, partner=None):
+        return {
+            "partner": (partner or self.customer).id,
+            "invoiceDate": None,
+            "invoiceDateDue": None,
+            "narration": "",
+            "folioLines": [
+                {"id": line.id, "quantity": quantity, "description": "Edited"}
+            ],
+            "downpaymentLines": [],
+        }
+
+    def test_edit_invoice_not_found(self):
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.put(
+                "/invoices/999999999", json=self._edit_payload(line)
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+
+    def test_edit_draft_invoice_rewrites_in_place(self):
+        folio = self._confirmed_folio()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            invoice_id, line = self._create_draft_invoice(test_client, folio, qty=2)
+            response = test_client.put(
+                f"/invoices/{invoice_id}",
+                json=self._edit_payload(line, quantity=1),
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        data = response.json()
+        self.assertEqual(data["id"], invoice_id)
+        self.assertEqual(data["state"], "draft")
+        folio_line = next(fl for fl in data["folioLines"] if fl["id"] == line.id)
+        self.assertEqual(folio_line["quantity"], 1)
+
+    def test_edit_posted_invoice_requires_refund_confirmation(self):
+        folio = self._confirmed_folio()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            invoice_id, line = self._create_draft_invoice(test_client, folio, qty=1)
+            validate = test_client.post(f"/invoices/{invoice_id}/validate")
+            self.assertEqual(validate.status_code, status.HTTP_200_OK, validate.text)
+            response = test_client.put(
+                f"/invoices/{invoice_id}", json=self._edit_payload(line, quantity=1)
+            )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(
+            response.json()["type"],
+            "/errors/invoice-refund-confirmation-required",
+        )
+
+    def test_edit_posted_invoice_with_confirm_refund_creates_replacement(self):
+        folio = self._confirmed_folio()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            invoice_id, line = self._create_draft_invoice(test_client, folio, qty=1)
+            test_client.post(f"/invoices/{invoice_id}/validate")
+            response = test_client.put(
+                f"/invoices/{invoice_id}?confirmRefund=true",
+                json=self._edit_payload(line, quantity=1),
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        data = response.json()
+        self.assertNotEqual(data["id"], invoice_id)
+        self.assertIsNotNone(data["replaces"])
+        self.assertEqual(data["replaces"]["id"], invoice_id)
+
+    def test_edit_invoice_composition_already_invoiced(self):
+        folio = self._confirmed_folio()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            # Two drafts share the same sale line (partial invoices).
+            _first_id, line = self._create_draft_invoice(test_client, folio, qty=1)
+            second_id, _line = self._create_draft_invoice(test_client, folio, qty=1)
+            response = test_client.put(
+                f"/invoices/{second_id}", json=self._edit_payload(line, quantity=1)
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/invoice-composition-invalid")
+
+    def test_edit_invoice_partner_fails_validation(self):
+        folio = self._confirmed_folio()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            invoice_id, line = self._create_draft_invoice(test_client, folio, qty=1)
+            response = test_client.put(
+                f"/invoices/{invoice_id}",
+                json=self._edit_payload(line, partner=self.customer_no_id),
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(response.json()["type"], "/errors/invoicing-validation-failed")

--- a/pms_fastapi/tests/test_folio_invoicing.py
+++ b/pms_fastapi/tests/test_folio_invoicing.py
@@ -1,8 +1,10 @@
 import datetime
+from unittest.mock import patch
 
 from fastapi import status
 
 from odoo import Command, fields
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
@@ -387,6 +389,43 @@ class TestFolioInvoicing(CommonTestPmsApi):
         )
         self.assertEqual(response.json()["type"], "/errors/multiple-properties")
 
+    def test_create_invoice_rolls_back_on_move_error(self):
+        # A receivable account with a wrong account_type makes the core
+        # constraint _check_payable_receivable raise while account.move is
+        # being created. Odoo constraints run after the INSERT, so without a
+        # savepoint around the attempt the move would get committed even
+        # though the endpoint returns an error. The request must fail AND
+        # leave no orphan move behind.
+        folio = self._confirmed_folio()
+        line = self._room_line(folio)
+        bad_account = self.env["account.account"].create(
+            {
+                "name": "Wrong Receivable",
+                "code": "TESTBADRCV",
+                "account_type": "asset_current",
+                "company_id": self.test_company.id,
+            }
+        )
+        self.customer.with_company(
+            self.test_company
+        ).property_account_receivable_id = bad_account
+        move_domain = [("folio_ids", "in", folio.ids)]
+        self.assertEqual(self.env["account.move"].search_count(move_domain), 0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = self._post_invoice(
+                test_client,
+                self._create_payload(line, customer_id=self.customer.id),
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(
+            self.env["account.move"].search_count(move_domain),
+            0,
+            "A failed invoice creation must not leave an orphan move.",
+        )
+
     # ------------------------------------------------------------------
     # POST /folios/invoices — downpaymentLines
     # ------------------------------------------------------------------
@@ -579,3 +618,102 @@ class TestFolioInvoicing(CommonTestPmsApi):
             response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
         )
         self.assertEqual(response.json()["type"], "/errors/invoicing-validation-failed")
+
+    # ------------------------------------------------------------------
+    # Transaction safety — a failure after a mutation must roll back
+    # ------------------------------------------------------------------
+    def test_edit_draft_invoice_rolls_back_on_failure(self):
+        # _edit_draft_invoice unlinks the draft's lines and then rebuilds them.
+        # If the rebuild step fails, the savepoint must restore the lines
+        # instead of leaving the draft emptied.
+        folio = self._confirmed_folio()
+        helper_cls = type(self.env["pms_api_invoice.invoice_router.helper"])
+
+        def _boom(helper, *args, **kwargs):
+            helper._raise_edit_problem(
+                422, "/errors/injected-failure", "Injected", "boom"
+            )
+
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            invoice_id, line = self._create_draft_invoice(test_client, folio, qty=2)
+            with patch.object(helper_cls, "_edit_compute_invoice_vals", _boom):
+                response = test_client.put(
+                    f"/invoices/{invoice_id}",
+                    json=self._edit_payload(line, quantity=1),
+                )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        invoice = self.env["account.move"].browse(invoice_id)
+        self.assertTrue(
+            invoice.invoice_line_ids,
+            "A rolled-back edit must leave the draft's lines intact.",
+        )
+
+    def test_edit_posted_invoice_rolls_back_on_failure(self):
+        # _edit_posted_invoice reverses the invoice (posted credit note) before
+        # rebuilding. If the rebuild fails, the savepoint must roll back so no
+        # orphan credit note is committed and the original stays posted.
+        folio = self._confirmed_folio()
+        helper_cls = type(self.env["pms_api_invoice.invoice_router.helper"])
+
+        def _boom(helper, *args, **kwargs):
+            helper._raise_edit_problem(
+                422, "/errors/injected-failure", "Injected", "boom"
+            )
+
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            invoice_id, line = self._create_draft_invoice(test_client, folio, qty=1)
+            self.assertEqual(
+                test_client.post(f"/invoices/{invoice_id}/validate").status_code,
+                status.HTTP_200_OK,
+            )
+            moves_before = self.env["account.move"].search_count(
+                [("company_id", "=", self.test_company.id)]
+            )
+            with patch.object(helper_cls, "_edit_compute_invoice_vals", _boom):
+                response = test_client.put(
+                    f"/invoices/{invoice_id}?confirmRefund=true",
+                    json=self._edit_payload(line, quantity=1),
+                )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        invoice = self.env["account.move"].browse(invoice_id)
+        self.assertEqual(invoice.state, "posted")
+        self.assertEqual(
+            self.env["account.move"].search_count(
+                [("company_id", "=", self.test_company.id)]
+            ),
+            moves_before,
+            "The reversal credit note must be rolled back, leaving no orphan move.",
+        )
+
+    def test_validate_invoice_rolls_back_on_post_failure(self):
+        # If action_post mutates and then raises, the savepoint must roll back
+        # so the invoice is not left partially posted.
+        folio = self._confirmed_folio()
+        move_cls = type(self.env["account.move"])
+        marker = "ROLLED_BACK_MARKER"
+
+        def _boom(moves, *args, **kwargs):
+            moves.write({"narration": marker})
+            raise UserError("boom")
+
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            invoice_id, _line = self._create_draft_invoice(test_client, folio, qty=1)
+            with patch.object(move_cls, "action_post", _boom):
+                response = test_client.post(f"/invoices/{invoice_id}/validate")
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.text
+        )
+        invoice = self.env["account.move"].browse(invoice_id)
+        self.assertEqual(invoice.state, "draft")
+        self.assertNotEqual(
+            invoice.narration or "",
+            marker,
+            "The write done before the post failure must be rolled back.",
+        )

--- a/pms_fastapi/tests/test_invoice_contact_validation.py
+++ b/pms_fastapi/tests/test_invoice_contact_validation.py
@@ -1,0 +1,72 @@
+from fastapi import status
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+class TestInvoiceContactValidation(CommonTestPmsApi):
+    """GET /invoices/validate-contact — base invoicing requirements.
+
+    The base implementation only requires a VAT number. The Spanish-specific
+    rules (AEAT identification, passport restrictions) are tested in
+    pms_fastapi_l10n_es.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_with_vat = cls.env["res.partner"].create(
+            {
+                "firstname": "John",
+                "lastname": "Doe",
+                "vat": "ES12345678Z",
+            }
+        )
+        cls.partner_without_fiscal_id = cls.env["res.partner"].create(
+            {
+                "firstname": "Jane",
+                "lastname": "Roe",
+            }
+        )
+
+    def _validate_url(self, contact_id, property_id=None):
+        property_id = self.test_property.id if property_id is None else property_id
+        return (
+            "/invoices/validate-contact"
+            f"?pmsPropertyId={property_id}&contactId={contact_id}"
+        )
+
+    def test_contact_with_vat_is_valid(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(self._validate_url(self.partner_with_vat.id))
+        self.assertEqual(
+            response.status_code, status.HTTP_204_NO_CONTENT, response.text
+        )
+
+    def test_contact_without_fiscal_id_is_invalid(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                self._validate_url(self.partner_without_fiscal_id.id)
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        body = response.json()
+        self.assertEqual(body["type"], "/errors/invoicing-validation-failed")
+        error_types = [e["type"] for e in body["errors"]]
+        self.assertIn("/errors/missing-fiscal-id", error_types)
+
+    def test_unknown_contact_returns_404(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(self._validate_url(999999999))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+
+    def test_unknown_property_returns_404(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                self._validate_url(self.partner_with_vat.id, property_id=999999999)
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)

--- a/pms_fastapi/tests/test_invoice_reconciliation.py
+++ b/pms_fastapi/tests/test_invoice_reconciliation.py
@@ -1,0 +1,229 @@
+from fastapi import status
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+@tagged("post_install", "-at_install")
+class TestInvoiceReconciliation(CommonTestPmsApi):
+    """Payment reconciliation endpoints on /invoices/{id}.
+
+    Covers create/delete reconciliation and the reconcilable-payments listing,
+    including the RFC 9457 problem branches.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.test_company
+        if not company.chart_template_id:
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            if not coa:
+                cls.skipTest(cls, "No chart of accounts available.")
+            coa.try_loading(company=company, install_demo=False)
+        cls.env.user.write(
+            {
+                "company_ids": [Command.link(company.id)],
+                "company_id": company.id,
+            }
+        )
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=company.ids)
+        )
+        cls.journal_sale = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", company.id)], limit=1
+        )
+        cls.journal_bank = cls.env["account.journal"].search(
+            [("type", "in", ("bank", "cash")), ("company_id", "=", company.id)],
+            limit=1,
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Recon Customer"})
+        cls.other_partner = cls.env["res.partner"].create({"name": "Other Customer"})
+
+    # -- helpers -------------------------------------------------------
+    def _create_invoice(self, amount=100.0, post=True):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "pms_property_id": self.test_property.id,
+                "journal_id": self.journal_sale.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Line",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        if post:
+            invoice.action_post()
+        return invoice
+
+    def _create_payment(self, amount=100.0, partner=None):
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": (partner or self.partner).id,
+                "amount": amount,
+                "journal_id": self.journal_bank.id,
+            }
+        )
+        payment.action_post()
+        return payment
+
+    def _payment_id(self, payment):
+        return f"payment_{payment.id}"
+
+    # ------------------------------------------------------------------
+    # POST /invoices/{id}/reconciliations
+    # ------------------------------------------------------------------
+    def test_create_reconciliation_invoice_not_found(self):
+        payment = self._create_payment()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/invoices/999999999/reconciliations",
+                json={"paymentId": self._payment_id(payment)},
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+
+    def test_create_reconciliation_draft_invoice_not_editable(self):
+        invoice = self._create_invoice(post=False)
+        payment = self._create_payment()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                f"/invoices/{invoice.id}/reconciliations",
+                json={"paymentId": self._payment_id(payment)},
+            )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(response.json()["type"], "/errors/invoice-not-editable")
+
+    def test_create_reconciliation_payment_not_found(self):
+        invoice = self._create_invoice()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                f"/invoices/{invoice.id}/reconciliations",
+                json={"paymentId": "payment_999999999"},
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/payment-not-found")
+
+    def test_create_reconciliation_payment_not_applicable(self):
+        invoice = self._create_invoice()
+        payment = self._create_payment(partner=self.other_partner)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                f"/invoices/{invoice.id}/reconciliations",
+                json={"paymentId": self._payment_id(payment)},
+            )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(response.json()["type"], "/errors/payment-not-applicable")
+
+    def test_create_reconciliation_success(self):
+        invoice = self._create_invoice(amount=100.0)
+        payment = self._create_payment(amount=100.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                f"/invoices/{invoice.id}/reconciliations",
+                json={"paymentId": self._payment_id(payment)},
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        self.assertEqual(response.json()["paymentState"], "paid")
+
+    def test_create_reconciliation_already_reconciled(self):
+        invoice = self._create_invoice(amount=100.0)
+        payment = self._create_payment(amount=40.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            first = test_client.post(
+                f"/invoices/{invoice.id}/reconciliations",
+                json={"paymentId": self._payment_id(payment)},
+            )
+            self.assertEqual(first.status_code, status.HTTP_200_OK, first.text)
+            second = test_client.post(
+                f"/invoices/{invoice.id}/reconciliations",
+                json={"paymentId": self._payment_id(payment)},
+            )
+        self.assertEqual(second.status_code, status.HTTP_409_CONFLICT, second.text)
+        self.assertEqual(second.json()["type"], "/errors/payment-already-reconciled")
+
+    # ------------------------------------------------------------------
+    # DELETE /invoices/{id}/reconciliations/{reconciliation_id}
+    # ------------------------------------------------------------------
+    def test_delete_reconciliation_invoice_not_found(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(
+                "/invoices/999999999/reconciliations/payment_1"
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+
+    def test_delete_reconciliation_not_found(self):
+        invoice = self._create_invoice(amount=100.0)
+        payment = self._create_payment(amount=100.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(
+                f"/invoices/{invoice.id}/reconciliations/{self._payment_id(payment)}"
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/reconciliation-not-found")
+
+    def test_delete_reconciliation_success(self):
+        invoice = self._create_invoice(amount=100.0)
+        payment = self._create_payment(amount=40.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            created = test_client.post(
+                f"/invoices/{invoice.id}/reconciliations",
+                json={"paymentId": self._payment_id(payment)},
+            )
+            self.assertEqual(created.status_code, status.HTTP_200_OK, created.text)
+            response = test_client.delete(
+                f"/invoices/{invoice.id}/reconciliations/{self._payment_id(payment)}"
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        self.assertEqual(response.json()["paymentState"], "notPaid")
+
+    # ------------------------------------------------------------------
+    # GET /invoices/{id}/reconcilable-payments
+    # ------------------------------------------------------------------
+    def test_reconcilable_payments_invoice_not_found(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/invoices/999999999/reconcilable-payments")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+
+    def test_reconcilable_payments_draft_invoice_empty(self):
+        invoice = self._create_invoice(post=False)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/invoices/{invoice.id}/reconcilable-payments")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        self.assertEqual(response.json(), [])
+
+    def test_reconcilable_payments_lists_available_payment(self):
+        invoice = self._create_invoice(amount=100.0)
+        payment = self._create_payment(amount=100.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/invoices/{invoice.id}/reconcilable-payments")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        ids = [p["id"] for p in response.json()]
+        self.assertIn(self._payment_id(payment), ids)

--- a/pms_fastapi/tests/test_invoice_reconciliation.py
+++ b/pms_fastapi/tests/test_invoice_reconciliation.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 from fastapi import status
 
 from odoo import Command
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
@@ -162,6 +165,33 @@ class TestInvoiceReconciliation(CommonTestPmsApi):
             )
         self.assertEqual(second.status_code, status.HTTP_409_CONFLICT, second.text)
         self.assertEqual(second.json()["type"], "/errors/payment-already-reconciled")
+
+    def test_create_reconciliation_rolls_back_on_failure(self):
+        # If reconcile() mutates and then raises, the savepoint must roll back
+        # so no partial reconciliation is committed while we return an error.
+        invoice = self._create_invoice(amount=100.0)
+        payment = self._create_payment(amount=100.0)
+        line_cls = type(self.env["account.move.line"])
+        marker = "ROLLED_BACK_MARKER"
+
+        def _boom(lines, *args, **kwargs):
+            lines.move_id.write({"narration": marker})
+            raise UserError("boom")
+
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            with patch.object(line_cls, "reconcile", _boom):
+                response = test_client.post(
+                    f"/invoices/{invoice.id}/reconciliations",
+                    json={"paymentId": self._payment_id(payment)},
+                )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertNotEqual(
+            invoice.narration or "",
+            marker,
+            "The write done before the reconcile failure must be rolled back.",
+        )
+        self.assertNotEqual(invoice.payment_state, "paid")
 
     # ------------------------------------------------------------------
     # DELETE /invoices/{id}/reconciliations/{reconciliation_id}

--- a/pms_fastapi/tests/test_invoices.py
+++ b/pms_fastapi/tests/test_invoices.py
@@ -146,13 +146,81 @@ class TestInvoicesEndpoints(CommonTestPmsApi):
         )
         self.assertFalse(invoice.exists())
 
-    def test_delete_invoice_posted(self):
-        """DELETE /invoices/{id} returns 409 for a posted invoice."""
+    def test_delete_invoice_posted_requires_confirmation(self):
+        """DELETE /invoices/{id} on a posted invoice without confirmRefund -> 409."""
         invoice = self._create_invoice()
         self.assertEqual(invoice.state, "posted")
         with self._create_test_client() as test_client:
             self._login(test_client)
             response = test_client.delete(f"/invoices/{invoice.id}")
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(
+            response.json()["type"], "/errors/invoice-refund-confirmation-required"
+        )
+        self.assertTrue(invoice.exists())
+        self.assertEqual(invoice.state, "posted")
+
+    def test_delete_invoice_posted_with_confirm_refund(self):
+        """DELETE with confirmRefund=true reverses the posted invoice and returns
+        the credit note that cancels it.
+
+        The reversal fully reconciles against the original (cancel=True), so the
+        invoice stays posted but its payment_state becomes 'reversed'.
+        """
+        invoice = self._create_invoice(amount=100.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(f"/invoices/{invoice.id}?confirmRefund=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        data = response.json()
+        self.assertNotEqual(data["id"], invoice.id)
+        credit_note = self.env["account.move"].browse(data["id"])
+        self.assertEqual(credit_note.move_type, "out_refund")
+        invoice.invalidate_recordset(["payment_state"])
+        self.assertEqual(invoice.payment_state, "reversed")
+
+    def test_delete_invoice_posted_reason_recorded(self):
+        """DELETE with confirmRefund=true records the reason on the credit note ref."""
+        invoice = self._create_invoice(amount=100.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(
+                f"/invoices/{invoice.id}?confirmRefund=true&reason=Wrong+customer"
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        credit_note = self.env["account.move"].browse(response.json()["id"])
+        self.assertIn("Wrong customer", credit_note.ref)
+
+    def test_delete_invoice_paid_keeps_payments(self):
+        """DELETE with confirmRefund=true on a paid invoice posts an open credit
+        note and leaves the original paid (not reconciled against it)."""
+        invoice = self._create_invoice(amount=100.0)
+        self.env["account.payment.register"].with_context(
+            active_model="account.move", active_ids=invoice.ids
+        ).create({})._create_payments()
+        invoice.invalidate_recordset(["payment_state"])
+        self.assertEqual(invoice.payment_state, "paid")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(f"/invoices/{invoice.id}?confirmRefund=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        credit_note = self.env["account.move"].browse(response.json()["id"])
+        self.assertEqual(credit_note.move_type, "out_refund")
+        self.assertEqual(credit_note.state, "posted")
+        # Credit note is open (refund owed), not reconciled against the original.
+        self.assertEqual(credit_note.payment_state, "not_paid")
+        # Original keeps its payment untouched.
+        invoice.invalidate_recordset(["payment_state"])
+        self.assertEqual(invoice.payment_state, "paid")
+
+    def test_delete_invoice_cancelled(self):
+        """DELETE on an already cancelled invoice returns 409 and keeps it."""
+        invoice = self._create_invoice()
+        invoice.button_cancel()
+        self.assertEqual(invoice.state, "cancel")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(f"/invoices/{invoice.id}?confirmRefund=true")
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
         self.assertEqual(response.json()["type"], "/errors/invoice-not-deletable")
         self.assertTrue(invoice.exists())

--- a/pms_fastapi/tests/test_invoices.py
+++ b/pms_fastapi/tests/test_invoices.py
@@ -134,6 +134,36 @@ class TestInvoicesEndpoints(CommonTestPmsApi):
             response = test_client.post("/invoices/999999999/validate")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_delete_invoice(self):
+        """DELETE /invoices/{id} removes a draft invoice and returns 204."""
+        invoice = self._create_draft_invoice()
+        self.assertEqual(invoice.state, "draft")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(f"/invoices/{invoice.id}")
+        self.assertEqual(
+            response.status_code, status.HTTP_204_NO_CONTENT, response.text
+        )
+        self.assertFalse(invoice.exists())
+
+    def test_delete_invoice_posted(self):
+        """DELETE /invoices/{id} returns 409 for a posted invoice."""
+        invoice = self._create_invoice()
+        self.assertEqual(invoice.state, "posted")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete(f"/invoices/{invoice.id}")
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(response.json()["type"], "/errors/invoice-not-deletable")
+        self.assertTrue(invoice.exists())
+
+    def test_delete_invoice_not_found(self):
+        """DELETE /invoices/{id} returns 404 for a non-existent invoice."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.delete("/invoices/999999999")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_invoices_get(self):
         with self._create_test_client() as test_client:
             self._login(test_client)

--- a/pms_fastapi/tests/test_invoices.py
+++ b/pms_fastapi/tests/test_invoices.py
@@ -142,6 +142,28 @@ class TestInvoicesEndpoints(CommonTestPmsApi):
             self.assertIn("count", response.json())
             self.assertIn("items", response.json())
 
+    def test_get_invoice_detail(self):
+        """GET /invoices/{id} returns the InvoiceDetail of a single invoice."""
+        invoice = self._create_invoice(amount=120.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/invoices/{invoice.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        data = response.json()
+        self.assertEqual(data["id"], invoice.id)
+        self.assertEqual(data["state"], "posted")
+        # InvoiceDetail-only fields absent from InvoiceSummary.
+        self.assertIn("lines", data)
+        self.assertIn("payments", data)
+
+    def test_get_invoice_detail_not_found(self):
+        """GET /invoices/{id} returns 404 (ProblemDetail) for a missing invoice."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/invoices/999999999")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/not-found")
+
     def test_invoice_payment_type_payment(self):
         """Register a payment against an invoice and check paymentType=payment."""
         invoice = self._create_invoice(amount=150.0)

--- a/pms_fastapi/tests/test_journals.py
+++ b/pms_fastapi/tests/test_journals.py
@@ -4,9 +4,75 @@ from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
 
 
 class TestJournalsEndpoints(CommonTestPmsApi):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.cash_journal = cls.env["account.journal"].create(
+            {
+                "name": "PMS Cash",
+                "type": "cash",
+                "code": "PCSH",
+                "company_id": cls.test_company.id,
+                "allowed_on_pms": True,
+                "pms_property_ids": [(6, 0, [cls.test_property.id])],
+            }
+        )
+        cls.bank_journal = cls.env["account.journal"].create(
+            {
+                "name": "PMS Bank",
+                "type": "bank",
+                "code": "PBNK",
+                "company_id": cls.test_company.id,
+                "allowed_on_pms": True,
+                "pms_property_ids": [(6, 0, [cls.test_property.id])],
+            }
+        )
+        cls.sale_journal = cls.env["account.journal"].create(
+            {
+                "name": "PMS Sale",
+                "type": "sale",
+                "code": "PSAL",
+                "company_id": cls.test_company.id,
+                "allowed_on_pms": True,
+                "pms_property_ids": [(6, 0, [cls.test_property.id])],
+            }
+        )
+
     def test_journals_get(self):
         with self._create_test_client() as test_client:
-            response = self._login(test_client)
+            self._login(test_client)
             response = test_client.get("/journals")
             self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
             self.assertIsInstance(response.json(), list)
+
+    def test_journals_filter_single_type(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/journals", params={"journalType": "cash"})
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+            ids = {row["id"] for row in response.json()}
+            self.assertIn(self.cash_journal.id, ids)
+            self.assertNotIn(self.bank_journal.id, ids)
+            self.assertNotIn(self.sale_journal.id, ids)
+
+    def test_journals_filter_multiple_types(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                "/journals", params={"journalType": ["cash", "bank"]}
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+            ids = {row["id"] for row in response.json()}
+            self.assertIn(self.cash_journal.id, ids)
+            self.assertIn(self.bank_journal.id, ids)
+            self.assertNotIn(self.sale_journal.id, ids)
+
+    def test_journals_filter_invalid_type(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/journals", params={"journalType": "wrong"})
+            self.assertEqual(
+                response.status_code,
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                response.text,
+            )

--- a/pms_fastapi/tests/test_payment_creation.py
+++ b/pms_fastapi/tests/test_payment_creation.py
@@ -1,0 +1,361 @@
+from fastapi import status
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentCreationEndpoints(CommonTestPmsApi):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.test_company
+        if not company.chart_template_id:
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            if not coa:
+                cls.skipTest(cls, "No chart of accounts available.")
+            coa.try_loading(company=company, install_demo=False)
+        cls.env.user.write(
+            {
+                "company_ids": [Command.link(company.id)],
+                "company_id": company.id,
+            }
+        )
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=company.ids)
+        )
+        cls.journal_cash = cls.env["account.journal"].create(
+            {
+                "name": "Cash Reception",
+                "type": "cash",
+                "code": "CSHP",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+            }
+        )
+        cls.journal_bank = cls.env["account.journal"].create(
+            {
+                "name": "Bank PMS",
+                "type": "bank",
+                "code": "BNKP",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+            }
+        )
+        cls.journal_bank2 = cls.env["account.journal"].create(
+            {
+                "name": "Bank PMS 2",
+                "type": "bank",
+                "code": "BNKP2",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+            }
+        )
+        cls.bank_inbound = cls.journal_bank.inbound_payment_method_line_ids[:1]
+        cls.bank_outbound = cls.journal_bank.outbound_payment_method_line_ids[:1]
+        cls.cash_outbound = cls.journal_cash.outbound_payment_method_line_ids[:1]
+        cls.customer = cls.env["res.partner"].create({"name": "Pay Customer"})
+        cls.supplier = cls.env["res.partner"].create({"name": "Pay Supplier"})
+        cls.product = cls.env["product.product"].create(
+            {"name": "Service", "type": "service"}
+        )
+
+    def _folio(self):
+        return self.env["pms.folio"].create(
+            {
+                "pms_property_id": self.test_property.id,
+                "partner_name": self.customer.name,
+                "partner_id": self.customer.id,
+            }
+        )
+
+    def _invoice_for_folio(self, folio, amount=100.0):
+        line = self.env["folio.sale.line"].create(
+            {
+                "folio_id": folio.id,
+                "name": "Stay",
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "product_uom_qty": 1,
+                "price_unit": amount,
+            }
+        )
+        return self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.customer.id,
+                "folio_ids": [(6, 0, folio.ids)],
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Stay",
+                            "product_id": self.product.id,
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "folio_line_ids": [(6, 0, line.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+
+    # -- POST /payments --
+
+    def test_supplier_payment(self):
+        """supplierPayment with no folio/invoice context → simple payment."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "supplierPayment",
+                    "amount": 80.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_outbound.id,
+                    "partnerId": self.supplier.id,
+                    "reference": "206/26/026735",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        body = response.json()
+        self.assertEqual(body["paymentType"], "supplierPayment")
+        self.assertEqual(body["amount"], 80.0)
+        self.assertEqual(body["partner"]["id"], self.supplier.id)
+        self.assertEqual(body["reference"], "206/26/026735")
+        payment = self.env["account.payment"].browse(body["id"])
+        self.assertEqual(payment.state, "posted")
+        self.assertEqual(payment.journal_id, self.journal_bank)
+
+    def test_customer_payment_from_folio(self):
+        """customerPayment with folioId links the payment to the folio."""
+        folio = self._folio()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": 10.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_inbound.id,
+                    "partnerId": None,
+                    "folioId": folio.id,
+                    "reference": "",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        body = response.json()
+        self.assertEqual(body["paymentType"], "customerPayment")
+        self.assertEqual(body["amount"], 10.0)
+        self.assertEqual(body["folio"]["id"], folio.id)
+        self.assertIn(body["id"], folio.payment_ids.ids)
+
+    def test_customer_payment_from_invoice(self):
+        """customerPayment with invoiceId derives the folio from the invoice."""
+        folio = self._folio()
+        invoice = self._invoice_for_folio(folio)
+        self.assertIn(folio.id, invoice.folio_ids.ids)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": 25.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_inbound.id,
+                    "invoiceId": invoice.id,
+                    "reference": "",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        self.assertEqual(response.json()["folio"]["id"], folio.id)
+
+    def test_invoice_without_folio_returns_422(self):
+        """invoiceId of an invoice with no folio is a validation error."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.customer.id,
+                "invoice_line_ids": [
+                    (0, 0, {"name": "x", "quantity": 1, "price_unit": 10.0})
+                ],
+            }
+        )
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": 25.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_inbound.id,
+                    "invoiceId": invoice.id,
+                },
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+
+    def test_amount_not_positive_returns_422(self):
+        """amount <= 0 is rejected with 422."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": 0.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_inbound.id,
+                    "folioId": self._folio().id,
+                },
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+
+    def test_folio_and_invoice_mutually_exclusive_returns_422(self):
+        folio = self._folio()
+        invoice = self._invoice_for_folio(folio)
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": 10.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_inbound.id,
+                    "folioId": folio.id,
+                    "invoiceId": invoice.id,
+                },
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+        self.assertEqual(response.json()["type"], "/errors/validation-error")
+
+    def test_supplier_payment_without_partner_returns_422(self):
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "supplierPayment",
+                    "amount": 80.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_outbound.id,
+                    "partnerId": None,
+                },
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+
+    def test_unknown_payment_method_returns_404(self):
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "supplierPayment",
+                    "amount": 80.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": 999999,
+                    "partnerId": self.supplier.id,
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/record-not-found")
+
+    def test_cash_payment_auto_opens_session(self):
+        """Paying on a cash journal with no open session auto-opens one."""
+        Statement = self.env["account.bank.statement"]
+        domain = [
+            ("journal_id", "=", self.journal_cash.id),
+            ("cash_session_closed", "=", False),
+        ]
+        self.assertFalse(Statement.search(domain))
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "supplierPayment",
+                    "amount": 40.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.cash_outbound.id,
+                    "partnerId": self.supplier.id,
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        self.assertEqual(len(Statement.search(domain)), 1)
+
+    # -- POST /internal-transfers --
+
+    def test_internal_transfer(self):
+        """internalTransfer creates a transfer between two journals."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 30000.0,
+                    "date": "2026-03-04",
+                    "originJournalId": self.journal_bank.id,
+                    "destinationJournalId": self.journal_bank2.id,
+                    "reason": "Traspaso cierre de caja",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        body = response.json()
+        self.assertEqual(body["paymentType"], "internalTransfer")
+        self.assertEqual(body["amount"], 30000.0)
+        self.assertIsNone(body["partner"])
+        payment = self.env["account.payment"].browse(body["id"])
+        self.assertTrue(payment.is_internal_transfer)
+        self.assertEqual(payment.journal_id, self.journal_bank)
+
+    def test_internal_transfer_same_journal_returns_422(self):
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 100.0,
+                    "date": "2026-03-04",
+                    "originJournalId": self.journal_bank.id,
+                    "destinationJournalId": self.journal_bank.id,
+                    "reason": "",
+                },
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+        self.assertEqual(response.json()["type"], "/errors/validation-error")
+
+    def test_internal_transfer_unknown_journal_returns_404(self):
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 100.0,
+                    "date": "2026-03-04",
+                    "originJournalId": self.journal_bank.id,
+                    "destinationJournalId": 999999,
+                    "reason": "",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/record-not-found")

--- a/pms_fastapi/tests/test_payment_creation.py
+++ b/pms_fastapi/tests/test_payment_creation.py
@@ -59,6 +59,8 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         )
         cls.bank_inbound = cls.journal_bank.inbound_payment_method_line_ids[:1]
         cls.bank_outbound = cls.journal_bank.outbound_payment_method_line_ids[:1]
+        cls.bank2_inbound = cls.journal_bank2.inbound_payment_method_line_ids[:1]
+        cls.bank2_outbound = cls.journal_bank2.outbound_payment_method_line_ids[:1]
         cls.cash_outbound = cls.journal_cash.outbound_payment_method_line_ids[:1]
         cls.customer = cls.env["res.partner"].create({"name": "Pay Customer"})
         cls.supplier = cls.env["res.partner"].create({"name": "Pay Supplier"})
@@ -304,7 +306,7 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
     # -- POST /internal-transfers --
 
     def test_internal_transfer(self):
-        """internalTransfer creates a transfer between two journals."""
+        """internalTransfer creates a transfer between two payment methods."""
         with self._create_test_client() as test_client:
             self._login(test_client)
             response = test_client.post(
@@ -312,8 +314,8 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
                 json={
                     "amount": 30000.0,
                     "date": "2026-03-04",
-                    "originJournalId": self.journal_bank.id,
-                    "destinationJournalId": self.journal_bank2.id,
+                    "originPaymentMethodId": self.bank_outbound.id,
+                    "destinationPaymentMethodId": self.bank2_inbound.id,
                     "reason": "Traspaso cierre de caja",
                 },
             )
@@ -325,6 +327,46 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         payment = self.env["account.payment"].browse(body["id"])
         self.assertTrue(payment.is_internal_transfer)
         self.assertEqual(payment.journal_id, self.journal_bank)
+        self.assertEqual(payment.payment_method_line_id, self.bank_outbound)
+        self.assertEqual(
+            payment.paired_internal_transfer_payment_id.journal_id, self.journal_bank2
+        )
+
+    def test_internal_transfer_honors_destination_method_line(self):
+        """When the destination journal exposes more than one inbound method
+        line, the counterpart ends up with the one sent in the payload (not the
+        default Odoo would pick)."""
+        # Add a second inbound line to the destination journal and select it.
+        manual = self.bank2_inbound.payment_method_id
+        extra_inbound = self.env["account.payment.method.line"].create(
+            {
+                "name": "Bank PMS 2 inbound alt",
+                "payment_method_id": manual.id,
+                "journal_id": self.journal_bank2.id,
+            }
+        )
+        self.assertNotEqual(extra_inbound, self.bank2_inbound)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 500.0,
+                    "date": "2026-03-04",
+                    "originPaymentMethodId": self.bank_outbound.id,
+                    "destinationPaymentMethodId": extra_inbound.id,
+                    "reason": "",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        payment = self.env["account.payment"].browse(response.json()["id"])
+        counterpart = payment.paired_internal_transfer_payment_id
+        self.assertEqual(counterpart.payment_method_line_id, extra_inbound)
+        self.assertEqual(counterpart.state, "posted")
+        transfer_lines = (
+            payment.move_id.line_ids + counterpart.move_id.line_ids
+        ).filtered(lambda line: line.account_id == payment.destination_account_id)
+        self.assertTrue(all(transfer_lines.mapped("reconciled")))
 
     def test_internal_transfer_same_journal_returns_422(self):
         with self._create_test_client(raise_server_exceptions=False) as test_client:
@@ -334,8 +376,8 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
                 json={
                     "amount": 100.0,
                     "date": "2026-03-04",
-                    "originJournalId": self.journal_bank.id,
-                    "destinationJournalId": self.journal_bank.id,
+                    "originPaymentMethodId": self.bank_outbound.id,
+                    "destinationPaymentMethodId": self.bank_inbound.id,
                     "reason": "",
                 },
             )
@@ -344,7 +386,7 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         self.assertEqual(response.status_code, 422, response.text)
         self.assertEqual(response.json()["type"], "/errors/validation-error")
 
-    def test_internal_transfer_unknown_journal_returns_404(self):
+    def test_internal_transfer_unknown_method_returns_404(self):
         with self._create_test_client(raise_server_exceptions=False) as test_client:
             self._login(test_client)
             response = test_client.post(
@@ -352,27 +394,15 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
                 json={
                     "amount": 100.0,
                     "date": "2026-03-04",
-                    "originJournalId": self.journal_bank.id,
-                    "destinationJournalId": 999999,
+                    "originPaymentMethodId": self.bank_outbound.id,
+                    "destinationPaymentMethodId": 999999,
                     "reason": "",
                 },
             )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
         self.assertEqual(response.json()["type"], "/errors/record-not-found")
 
-    def test_internal_transfer_non_bank_cash_journal_returns_422(self):
-        """A transfer to/from a journal that is not bank or cash (e.g. a sale
-        journal) is rejected with a specific validation error instead of the
-        generic 400 Odoo raises when posting it."""
-        journal_sale = self.env["account.journal"].create(
-            {
-                "name": "Sales PMS",
-                "type": "sale",
-                "code": "SALP",
-                "company_id": self.test_company.id,
-                "pms_property_ids": [Command.set([self.test_property.id])],
-            }
-        )
+    def test_internal_transfer_origin_not_outbound_returns_422(self):
         with self._create_test_client(raise_server_exceptions=False) as test_client:
             self._login(test_client)
             response = test_client.post(
@@ -380,8 +410,26 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
                 json={
                     "amount": 100.0,
                     "date": "2026-03-04",
-                    "originJournalId": self.journal_bank.id,
-                    "destinationJournalId": journal_sale.id,
+                    "originPaymentMethodId": self.bank_inbound.id,
+                    "destinationPaymentMethodId": self.bank2_inbound.id,
+                    "reason": "",
+                },
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+        self.assertEqual(response.json()["type"], "/errors/validation-error")
+
+    def test_internal_transfer_destination_not_inbound_returns_422(self):
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 100.0,
+                    "date": "2026-03-04",
+                    "originPaymentMethodId": self.bank_outbound.id,
+                    "destinationPaymentMethodId": self.bank2_outbound.id,
                     "reason": "",
                 },
             )
@@ -494,8 +542,8 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
                 json={
                     "amount": 30000.0,
                     "date": "2026-03-04",
-                    "originJournalId": self.journal_bank.id,
-                    "destinationJournalId": self.journal_bank2.id,
+                    "originPaymentMethodId": self.bank_outbound.id,
+                    "destinationPaymentMethodId": self.bank2_inbound.id,
                     "reason": "Traspaso",
                 },
             )
@@ -525,8 +573,8 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
                 json={
                     "amount": 100.0,
                     "date": "2026-03-04",
-                    "originJournalId": self.journal_bank.id,
-                    "destinationJournalId": self.journal_bank2.id,
+                    "originPaymentMethodId": self.bank_outbound.id,
+                    "destinationPaymentMethodId": self.bank2_inbound.id,
                     "reason": "",
                 },
             )

--- a/pms_fastapi/tests/test_payment_creation.py
+++ b/pms_fastapi/tests/test_payment_creation.py
@@ -360,6 +360,36 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
         self.assertEqual(response.json()["type"], "/errors/record-not-found")
 
+    def test_internal_transfer_non_bank_cash_journal_returns_422(self):
+        """A transfer to/from a journal that is not bank or cash (e.g. a sale
+        journal) is rejected with a specific validation error instead of the
+        generic 400 Odoo raises when posting it."""
+        journal_sale = self.env["account.journal"].create(
+            {
+                "name": "Sales PMS",
+                "type": "sale",
+                "code": "SALP",
+                "company_id": self.test_company.id,
+                "pms_property_ids": [Command.set([self.test_property.id])],
+            }
+        )
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 100.0,
+                    "date": "2026-03-04",
+                    "originJournalId": self.journal_bank.id,
+                    "destinationJournalId": journal_sale.id,
+                    "reason": "",
+                },
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+        self.assertEqual(response.json()["type"], "/errors/validation-error")
+
     # -- PATCH /payments/{id} --
 
     def _create_supplier_payment(self, amount=80.0):

--- a/pms_fastapi/tests/test_payment_creation.py
+++ b/pms_fastapi/tests/test_payment_creation.py
@@ -359,3 +359,153 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
             )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
         self.assertEqual(response.json()["type"], "/errors/record-not-found")
+
+    # -- PATCH /payments/{id} --
+
+    def _create_supplier_payment(self, amount=80.0):
+        return (
+            self.env["account.payment"]
+            .sudo()
+            .create(
+                {
+                    "journal_id": self.journal_bank.id,
+                    "payment_method_line_id": self.bank_outbound.id,
+                    "partner_id": self.supplier.id,
+                    "amount": amount,
+                    "date": "2026-03-04",
+                    "payment_type": "outbound",
+                    "partner_type": "supplier",
+                }
+            )
+        )
+
+    def test_update_amount_and_date(self):
+        """Partial edit of amount and date on a registered payment."""
+        payment = self._create_supplier_payment()
+        payment.action_post()
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.patch(
+                f"/payments/{payment.id}",
+                json={"amount": 95.5, "date": "2026-04-10"},
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        body = response.json()
+        self.assertEqual(body["id"], payment.id)
+        self.assertEqual(body["amount"], 95.5)
+        self.assertEqual(body["date"], "2026-04-10")
+        self.assertEqual(payment.state, "posted")
+        self.assertEqual(payment.amount, 95.5)
+
+    def test_update_payment_method_to_other_journal_recreates(self):
+        """Odoo forbids changing the journal of a posted payment, so a payment
+        method change that moves to another journal cancels the original and
+        creates a replacement (new id), as the legacy API did."""
+        payment = self._create_supplier_payment()
+        payment.action_post()
+        original_id = payment.id
+        new_line = self.journal_bank2.outbound_payment_method_line_ids[:1]
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.patch(
+                f"/payments/{original_id}",
+                json={"paymentMethodId": new_line.id},
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        body = response.json()
+        self.assertNotEqual(body["id"], original_id)
+        self.assertEqual(body["paymentMethod"]["id"], new_line.id)
+        new_payment = self.env["account.payment"].browse(body["id"])
+        self.assertEqual(new_payment.journal_id, self.journal_bank2)
+        self.assertEqual(new_payment.state, "posted")
+        self.assertEqual(
+            self.env["account.payment"].browse(original_id).state, "cancel"
+        )
+
+    def test_update_amount_not_positive_returns_422(self):
+        payment = self._create_supplier_payment()
+        payment.action_post()
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.patch(
+                f"/payments/{payment.id}",
+                json={"amount": 0.0},
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+
+    def test_update_unknown_payment_returns_404(self):
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.patch("/payments/999999", json={"amount": 10.0})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/record-not-found")
+
+    def test_update_unknown_payment_method_returns_404(self):
+        payment = self._create_supplier_payment()
+        payment.action_post()
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.patch(
+                f"/payments/{payment.id}",
+                json={"paymentMethodId": 999999},
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/record-not-found")
+
+    def test_update_internal_transfer_syncs_both_legs(self):
+        """Editing the amount of one transfer leg updates the counterpart too
+        and keeps the pair reconciled."""
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            create = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 30000.0,
+                    "date": "2026-03-04",
+                    "originJournalId": self.journal_bank.id,
+                    "destinationJournalId": self.journal_bank2.id,
+                    "reason": "Traspaso",
+                },
+            )
+            self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.text)
+            payment = self.env["account.payment"].browse(create.json()["id"])
+            counterpart = payment.paired_internal_transfer_payment_id
+            self.assertTrue(counterpart)
+            response = test_client.patch(
+                f"/payments/{payment.id}",
+                json={"amount": 25000.0},
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        self.assertEqual(payment.amount, 25000.0)
+        self.assertEqual(counterpart.amount, 25000.0)
+        self.assertEqual(payment.state, "posted")
+        self.assertEqual(counterpart.state, "posted")
+        transfer_lines = (
+            payment.move_id.line_ids + counterpart.move_id.line_ids
+        ).filtered(lambda line: line.account_id == payment.destination_account_id)
+        self.assertTrue(all(transfer_lines.mapped("reconciled")))
+
+    def test_update_internal_transfer_payment_method_returns_422(self):
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            create = test_client.post(
+                "/internal-transfers",
+                json={
+                    "amount": 100.0,
+                    "date": "2026-03-04",
+                    "originJournalId": self.journal_bank.id,
+                    "destinationJournalId": self.journal_bank2.id,
+                    "reason": "",
+                },
+            )
+            payment_id = create.json()["id"]
+            response = test_client.patch(
+                f"/payments/{payment_id}",
+                json={"paymentMethodId": self.bank_inbound.id},
+            )
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+        self.assertEqual(response.json()["type"], "/errors/validation-error")

--- a/pms_fastapi/tests/test_payment_creation.py
+++ b/pms_fastapi/tests/test_payment_creation.py
@@ -1,6 +1,8 @@
+import datetime
+
 from fastapi import status
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.tests import tagged
 
 from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
@@ -67,6 +69,44 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         cls.product = cls.env["product.product"].create(
             {"name": "Service", "type": "service"}
         )
+        # Room infrastructure so a folio can hold a real (invoiceable)
+        # reservation line instead of a hand-crafted folio.sale.line.
+        cls.room_type_class = cls.env["pms.room.type.class"].create(
+            {"name": "Standard", "default_code": "STD"}
+        )
+        cls.room_type = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.test_property.id],
+                "name": "Double Test",
+                "default_code": "DBL_Test",
+                "class_id": cls.room_type_class.id,
+            }
+        )
+        cls.room1 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.test_property.id,
+                "name": "101",
+                "room_type_id": cls.room_type.id,
+                "capacity": 2,
+            }
+        )
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Direct Test", "channel_type": "direct"}
+        )
+        # Folio invoicing with no explicit partner picks the property's
+        # simplified sale journal; without it _create_invoices() raises.
+        cls.journal_simplified = cls.env["account.journal"].create(
+            {
+                "name": "Simplified Sales",
+                "code": "SIMP",
+                "type": "sale",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+            }
+        )
+        cls.test_property.write(
+            {"journal_simplified_invoice_id": cls.journal_simplified.id}
+        )
 
     def _folio(self):
         return self.env["pms.folio"].create(
@@ -77,37 +117,34 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
             }
         )
 
-    def _invoice_for_folio(self, folio, amount=100.0):
-        line = self.env["folio.sale.line"].create(
+    def _confirmed_folio(self, nights=2, price=100.0):
+        """A folio with a confirmed, invoiceable reservation."""
+        start = fields.date.today()
+        folio = self._folio()
+        self.env["pms.reservation"].create(
             {
                 "folio_id": folio.id,
-                "name": "Stay",
-                "product_id": self.product.id,
-                "product_uom": self.product.uom_id.id,
-                "product_uom_qty": 1,
-                "price_unit": amount,
-            }
-        )
-        return self.env["account.move"].create(
-            {
-                "move_type": "out_invoice",
+                "room_type_id": self.room_type.id,
                 "partner_id": self.customer.id,
-                "folio_ids": [(6, 0, folio.ids)],
-                "invoice_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "Stay",
-                            "product_id": self.product.id,
-                            "quantity": 1,
-                            "price_unit": amount,
-                            "folio_line_ids": [(6, 0, line.ids)],
-                        },
-                    )
+                "adults": 1,
+                "sale_channel_origin_id": self.sale_channel.id,
+                "reservation_line_ids": [
+                    (0, False, {"date": start + datetime.timedelta(days=i)})
+                    for i in range(nights)
                 ],
             }
         )
+        folio.action_confirm()
+        folio.reservation_ids.reservation_line_ids.write({"price": price})
+        return folio
+
+    def _invoice_for_folio(self, folio, post=True):
+        """Invoice the folio the way the PMS does (real sale lines), so the
+        folio<->invoice link is genuine."""
+        invoice = folio._create_invoices()[:1]
+        if post:
+            invoice.action_post()
+        return invoice
 
     # -- POST /payments --
 
@@ -160,12 +197,69 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         self.assertEqual(body["folio"]["id"], folio.id)
         self.assertIn(body["id"], folio.payment_ids.ids)
 
-    def test_customer_payment_from_invoice(self):
-        """customerPayment with invoiceId derives the folio from the invoice."""
-        folio = self._folio()
+    def test_customer_payment_from_invoice_reconciles(self):
+        """A payment from invoiceId is registered against the invoice and
+        reconciled with it; the folio link is then derived from the reconciled
+        invoice (not from do_payment)."""
+        folio = self._confirmed_folio()
         invoice = self._invoice_for_folio(folio)
         self.assertIn(folio.id, invoice.folio_ids.ids)
+        total = invoice.amount_total
+        pay_amount = round(total / 2, 2)
+        self.assertGreater(total, pay_amount)  # ensures a partial payment
         with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": pay_amount,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_inbound.id,
+                    "invoiceId": invoice.id,
+                    "reference": "",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        body = response.json()
+        self.assertEqual(body["folio"]["id"], folio.id)
+        payment = self.env["account.payment"].browse(body["id"])
+        # Reconciled directly against the invoice ...
+        self.assertIn(invoice.id, payment.reconciled_invoice_ids.ids)
+        # ... which leaves the invoice partially paid ...
+        self.assertEqual(invoice.payment_state, "partial")
+        self.assertAlmostEqual(invoice.amount_residual, total - pay_amount, places=2)
+        # ... and the folio link is the computed one (via the reconciled invoice).
+        self.assertIn(folio.id, payment.folio_ids.ids)
+
+    def test_customer_payment_from_invoice_full_marks_paid(self):
+        """Paying the full invoice residual marks it as paid."""
+        folio = self._confirmed_folio()
+        invoice = self._invoice_for_folio(folio)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": invoice.amount_total,
+                    "date": "2026-03-04",
+                    "paymentMethodId": self.bank_inbound.id,
+                    "invoiceId": invoice.id,
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
+        payment = self.env["account.payment"].browse(response.json()["id"])
+        self.assertIn(invoice.id, payment.reconciled_invoice_ids.ids)
+        self.assertEqual(invoice.payment_state, "paid")
+
+    def test_customer_payment_from_draft_invoice_returns_422(self):
+        """A not-posted invoice cannot be paid (would crash the register
+        wizard); the endpoint rejects it with 422 instead."""
+        folio = self._confirmed_folio()
+        invoice = self._invoice_for_folio(folio, post=False)
+        self.assertEqual(invoice.state, "draft")
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
             self._login(test_client)
             response = test_client.post(
                 "/payments",
@@ -175,11 +269,12 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
                     "date": "2026-03-04",
                     "paymentMethodId": self.bank_inbound.id,
                     "invoiceId": invoice.id,
-                    "reference": "",
                 },
             )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
-        self.assertEqual(response.json()["folio"]["id"], folio.id)
+        # 422 literal: 422 is deprecated in
+        # newer starlette and the test runner turns the warning into an error.
+        self.assertEqual(response.status_code, 422, response.text)
+        self.assertEqual(response.json()["type"], "/errors/validation-error")
 
     def test_invoice_without_folio_returns_422(self):
         """invoiceId of an invoice with no folio is a validation error."""
@@ -227,7 +322,7 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         self.assertEqual(response.status_code, 422, response.text)
 
     def test_folio_and_invoice_mutually_exclusive_returns_422(self):
-        folio = self._folio()
+        folio = self._confirmed_folio()
         invoice = self._invoice_for_folio(folio)
         with self._create_test_client(raise_server_exceptions=False) as test_client:
             self._login(test_client)

--- a/pms_fastapi/tests/test_payment_creation.py
+++ b/pms_fastapi/tests/test_payment_creation.py
@@ -398,6 +398,34 @@ class TestPaymentCreationEndpoints(CommonTestPmsApi):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.text)
         self.assertEqual(len(Statement.search(domain)), 1)
 
+    def test_cash_payment_rolls_back_phantom_session_on_failure(self):
+        """A cash payment that fails after the session was auto-opened (here a
+        non-existent folio) must roll back the phantom empty cash session
+        instead of committing it."""
+        Statement = self.env["account.bank.statement"]
+        cash_inbound = self.journal_cash.inbound_payment_method_line_ids[:1]
+        self.assertTrue(cash_inbound)
+        domain = [("journal_id", "=", self.journal_cash.id)]
+        self.assertFalse(Statement.search(domain))
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(
+                "/payments",
+                json={
+                    "paymentType": "customerPayment",
+                    "amount": 10.0,
+                    "date": "2026-03-04",
+                    "paymentMethodId": cash_inbound.id,
+                    "folioId": 999999999,
+                    "reference": "",
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertFalse(
+            Statement.search(domain),
+            "A failed cash payment must not leave a phantom cash session.",
+        )
+
     # -- POST /internal-transfers --
 
     def test_internal_transfer(self):

--- a/pms_fastapi/tests/test_payments.py
+++ b/pms_fastapi/tests/test_payments.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest.mock import patch
 
 from fastapi import status
 
@@ -261,5 +262,31 @@ class TestPaymentsEndpoints(CommonTestPmsApi):
         with self._create_test_client(raise_server_exceptions=False) as test_client:
             self._login(test_client)
             response = test_client.get("/payments/999999")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/payment-not-found")
+
+    def test_payment_report_pdf(self):
+        """GET /payments/{id}/report returns the PDF for a posted payment."""
+        payment = self._create_payment(amount=120.0)
+        fake_pdf = b"%PDF-1.4 fake"
+        with patch(
+            "odoo.addons.base.models.ir_actions_report.IrActionsReport"
+            "._render_qweb_pdf",
+            return_value=(fake_pdf, "pdf"),
+        ):
+            with self._create_test_client() as test_client:
+                self._login(test_client)
+                response = test_client.get(f"/payments/{payment.id}/report")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        self.assertEqual(response.headers["content-type"], "application/pdf")
+        self.assertIn("attachment", response.headers["content-disposition"])
+        self.assertIn(".pdf", response.headers["content-disposition"])
+        self.assertEqual(response.content, fake_pdf)
+
+    def test_payment_report_pdf_not_found(self):
+        """GET /payments/{id}/report on a missing id returns 404."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.get("/payments/999999/report")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
         self.assertEqual(response.json()["type"], "/errors/payment-not-found")

--- a/pms_fastapi/tests/test_payments.py
+++ b/pms_fastapi/tests/test_payments.py
@@ -240,3 +240,26 @@ class TestPaymentsEndpoints(CommonTestPmsApi):
         # their payment method, not by sign.
         self.assertEqual(items[outbound.id]["amount"], 30000.0)
         self.assertEqual(items[inbound.id]["amount"], 30000.0)
+
+    def test_get_payment_by_id(self):
+        """GET /payments/{id} returns the single payment (same model)."""
+        payment = self._create_payment(amount=120.0, ref="206/26/026735")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(f"/payments/{payment.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        body = response.json()
+        self.assertEqual(body["id"], payment.id)
+        self.assertEqual(body["paymentType"], "customerPayment")
+        self.assertEqual(body["amount"], 120.0)
+        self.assertEqual(body["reference"], "206/26/026735")
+        self.assertEqual(body["partner"]["id"], self.customer.id)
+        self.assertIsNotNone(body["currency"]["code"])
+
+    def test_get_unknown_payment_returns_404(self):
+        """GET /payments/{id} on a missing id returns 404 payment-not-found."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.get("/payments/999999")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/payment-not-found")

--- a/pms_fastapi/tests/test_payments.py
+++ b/pms_fastapi/tests/test_payments.py
@@ -290,3 +290,60 @@ class TestPaymentsEndpoints(CommonTestPmsApi):
             response = test_client.get("/payments/999999/report")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
         self.assertEqual(response.json()["type"], "/errors/payment-not-found")
+
+    def test_cancel_payment(self):
+        """POST /payments/{id}/cancel cancels the payment and returns it."""
+        payment = self._create_payment(amount=150.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(f"/payments/{payment.id}/cancel")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        self.assertEqual(response.json()["id"], payment.id)
+        self.assertEqual(payment.state, "cancel")
+
+    def test_cancel_payment_drops_it_from_listing(self):
+        """A cancelled payment leaves the (posted-only) listing."""
+        payment = self._create_payment(amount=150.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            test_client.post(f"/payments/{payment.id}/cancel")
+            items = self._items_by_id(
+                test_client.get(f"/payments?pmsPropertyId={self.test_property.id}")
+            )
+        self.assertNotIn(payment.id, items)
+
+    def test_cancel_unknown_payment_returns_404(self):
+        """POST /payments/{id}/cancel on a missing id returns 404."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post("/payments/999999/cancel")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.text)
+        self.assertEqual(response.json()["type"], "/errors/payment-not-found")
+
+    def test_cancel_payment_in_locked_period_returns_409(self):
+        """A payment dated within a locked fiscal period cannot be cancelled."""
+        payment = self._create_payment(amount=150.0, pay_date=date(2025, 12, 22))
+        self.test_company.sudo().write({"fiscalyear_lock_date": date(2025, 12, 31)})
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.post(f"/payments/{payment.id}/cancel")
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.text)
+        self.assertEqual(response.json()["type"], "/errors/fiscal-lock-date")
+        self.assertEqual(payment.state, "posted")
+
+    def test_cancel_internal_transfer_cancels_both_legs(self):
+        """Cancelling one leg of an internal transfer cancels its pair too."""
+        outbound = self._create_payment(
+            amount=500.0,
+            payment_type="outbound",
+            is_internal_transfer=True,
+            destination_journal=self.journal_bank2,
+        )
+        paired = outbound.paired_internal_transfer_payment_id
+        self.assertTrue(paired)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.post(f"/payments/{outbound.id}/cancel")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        self.assertEqual(outbound.state, "cancel")
+        self.assertEqual(paired.state, "cancel")

--- a/pms_fastapi/tests/test_payments.py
+++ b/pms_fastapi/tests/test_payments.py
@@ -1,0 +1,242 @@
+from datetime import date
+
+from fastapi import status
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentsEndpoints(CommonTestPmsApi):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.test_company
+        if not company.chart_template_id:
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            if not coa:
+                cls.skipTest(cls, "No chart of accounts available.")
+            coa.try_loading(company=company, install_demo=False)
+        cls.env.user.write(
+            {
+                "company_ids": [Command.link(company.id)],
+                "company_id": company.id,
+            }
+        )
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=company.ids)
+        )
+        # Journals tied to the property: only these must be in scope.
+        cls.journal_bank = cls.env["account.journal"].create(
+            {
+                "name": "Bank PMS",
+                "type": "bank",
+                "code": "BNKP",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+            }
+        )
+        cls.journal_bank2 = cls.env["account.journal"].create(
+            {
+                "name": "Bank PMS 2",
+                "type": "bank",
+                "code": "BNKP2",
+                "company_id": company.id,
+                "pms_property_ids": [Command.set([cls.test_property.id])],
+            }
+        )
+        # Journal NOT tied to any property: must stay out of scope.
+        cls.journal_no_property = cls.env["account.journal"].create(
+            {
+                "name": "Bank no property",
+                "type": "bank",
+                "code": "BNKNP",
+                "company_id": company.id,
+            }
+        )
+        cls.customer = cls.env["res.partner"].create({"name": "Payments Customer"})
+        cls.supplier = cls.env["res.partner"].create({"name": "Payments Supplier"})
+
+    def _create_payment(
+        self,
+        amount=100.0,
+        payment_type="inbound",
+        partner_type="customer",
+        journal=None,
+        partner=None,
+        ref="",
+        pay_date=None,
+        is_internal_transfer=False,
+        destination_journal=None,
+        post=True,
+    ):
+        vals = {
+            "amount": amount,
+            "payment_type": payment_type,
+            "partner_type": partner_type,
+            "journal_id": (journal or self.journal_bank).id,
+            "partner_id": (partner or self.customer).id,
+            "ref": ref,
+            "date": pay_date or date(2025, 12, 22),
+            "is_internal_transfer": is_internal_transfer,
+        }
+        if is_internal_transfer:
+            vals["destination_journal_id"] = (
+                destination_journal or self.journal_bank2
+            ).id
+        payment = self.env["account.payment"].create(vals)
+        if post:
+            payment.action_post()
+        return payment
+
+    def _items_by_id(self, response):
+        return {item["id"]: item for item in response.json()["items"]}
+
+    def test_list_payments_shape_and_mapping(self):
+        """GET /payments returns count+items and maps a customer payment."""
+        payment = self._create_payment(amount=120.0, ref="206/26/026544")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                f"/payments?pmsPropertyId={self.test_property.id}"
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+        body = response.json()
+        self.assertIn("count", body)
+        self.assertIn("items", body)
+        item = self._items_by_id(response)[payment.id]
+        self.assertEqual(item["paymentType"], "customerPayment")
+        self.assertEqual(item["amount"], 120.0)
+        self.assertEqual(item["reference"], "206/26/026544")
+        self.assertEqual(item["partner"]["id"], self.customer.id)
+        self.assertIsNotNone(item["currency"]["code"])
+        self.assertIsNotNone(item["createdBy"]["id"])
+        self.assertIsNotNone(item["paymentMethod"]["id"])
+
+    def test_amount_always_positive(self):
+        """Outbound payments are reported with a positive (absolute) amount."""
+        refund = self._create_payment(
+            amount=50.0, payment_type="outbound", partner_type="customer"
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                f"/payments?pmsPropertyId={self.test_property.id}"
+            )
+        item = self._items_by_id(response)[refund.id]
+        self.assertEqual(item["paymentType"], "customerRefund")
+        self.assertEqual(item["amount"], 50.0)
+
+    def test_payment_type_filter(self):
+        """paymentType filters by transaction type."""
+        customer_pay = self._create_payment(
+            payment_type="inbound", partner_type="customer"
+        )
+        supplier_pay = self._create_payment(
+            payment_type="outbound", partner_type="supplier", partner=self.supplier
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                f"/payments?pmsPropertyId={self.test_property.id}"
+                "&paymentType=customerPayment"
+            )
+        items = self._items_by_id(response)
+        self.assertIn(customer_pay.id, items)
+        self.assertNotIn(supplier_pay.id, items)
+
+    def test_amount_filters(self):
+        """amountGt / amountLt / amountEq filter by absolute amount."""
+        low = self._create_payment(amount=10.0)
+        high = self._create_payment(amount=1000.0)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            gt = self._items_by_id(
+                test_client.get(
+                    f"/payments?pmsPropertyId={self.test_property.id}&amountGt=100"
+                )
+            )
+            eq = self._items_by_id(
+                test_client.get(
+                    f"/payments?pmsPropertyId={self.test_property.id}&amountEq=10"
+                )
+            )
+        self.assertIn(high.id, gt)
+        self.assertNotIn(low.id, gt)
+        self.assertIn(low.id, eq)
+        self.assertNotIn(high.id, eq)
+
+    def test_reference_filter(self):
+        """reference filters exclusively on the payment reference."""
+        match = self._create_payment(ref="UNIQUEREF123")
+        other = self._create_payment(ref="somethingelse")
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            items = self._items_by_id(
+                test_client.get(
+                    f"/payments?pmsPropertyId={self.test_property.id}"
+                    "&reference=UNIQUEREF123"
+                )
+            )
+        self.assertIn(match.id, items)
+        self.assertNotIn(other.id, items)
+
+    def test_invalid_date_range_returns_422(self):
+        """dateTo earlier than dateFrom is rejected with 422."""
+        with self._create_test_client(raise_server_exceptions=False) as test_client:
+            self._login(test_client)
+            response = test_client.get(
+                f"/payments?pmsPropertyId={self.test_property.id}"
+                "&dateFrom=2025-12-31&dateTo=2025-01-01"
+            )
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+
+    def test_property_journal_scope(self):
+        """Payments on journals not tied to the property are out of scope."""
+        in_scope = self._create_payment(journal=self.journal_bank)
+        out_scope = self._create_payment(journal=self.journal_no_property)
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            items = self._items_by_id(
+                test_client.get(f"/payments?pmsPropertyId={self.test_property.id}")
+            )
+        self.assertIn(in_scope.id, items)
+        self.assertNotIn(out_scope.id, items)
+
+    def test_internal_transfer_both_legs(self):
+        """Internal transfers return BOTH legs (inbound + outbound), each as
+        internalTransfer, replicating the legacy API (no dedup)."""
+        outbound = self._create_payment(
+            amount=30000.0,
+            payment_type="outbound",
+            is_internal_transfer=True,
+            destination_journal=self.journal_bank2,
+        )
+        inbound = self._create_payment(
+            amount=30000.0,
+            payment_type="inbound",
+            is_internal_transfer=True,
+            journal=self.journal_bank2,
+            destination_journal=self.journal_bank,
+        )
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            items = self._items_by_id(
+                test_client.get(f"/payments?pmsPropertyId={self.test_property.id}")
+            )
+        self.assertIn(outbound.id, items)
+        self.assertIn(inbound.id, items)
+        self.assertEqual(items[outbound.id]["paymentType"], "internalTransfer")
+        self.assertEqual(items[inbound.id]["paymentType"], "internalTransfer")
+        # Both legs carry a positive amount (contract); they are told apart by
+        # their payment method, not by sign.
+        self.assertEqual(items[outbound.id]["amount"], 30000.0)
+        self.assertEqual(items[inbound.id]["amount"], 30000.0)

--- a/pms_fastapi_l10n_es/routers/__init__.py
+++ b/pms_fastapi_l10n_es/routers/__init__.py
@@ -1,3 +1,4 @@
 from . import contact
 from . import contact_fiscal_document_type
+from . import invoice
 from . import pms_folio

--- a/pms_fastapi_l10n_es/routers/invoice.py
+++ b/pms_fastapi_l10n_es/routers/invoice.py
@@ -1,0 +1,66 @@
+from odoo import models
+
+from odoo.addons.l10n_es_aeat_partner_identification.models.res_partner import (
+    AEAT_TYPES_ID_CATEGORY_MAP,
+)
+
+_PASSPORT_AEAT_TYPE = "03"
+
+
+class PmsApiInvoiceRouterHelper(models.AbstractModel):
+    _inherit = "pms_api_invoice.invoice_router.helper"
+
+    def _check_fiscal_id(self, partner, pms_property) -> list[dict]:
+        """Spanish fiscal identification check.
+
+        Valid if the contact has a VAT number or both aeat_identification_type
+        and aeat_identification set. Additionally, passport (type 03) cannot
+        be used to invoice when the document was issued by Spain.
+        """
+        has_fiscal_id = bool(partner.vat) or bool(
+            partner.aeat_identification_type and partner.aeat_identification
+        )
+        errors = []
+        if not has_fiscal_id:
+            errors.append(
+                {
+                    "type": "/errors/missing-fiscal-id",
+                    "title": "Missing fiscal identification number",
+                    "detail": (
+                        "El contacto no tiene número de identificación"
+                        " fiscal configurado."
+                    ),
+                }
+            )
+        if (
+            partner.aeat_identification_type == _PASSPORT_AEAT_TYPE
+            and self._is_spanish_passport(partner)
+        ):
+            errors.append(
+                {
+                    "type": "/errors/invalid-id-type-for-country",
+                    "title": "Invalid identification type for country",
+                    "detail": (
+                        "No se puede emitir factura a un ciudadano español"
+                        " con número de pasaporte."
+                    ),
+                }
+            )
+        return errors
+
+    def _is_spanish_passport(self, partner) -> bool:
+        """Return True if the partner's passport document was issued by Spain."""
+        passport_categories = self.env["res.partner.id_category"].search(
+            [
+                (
+                    "partner_map_field",
+                    "=",
+                    AEAT_TYPES_ID_CATEGORY_MAP[_PASSPORT_AEAT_TYPE],
+                )
+            ]
+        )
+        passport_id_number = partner.id_numbers.filtered(
+            lambda n: n.category_id in passport_categories
+        )
+        spain = self.env.ref("base.es")
+        return bool(passport_id_number and passport_id_number[:1].country_id == spain)

--- a/pms_fastapi_l10n_es/tests/__init__.py
+++ b/pms_fastapi_l10n_es/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_contacts
+from . import test_invoices

--- a/pms_fastapi_l10n_es/tests/test_invoices.py
+++ b/pms_fastapi_l10n_es/tests/test_invoices.py
@@ -1,0 +1,139 @@
+from fastapi import status
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+class TestInvoiceContactValidationL10nEs(CommonTestPmsApi):
+    """GET /invoices/validate-contact — Spanish invoicing requirements.
+
+    A contact can invoice if it has a VAT *or* both AEAT identification type
+    and number. On top of that, a Spanish-issued passport (AEAT type 03) cannot
+    be used to invoice.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.country_es = cls.env.ref("base.es")
+        cls.country_fr = cls.env.ref("base.fr")
+        cls.passport_category = cls.env.ref(
+            "pms_partner_identification.document_type_passport"
+        )
+
+    def _validate_url(self, contact_id, property_id=None):
+        property_id = self.test_property.id if property_id is None else property_id
+        return (
+            "/invoices/validate-contact"
+            f"?pmsPropertyId={property_id}&contactId={contact_id}"
+        )
+
+    def _validate(self, partner):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            return test_client.get(self._validate_url(partner.id))
+
+    def _error_types(self, response):
+        return [e["type"] for e in response.json()["errors"]]
+
+    def _add_passport_id_number(self, partner, country, name):
+        return self.env["res.partner.id_number"].create(
+            {
+                "name": name,
+                "category_id": self.passport_category.id,
+                "country_id": country.id,
+                "partner_id": partner.id,
+            }
+        )
+
+    def test_vat_only_is_valid(self):
+        partner = self.env["res.partner"].create(
+            {"firstname": "John", "lastname": "Doe", "vat": "ES12345678Z"}
+        )
+        response = self._validate(partner)
+        self.assertEqual(
+            response.status_code, status.HTTP_204_NO_CONTENT, response.text
+        )
+
+    def test_aeat_identification_non_passport_is_valid(self):
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Res",
+                "lastname": "Cert",
+                "aeat_identification_type": "05",
+                "aeat_identification": "X1234567",
+            }
+        )
+        response = self._validate(partner)
+        self.assertEqual(
+            response.status_code, status.HTTP_204_NO_CONTENT, response.text
+        )
+
+    def test_incomplete_aeat_identification_is_invalid(self):
+        # AEAT type set but no identification number, and no VAT.
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Half",
+                "lastname": "Aeat",
+                "aeat_identification_type": "03",
+            }
+        )
+        response = self._validate(partner)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(self._error_types(response), ["/errors/missing-fiscal-id"])
+
+    def test_spanish_passport_is_invalid(self):
+        # AEAT passport type with a number (fiscal id present) plus a passport
+        # document issued by Spain, which is what must be rejected.
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Pass",
+                "lastname": "Es",
+                "aeat_identification_type": "03",
+                "aeat_identification": "ESID001",
+            }
+        )
+        self._add_passport_id_number(partner, self.country_es, "ES-PASS-001")
+        response = self._validate(partner)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(
+            self._error_types(response), ["/errors/invalid-id-type-for-country"]
+        )
+
+    def test_non_spanish_passport_is_valid(self):
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Pass",
+                "lastname": "Fr",
+                "aeat_identification_type": "03",
+                "aeat_identification": "FRID001",
+            }
+        )
+        self._add_passport_id_number(partner, self.country_fr, "FR-PASS-001")
+        response = self._validate(partner)
+        self.assertEqual(
+            response.status_code, status.HTTP_204_NO_CONTENT, response.text
+        )
+
+    def test_spanish_passport_without_fiscal_id_accumulates_errors(self):
+        # AEAT passport type set but no identification number (fiscal id
+        # missing) while holding a Spanish passport: both errors must report.
+        partner = self.env["res.partner"].create(
+            {
+                "firstname": "Pass",
+                "lastname": "NoId",
+                "aeat_identification_type": "03",
+            }
+        )
+        self._add_passport_id_number(partner, self.country_es, "ES-PASS-002")
+        response = self._validate(partner)
+        self.assertEqual(
+            response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+        )
+        self.assertEqual(
+            set(self._error_types(response)),
+            {"/errors/missing-fiscal-id", "/errors/invalid-id-type-for-country"},
+        )

--- a/roomdoo_fastapi/schemas/pms_folio.py
+++ b/roomdoo_fastapi/schemas/pms_folio.py
@@ -11,8 +11,8 @@ from odoo.addons.pms_fastapi.schemas.pms_folio import (
     folioPaymentStateEnum,
     invoiceStateEnum,
     preCheckinStateEnum,
-    reservationStateEnum,
 )
+from odoo.addons.pms_fastapi.schemas.pms_reservation import reservationStateEnum
 
 
 class FolioPendingSearch(FolioSearch):

--- a/roomdoo_payments_exporter/__init__.py
+++ b/roomdoo_payments_exporter/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Roomdoo - Commit[Sun]
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import report

--- a/roomdoo_payments_exporter/__manifest__.py
+++ b/roomdoo_payments_exporter/__manifest__.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Roomdoo - Commit[Sun]
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Payments Report Exporter",
+    "version": "16.0.1.0.0",
+    "author": "Commitsun",
+    "website": "https://www.roomdoo.com",
+    "category": "Accounting",
+    "summary": "Export a list of payments to PDF or Excel",
+    "depends": [
+        "account",
+        "pms",
+        "report_xlsx",
+    ],
+    "external_dependencies": {"python": ["xlsxwriter"]},
+    "data": [
+        "report/report_payments_templates.xml",
+        "report/report_data.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+    "license": "AGPL-3",
+}

--- a/roomdoo_payments_exporter/i18n/es.po
+++ b/roomdoo_payments_exporter/i18n/es.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* roomdoo_payments_exporter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Amount"
+msgstr "Importe"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Customer payment"
+msgstr "Cobro de cliente"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Customer refund"
+msgstr "Devolución a cliente"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Date"
+msgstr "Fecha"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Folio"
+msgstr "Folio"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Internal transfer"
+msgstr "Transferencia interna"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Journal"
+msgstr "Diario"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Number"
+msgstr "Número"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Payment Method"
+msgstr "Forma de pago"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Payments"
+msgstr "Pagos"
+
+#. module: roomdoo_payments_exporter
+#: model:ir.actions.report,name:roomdoo_payments_exporter.action_report_payments_xlsx
+msgid "Payments (Excel)"
+msgstr "Pagos (Excel)"
+
+#. module: roomdoo_payments_exporter
+#: model:ir.actions.report,name:roomdoo_payments_exporter.action_report_payments_pdf
+msgid "Payments (PDF)"
+msgstr "Pagos (PDF)"
+
+#. module: roomdoo_payments_exporter
+#: model:ir.model,name:roomdoo_payments_exporter.model_report_roomdoo_payments_exporter_report_payments
+msgid "Payments PDF Report"
+msgstr "Informe de pagos PDF"
+
+#. module: roomdoo_payments_exporter
+#: model:ir.model,name:roomdoo_payments_exporter.model_report_roomdoo_payments_exporter_payment_report
+msgid "Payments XLSX Report"
+msgstr "Informe de pagos XLSX"
+
+#. module: roomdoo_payments_exporter
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+msgid "Payments report"
+msgstr "Informe de pagos"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Reference"
+msgstr "Referencia"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Registered By"
+msgstr "Registrado por"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Supplier payment"
+msgstr "Pago a proveedor"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Supplier refund"
+msgstr "Devolución de proveedor"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Type"
+msgstr "Tipo"

--- a/roomdoo_payments_exporter/i18n/roomdoo_payments_exporter.pot
+++ b/roomdoo_payments_exporter/i18n/roomdoo_payments_exporter.pot
@@ -1,0 +1,166 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* roomdoo_payments_exporter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Amount"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Contact"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Currency"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Customer payment"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Customer refund"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Date"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Folio"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Internal transfer"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Journal"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Number"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Payment Method"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Payments"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#: model:ir.actions.report,name:roomdoo_payments_exporter.action_report_payments_xlsx
+msgid "Payments (Excel)"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#: model:ir.actions.report,name:roomdoo_payments_exporter.action_report_payments_pdf
+msgid "Payments (PDF)"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#: model:ir.model,name:roomdoo_payments_exporter.model_report_roomdoo_payments_exporter_report_payments
+msgid "Payments PDF Report"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#: model:ir.model,name:roomdoo_payments_exporter.model_report_roomdoo_payments_exporter_payment_report
+msgid "Payments XLSX Report"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+msgid "Payments report"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Reference"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#, python-format
+msgid "Registered By"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Supplier payment"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_report.py:0
+#, python-format
+msgid "Supplier refund"
+msgstr ""
+
+#. module: roomdoo_payments_exporter
+#. odoo-python
+#: code:addons/roomdoo_payments_exporter/report/payment_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:roomdoo_payments_exporter.report_payments
+#, python-format
+msgid "Type"
+msgstr ""

--- a/roomdoo_payments_exporter/report/__init__.py
+++ b/roomdoo_payments_exporter/report/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 Roomdoo - Commit[Sun]
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import payment_report
+from . import payment_xlsx

--- a/roomdoo_payments_exporter/report/payment_report.py
+++ b/roomdoo_payments_exporter/report/payment_report.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Roomdoo - Commit[Sun]
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models
+
+
+class PaymentReportMixin(models.AbstractModel):
+    """Row/label builders shared by the PDF and XLSX renderers.
+
+    These live on a model (not a module-level function) so the `_()` calls
+    resolve the language from `self.env` — a bare function frame has no `self`
+    and would always return the source string untranslated.
+    """
+
+    _name = "report.roomdoo_payments_exporter.mixin"
+    _description = "Payments report data builder"
+
+    def _payment_type_label(self, payment):
+        """Human-readable payment type, derived from the accounting fields.
+
+        Mirrors the API contract (PaymentSummary) without depending on the
+        `pms_api_transaction_type` computed field, so the report module stays
+        decoupled from the API layer.
+        """
+        if payment.is_internal_transfer:
+            return _("Internal transfer")
+        labels = {
+            ("inbound", "customer"): _("Customer payment"),
+            ("outbound", "customer"): _("Customer refund"),
+            ("outbound", "supplier"): _("Supplier payment"),
+            ("inbound", "supplier"): _("Supplier refund"),
+        }
+        return labels.get((payment.payment_type, payment.partner_type), "")
+
+    def _payment_report_rows(self, payments):
+        """Flatten payments into the rows shown by the PDF / XLSX report.
+
+        Single source of truth shared by both renderers. New columns are added
+        here so PDF and Excel stay in sync.
+        """
+        rows = []
+        for payment in payments:
+            currency = payment.currency_id or payment.company_id.currency_id
+            # Internal transfers carry the company partner internally; the
+            # report shows no contact for them, replicating the listing.
+            partner = (
+                payment.partner_id
+                if payment.partner_id and not payment.is_internal_transfer
+                else False
+            )
+            rows.append(
+                {
+                    "name": payment.name or "",
+                    "date": payment.date,
+                    "type_label": self._payment_type_label(payment),
+                    "partner_name": partner.display_name if partner else "",
+                    "payment_method": payment.payment_method_line_id.name or "",
+                    "journal_name": payment.journal_id.name or "",
+                    "folio_name": ", ".join(payment.folio_ids.mapped("name")),
+                    "ref": payment.ref or "",
+                    "created_by": payment.create_uid.name or "",
+                    "amount": abs(payment.amount),
+                    "currency": currency,
+                    "currency_name": currency.name or "",
+                }
+            )
+        return rows
+
+
+class ReportPayments(models.AbstractModel):
+    _name = "report.roomdoo_payments_exporter.report_payments"
+    _inherit = "report.roomdoo_payments_exporter.mixin"
+    _description = "Payments PDF Report"
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        payments = self.env["account.payment"].browse(docids)
+        return {
+            "doc_ids": docids,
+            "doc_model": "account.payment",
+            "docs": payments,
+            "rows": self._payment_report_rows(payments),
+        }

--- a/roomdoo_payments_exporter/report/payment_xlsx.py
+++ b/roomdoo_payments_exporter/report/payment_xlsx.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Roomdoo - Commit[Sun]
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+
+STRFTIME_TO_EXCEL = {
+    "%d": "DD",
+    "%m": "MM",
+    "%Y": "YYYY",
+    "%y": "YY",
+    "%B": "MMMM",
+    "%b": "MMM",
+}
+
+
+class PaymentXlsx(models.AbstractModel):
+    _name = "report.roomdoo_payments_exporter.payment_report"
+    _inherit = [
+        "report.report_xlsx.abstract",
+        "report.roomdoo_payments_exporter.mixin",
+    ]
+    _description = "Payments XLSX Report"
+
+    def _get_date_format(self):
+        code = self.env.user.lang or "en_US"
+        py_fmt = self.env["res.lang"]._lang_get(code).date_format
+        for py, xl in STRFTIME_TO_EXCEL.items():
+            py_fmt = py_fmt.replace(py, xl)
+        return py_fmt
+
+    def _get_columns(self):
+        # (label, width, row-key, format-key)
+        return [
+            (_("Number"), 20, "name", "text"),
+            (_("Date"), 15, "date", "date"),
+            (_("Type"), 20, "type_label", "text"),
+            (_("Contact"), 35, "partner_name", "text"),
+            (_("Payment Method"), 20, "payment_method", "text"),
+            (_("Journal"), 20, "journal_name", "text"),
+            (_("Folio"), 20, "folio_name", "text"),
+            (_("Reference"), 20, "ref", "text"),
+            (_("Registered By"), 20, "created_by", "text"),
+            (_("Amount"), 15, "amount", "money"),
+            (_("Currency"), 10, "currency_name", "text"),
+        ]
+
+    def _get_formats(self, workbook):
+        return {
+            "header": workbook.add_format(
+                {
+                    "bold": True,
+                    "bg_color": "#4472C4",
+                    "font_color": "#FFFFFF",
+                    "border": 1,
+                    "text_wrap": True,
+                    "valign": "vcenter",
+                }
+            ),
+            "text": workbook.add_format({"border": 1, "valign": "vcenter"}),
+            "date": workbook.add_format(
+                {
+                    "num_format": self._get_date_format(),
+                    "border": 1,
+                    "valign": "vcenter",
+                }
+            ),
+            "money": workbook.add_format(
+                {
+                    "num_format": "#,##0.00",
+                    "border": 1,
+                    "valign": "vcenter",
+                }
+            ),
+        }
+
+    @staticmethod
+    def _write_cell(sheet, row, col, value, cell_format):
+        if value is None or value is False:
+            sheet.write_blank(row, col, None, cell_format)
+        else:
+            sheet.write(row, col, value, cell_format)
+
+    def generate_xlsx_report(self, workbook, data, payments):
+        rows = self._payment_report_rows(payments)
+        fmt = self._get_formats(workbook)
+        columns = self._get_columns()
+
+        sheet = workbook.add_worksheet(_("Payments"))
+        for col_idx, (label, width, _key, _fmt_key) in enumerate(columns):
+            sheet.write(0, col_idx, label, fmt["header"])
+            sheet.set_column(col_idx, col_idx, width)
+        sheet.freeze_panes(1, 0)
+
+        for row_idx, row in enumerate(rows, start=1):
+            for col_idx, (_label, _width, key, fmt_key) in enumerate(columns):
+                self._write_cell(sheet, row_idx, col_idx, row.get(key), fmt[fmt_key])
+
+        if rows:
+            sheet.autofilter(0, 0, len(rows), len(columns) - 1)

--- a/roomdoo_payments_exporter/report/report_data.xml
+++ b/roomdoo_payments_exporter/report/report_data.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="paperformat_payments_landscape" model="report.paperformat">
+        <field name="name">Payments Report (Landscape)</field>
+        <field name="format">A4</field>
+        <field name="orientation">Landscape</field>
+        <field name="margin_top">40</field>
+        <field name="margin_bottom">23</field>
+        <field name="margin_left">7</field>
+        <field name="margin_right">7</field>
+        <field name="header_line" eval="False" />
+        <field name="header_spacing">35</field>
+        <field name="dpi">90</field>
+    </record>
+
+    <record id="action_report_payments_pdf" model="ir.actions.report">
+        <field name="name">Payments (PDF)</field>
+        <field name="model">account.payment</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">roomdoo_payments_exporter.report_payments</field>
+        <field name="report_file">roomdoo_payments_exporter.report_payments</field>
+        <field name="binding_model_id" ref="account.model_account_payment" />
+        <field name="binding_type">report</field>
+        <field name="paperformat_id" ref="paperformat_payments_landscape" />
+    </record>
+
+    <record id="action_report_payments_xlsx" model="ir.actions.report">
+        <field name="name">Payments (Excel)</field>
+        <field name="model">account.payment</field>
+        <field name="report_type">xlsx</field>
+        <field name="report_name">roomdoo_payments_exporter.payment_report</field>
+        <field name="report_file">payment_report</field>
+        <field name="binding_model_id" ref="account.model_account_payment" />
+        <field name="binding_type">report</field>
+    </record>
+
+</odoo>

--- a/roomdoo_payments_exporter/report/report_payments_templates.xml
+++ b/roomdoo_payments_exporter/report/report_payments_templates.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <template id="report_payments">
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h2>Payments report</h2>
+                    <table class="table table-sm o_main_table mt-3">
+                        <thead>
+                            <tr>
+                                <th>Number</th>
+                                <th>Date</th>
+                                <th>Type</th>
+                                <th>Contact</th>
+                                <th>Payment Method</th>
+                                <th>Folio</th>
+                                <th>Reference</th>
+                                <th class="text-end">Amount</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr t-foreach="rows" t-as="row">
+                                <td t-out="row['name']" />
+                                <td
+                  t-out="row['date']"
+                  t-options='{"widget": "date"}'
+                />
+                                <td t-out="row['type_label']" />
+                                <td t-out="row['partner_name']" />
+                                <td t-out="row['payment_method']" />
+                                <td t-out="row['folio_name']" />
+                                <td t-out="row['ref']" />
+                                <td
+                  class="text-end"
+                  t-out="row['amount']"
+                  t-options-widget="'monetary'"
+                  t-options-display_currency="row['currency']"
+                />
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </t>
+        </t>
+    </template>
+
+</odoo>

--- a/setup/roomdoo_payments_exporter/odoo/addons/roomdoo_payments_exporter
+++ b/setup/roomdoo_payments_exporter/odoo/addons/roomdoo_payments_exporter
@@ -1,0 +1,1 @@
+../../../../roomdoo_payments_exporter

--- a/setup/roomdoo_payments_exporter/setup.py
+++ b/setup/roomdoo_payments_exporter/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Brings the FastAPI billing surface (`pms_fastapi`) up to the feature set the
front needs to invoice, collect and reconcile from folios, plus cash-session
management and a payments report. The bulk is **additive** (new endpoints,
schemas and two modules); the few touches to pre-existing endpoints are
backward compatible (see the breaking-changes note at the end).

## New endpoints

### Folio billing — `pms_fastapi/routers/pms_folio.py`
- `GET /folios/{id}` — billing detail: totals, to-invoice totals, payers and
  reservations (each with its sale-line ids).
- `GET /folios/{id}/sale-lines` — billable room/service lines with per-line tax
  breakdown and invoice state. Sections, notes and down payments are excluded.
- `GET /sale-lines/{id}` — single billable sale line.
- `GET /folios/{id}/down-payment-invoices` — down-payment invoices of the folio.
- `GET /folios/{id}/contacts` — unique contacts across the folio, its
  reservations, agencies and guests.
- `POST /folios/invoices` — create an invoice from sale lines, optionally
  grouping lines from several folios of the same property, subtracting
  down-payment invoices and posting on creation. Validates duplicates, access,
  line kind, quantities vs pending, single property, customer/contact
  invoicing requirements and the simplified-invoice limit.

### Invoicing — `pms_fastapi/routers/invoice.py`
- `GET /invoices/{id}` — full `InvoiceDetail` for editing.
- `PUT /invoices/{id}` — full-replacement edit. Drafts are rewritten in place
  (same id); posted invoices, with `confirmRefund=true`, generate a refund that
  cancels the original and a new corrected draft linked via `replaces`.
- `GET /invoices/validate-contact` — validate a contact against a property's
  invoicing rules (204 / 422 ProblemDetail).
- `POST /invoices/{id}/reconciliations`, `DELETE
  /invoices/{id}/reconciliations/{reconciliation_id}`,
  `GET /invoices/{id}/reconcilable-payments` — apply/undo payments and list
  applicable ones. Reconciliation ids are opaque composite strings
  (`payment_{id}`) so the contract can grow to other document types.

### Payments — `pms_fastapi/routers/payment.py` (new router)
- `GET /payments`, `GET /payments/{id}` — property-scoped listing/detail with
  contact and global-search filters.
- `POST /payments` (customer/supplier) and `POST /internal-transfers`.
- `PATCH /payments/{id}` — edit; blocked (409) when the payment, or its
  internal-transfer counterpart, is matched against a bank statement.
- `POST /payments/{id}/cancel` — cancel a payment (both legs for transfers);
  409 on fiscal-lock-date or bank-matched payments.
- `GET /payments/{id}/report` and `POST /payments/report` — single-payment
  receipt and bulk report (PDF/XLSX), mirroring the invoices report skeleton.

### Cash sessions — `pms_fastapi/routers/cash_session.py` (new router)
- `POST /cash-sessions`, `GET /cash-sessions/current`,
  `GET /cash-sessions/last-closing`, `POST /cash-sessions/{id}/closing`.
- Backed by `account.bank.statement`, porting the accounting close from
  `pms_api_rest` (statement lines, reconciliation, profit/loss difference).
  Cash journals auto-open a session on payment.

## New modules
- **`roomdoo_payments_exporter`** — payments report definitions: a shared
  AbstractModel mixin builds the rows so the landscape QWeb PDF and the
  single-sheet XLSX stay in sync. Includes Spanish translations.
- **`pms_fastapi_l10n_es`** — Spanish override of the invoicing contact
  validation: checks AEAT id requirements and the Spanish-passport rule on top
  of the base VAT check.

## Notable internals
- `account.move`: `replaces_invoice_id` / `replaced_by_invoice_ids` to link an
  edited posted invoice to its corrected replacement.
- `folio.sale.line._prepare_invoice_line` honours per-line descriptions passed
  through context, so the front can override the invoice line text.
- Contact validation is extensible: `_get_contact_validation_errors` /
  `_check_fiscal_id` return RFC 9457 problem items and are overridden per
  localization.
- Portal-friendliness: the invoice create/edit/reconcile flows use
  `sudo` + `pms_api_check_access` instead of native ACLs, which blocked portal
  users with `AccessError`.
- Error responses are localized (i18n `.pot` + `es.po`); user-facing
  `title`/`detail` are wrapped in `_()` and resolved via `Accept-Language`. The
  raises were moved into model helpers so `_()` resolves the request language.

## Cash-session shared state + migration
The open/closed state of a cash session is owned by `pms_fastapi` via
`cash_session_closed`. While both APIs coexist behind feature flags a session
may be opened on one API and closed on the other, so:
- `pms_api_rest` close now also stamps the flag (temporary bridge,
  `_mark_cash_session_closed`, guarded on the field's presence and meant to be
  removed with the module). No change to the legacy response.
- `pms_fastapi` migration `16.0.1.4.0/post-migrate.py` backfills the flag on
  historical cash statements (using `is_complete` as the closed signal) and
  repairs already-closed rows missing closing date/uid, which previously made
  `last-closing` return HTTP 500.

## New dependencies (`pms_fastapi/__manifest__.py`, 1.3.0 → 1.4.0)
- `roomdoo_payments_exporter` (new, this PR)
- `pms_autoreconcile_folio_payments` — note: updating `pms_fastapi` will install
  it and enable folio-payment auto-reconciliation.

## Tests
End-to-end HTTP coverage of the module's own logic: contact validation (base
VAT + Spanish AEAT/passport), folio sale-lines and detail (filtering, state
mapping, payers/contacts dedup), invoice create/edit/reconcile (validation
branches, posted-refund replacement, simplified invoice), payments
create/edit/cancel, journals multi-type filter, and a full open/pay/close cash
flow.

## Breaking changes — none for a well-behaved consumer
Nothing is renamed or removed in existing endpoints, paths, params or fields.
Two pre-existing surfaces are **extended** (backward compatible):
- `GET /invoices` — each item in `payments[]` gains `id`, `paymentAmount`,
  `paymentAmountCompany`, `companyCurrency`; `ref` becomes optional. Added
  fields only.
- `GET /journals` — `journalType` now accepts a repeated value (list) in
  addition to a single value; `?journalType=cash` keeps working.

Caveats only for consumers doing strict schema validation (new fields), clients
generated from the OpenAPI spec (`journalType` type changes → regenerate), or
those string-matching error `title`/`detail` (now translated; the offboarding
error was reworded to stop leaking the internal reservation state). The error
`type`/`status` contract is unchanged.
