### PR TITLE
[IMP] pms_fastapi: invoice and folio improvements

### DIFF
--- a/pms_fastapi/models/__init__.py
+++ b/pms_fastapi/models/__init__.py
@@ -1,4 +1,5 @@
 from . import fastapi_endpoint
+from . import folio_sale_line
 from . import pms_folio
 from . import res_partner
 from . import id_number_category

--- a/pms_fastapi/models/folio_sale_line.py
+++ b/pms_fastapi/models/folio_sale_line.py
@@ -1,0 +1,26 @@
+from odoo import api, fields, models
+
+
+class FolioSaleLine(models.Model):
+    _inherit = "folio.sale.line"
+
+    amount_to_invoice = fields.Monetary(
+        help="Remaining amount to invoice on the folio line (taxes included)",
+        compute="_compute_amount_to_invoice",
+        compute_sudo=True,
+    )
+
+    @api.depends("qty_to_invoice", "price_reduce", "tax_ids", "product_uom_qty")
+    def _compute_amount_to_invoice(self):
+        for line in self:
+            if not line.qty_to_invoice:
+                line.amount_to_invoice = 0.0
+                continue
+            taxes = line.tax_ids.compute_all(
+                line.price_reduce,
+                currency=line.currency_id,
+                quantity=line.qty_to_invoice,
+                product=line.product_id,
+                partner=line.folio_id.partner_id,
+            )
+            line.amount_to_invoice = taxes["total_included"]

--- a/pms_fastapi/models/pms_folio.py
+++ b/pms_fastapi/models/pms_folio.py
@@ -33,6 +33,18 @@ class PmsFolio(models.Model):
         store=True,
         index=True,
     )
+    amount_to_invoice = fields.Monetary(
+        help="Remaining amount to invoice on the folio (taxes included)",
+        compute="_compute_amount_to_invoice",
+        compute_sudo=True,
+    )
+
+    @api.depends("sale_line_ids.amount_to_invoice")
+    def _compute_amount_to_invoice(self):
+        for folio in self:
+            folio.amount_to_invoice = sum(
+                folio.sale_line_ids.mapped("amount_to_invoice")
+            )
 
     @api.depends("reservation_ids.state", "reservation_ids.cancelled_reason")
     def _compute_fastapi_sort_state(self):

--- a/pms_fastapi/routers/__init__.py
+++ b/pms_fastapi/routers/__init__.py
@@ -21,3 +21,4 @@ from . import invoice
 from . import journal
 from . import payment_method
 from . import reservation_guest
+from . import pms_reservation

--- a/pms_fastapi/routers/__init__.py
+++ b/pms_fastapi/routers/__init__.py
@@ -11,6 +11,7 @@ from . import contact_tags
 from . import contact_id_number
 from . import contact_fiscal_document_type
 from . import pms_sale_channel
+from . import pms_service
 from . import agency
 from . import customer
 from . import supplier

--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -29,6 +29,7 @@ from odoo.addons.pms_fastapi.schemas.invoice import (
 from odoo.addons.pms_fastapi.utils import FilteredModelAdapter
 
 INVOICE_REPORT_MAX_RECORDS = 5000
+INVOICE_PDF_REPORT_MAX_RECORDS = 100
 
 InvoiceOrderDependency = create_order_dependency(
     InvoiceOrderField, INVOICE_ORDER_MAPPING, ["-invoice_date,-name"]
@@ -113,6 +114,38 @@ async def get_invoice_report(
     "/invoices/report",
     tags=["invoice"],
     responses={
+        200: {"content": {"application/pdf": {}}},
+    },
+    response_class=Response,
+)
+async def get_invoices_report(
+    env: AuthenticatedEnv,
+    filters: Annotated[InvoiceSearch, Depends()],
+    ids: Annotated[
+        list[int] | None,
+        Query(
+            description="Invoice IDs to include in the report. "
+            "Mutually exclusive with filter parameters.",
+        ),
+    ] = None,
+) -> Response:
+    """Download a single PDF with one or more invoices.
+
+    Pass either an explicit list of `ids` or filter parameters.
+    Returns the same PDF format as downloading an individual invoice,
+    concatenating all selected invoices.
+    """
+    return (
+        env["pms_api_invoice.invoice_router.helper"]
+        .new()
+        ._get_invoices_pdf(filters, ids)
+    )
+
+
+@pms_api_router.post(
+    "/invoices/accounting-report",
+    tags=["invoice"],
+    responses={
         200: {
             "content": {
                 "application/pdf": {},
@@ -191,7 +224,9 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
     def _has_report_filters(filters):
         return any(v is not None for v in filters.__dict__.values())
 
-    def _generate_report(self, report_format, filters, ids):
+    def _resolve_report_invoices(
+        self, filters, ids, max_records=INVOICE_REPORT_MAX_RECORDS
+    ):
         if ids and self._has_report_filters(filters):
             return JSONResponse(
                 status_code=400,
@@ -205,15 +240,19 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                     ),
                 },
                 media_type="application/problem+json",
-            )
+            ), None
         if ids:
             domain = [("id", "in", ids)]
-            count = self.model_adapter.count(domain)
+            context = None
         else:
             domain = filters.to_odoo_domain(self.env)
             context = filters.to_odoo_context(self.env)
-            count = self.model_adapter.count(domain, context=context)
-        if count > INVOICE_REPORT_MAX_RECORDS:
+        count = (
+            self.model_adapter.count(domain)
+            if context is None
+            else self.model_adapter.count(domain, context=context)
+        )
+        if count > max_records:
             return JSONResponse(
                 status_code=400,
                 content={
@@ -222,17 +261,24 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
                     "status": 400,
                     "detail": (
                         f"The export requested {count} records, "
-                        f"but the maximum allowed is {INVOICE_REPORT_MAX_RECORDS}."
+                        f"but the maximum allowed is {max_records}."
                     ),
                     "requestedCount": count,
-                    "maxAllowed": INVOICE_REPORT_MAX_RECORDS,
+                    "maxAllowed": max_records,
                 },
                 media_type="application/problem+json",
-            )
-        if ids:
-            invoices = self.model_adapter.search(domain)
-        else:
-            invoices = self.model_adapter.search(domain, context=context)
+            ), None
+        invoices = (
+            self.model_adapter.search(domain)
+            if context is None
+            else self.model_adapter.search(domain, context=context)
+        )
+        return None, invoices
+
+    def _generate_report(self, report_format, filters, ids):
+        error, invoices = self._resolve_report_invoices(filters, ids)
+        if error is not None:
+            return error
         if report_format == ReportFormatEnum.xlsx:
             return self._render_invoice_xlsx(invoices)
         return self._render_invoice_pdf(invoices)
@@ -326,6 +372,25 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
             media_type="application/pdf",
             headers={
                 "Content-Disposition": f'attachment; filename="{filename}"',
+            },
+        )
+
+    def _get_invoices_pdf(self, filters, ids):
+        error, invoices = self._resolve_report_invoices(
+            filters, ids, max_records=INVOICE_PDF_REPORT_MAX_RECORDS
+        )
+        if error is not None:
+            return error
+        content, _report_type = (
+            self.env["ir.actions.report"]
+            .sudo()
+            ._render_qweb_pdf("account.account_invoices", invoices.ids)
+        )
+        return Response(
+            content=content,
+            media_type="application/pdf",
+            headers={
+                "Content-Disposition": 'attachment; filename="invoices_report.pdf"',
             },
         )
 

--- a/pms_fastapi/routers/pms_folio.py
+++ b/pms_fastapi/routers/pms_folio.py
@@ -19,6 +19,7 @@ from odoo.addons.pms_fastapi.dependencies import (
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
 from odoo.addons.pms_fastapi.schemas.pms_folio import (
     FOLIO_ORDER_MAPPING,
+    FolioCountSummary,
     FolioOrderField,
     FolioSearch,
     FolioSummary,
@@ -71,15 +72,21 @@ async def folios_report(
 
 @pms_api_router.get(
     "/folios/count",
-    response_model=int,
+    response_model=FolioCountSummary,
     tags=["folio"],
 )
 async def count_folios(
     env: AuthenticatedEnv,
     filters: Annotated[FolioSearch, Depends()],
-) -> int:
-    """Get the number of folios matching the given filters"""
-    return env["pms_api_folio.folio_router.helper"].new().count(filters)
+) -> FolioCountSummary:
+    """Get the counts of folios and their reservations matching the given filters"""
+    folios_count, reservations_count = (
+        env["pms_api_folio.folio_router.helper"].new().count(filters)
+    )
+    return FolioCountSummary(
+        foliosCount=folios_count,
+        reservationsCount=reservations_count,
+    )
 
 
 @pms_api_router.get(
@@ -142,14 +149,37 @@ class PmsApiFolioRouterHelper(models.AbstractModel):
             order=order,
         )
 
-    def count(self, params=None) -> int:
+    def count(self, params=None) -> tuple[int, int]:
         if params:
             domain = params.to_odoo_domain(self.env)
             context = params.to_odoo_context(self.env)
         else:
             domain = []
             context = {}
-        return self.model_adapter.count(domain, context=context)
+        # Resolve the folio domain once as a materialized CTE and reuse
+        # it for both counts, so the subquery (which may include a large
+        # id IN (...) coming from reservation pre-filtering) runs a
+        # single time.
+        full_folio_domain = expression.AND([self.model_adapter._base_domain, domain])
+        folio_model = self.env["pms.folio"].sudo().with_context(**context)
+        folio_query = folio_model._where_calc(full_folio_domain)
+        folio_model._apply_ir_rules(folio_query, "read")
+        folio_subselect, folio_params = folio_query.subselect()
+        self.env.cr.execute(
+            f"""
+            WITH folio_ids AS MATERIALIZED ({folio_subselect})
+            SELECT
+                (SELECT COUNT(*) FROM folio_ids) AS folios,
+                (SELECT COUNT(*) FROM pms_reservation r
+                 WHERE r.folio_id IN (SELECT id FROM folio_ids)
+                   AND (r.cancelled_reason IS NULL
+                        OR r.cancelled_reason != 'modified')
+                ) AS reservations
+            """,
+            folio_params,
+        )
+        folios_count, reservations_count = self.env.cr.fetchone()
+        return folios_count, reservations_count
 
     @api.model
     def extra_features(self):

--- a/pms_fastapi/routers/pms_reservation.py
+++ b/pms_fastapi/routers/pms_reservation.py
@@ -1,0 +1,139 @@
+from fastapi import Response
+from fastapi.responses import JSONResponse
+
+from odoo import fields, models
+from odoo.exceptions import MissingError
+from odoo.osv import expression
+
+from odoo.addons.pms.models.pms_reservation import PmsReservation
+from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
+from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.utils import FilteredModelAdapter
+
+OFFBOARDING_INVALID_RESERVATION_STATES = ("draft", "cancel")
+
+
+@pms_api_router.post(
+    "/reservations/{reservation_id}/onboarding",
+    status_code=204,
+    tags=["reservation"],
+)
+async def onboarding(
+    env: AuthenticatedEnv,
+    reservation_id: int,
+):
+    """Confirm arrival for eligible guests of a reservation.
+
+    Eligible guests are those with completed check-in data who have not yet
+    arrived, on a reservation whose check-in date is today or earlier.
+    Idempotent: returns 204 even if no guests are eligible.
+    """
+    return env["pms_api_reservation.router.helper"].new()._onboarding(reservation_id)
+
+
+@pms_api_router.post(
+    "/reservations/{reservation_id}/offboarding",
+    status_code=204,
+    tags=["reservation"],
+)
+async def offboarding(
+    env: AuthenticatedEnv,
+    reservation_id: int,
+):
+    """Confirm departure for eligible in-house guests of a reservation.
+
+    Eligible guests are those currently in-house. Idempotent: returns 204
+    even if no guests are eligible. Returns 409 if the reservation is in a
+    state that does not allow confirming departures (e.g. draft, cancelled).
+    """
+    return env["pms_api_reservation.router.helper"].new()._offboarding(reservation_id)
+
+
+class PmsApiReservationRouterHelper(models.AbstractModel):
+    _name = "pms_api_reservation.router.helper"
+    _description = "PMS API Reservation Router Helper"
+
+    def _get_domain_adapter(self):
+        return []
+
+    def _get_multicompany_rule(self):
+        allowed_company_ids = self.env.user.company_ids.ids
+        return expression.OR(
+            [
+                [("company_id", "=", False)],
+                [("company_id", "in", allowed_company_ids)],
+            ]
+        )
+
+    @property
+    def model_adapter(self) -> FilteredModelAdapter[PmsReservation]:
+        base_domain = self._get_domain_adapter()
+        multicompany_domain = self._get_multicompany_rule()
+        model_domain = expression.AND([base_domain, multicompany_domain])
+        return FilteredModelAdapter[PmsReservation](self.env, model_domain)
+
+    def get(self, record_id) -> PmsReservation:
+        return self.model_adapter.get(record_id)
+
+    def _reservation_not_found_response(self, reservation_id, action):
+        return JSONResponse(
+            status_code=404,
+            content={
+                "type": "/errors/reservation-not-found",
+                "title": "Reservation not found",
+                "status": 404,
+                "detail": f"Reservation {reservation_id} does not exist.",
+                "instance": f"/reservations/{reservation_id}/{action}",
+            },
+            media_type="application/problem+json",
+        )
+
+    def _onboarding(self, reservation_id):
+        try:
+            reservation = self.get(reservation_id)
+        except MissingError:
+            return self._reservation_not_found_response(reservation_id, "onboarding")
+
+        today = fields.Date.today()
+        eligible = reservation.checkin_partner_ids.filtered(
+            lambda c: (
+                c.state == "precheckin"
+                and c.reservation_id.checkin <= today
+                and c.reservation_id.checkout >= today
+            )
+        )
+        if eligible:
+            eligible.sudo().action_on_board()
+        return Response(status_code=204)
+
+    def _offboarding(self, reservation_id):
+        try:
+            reservation = self.get(reservation_id)
+        except MissingError:
+            return self._reservation_not_found_response(reservation_id, "offboarding")
+
+        if reservation.state in OFFBOARDING_INVALID_RESERVATION_STATES:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "type": "/errors/reservation-state-invalid",
+                    "title": (
+                        "Reservation state does not allow " "confirming departures"
+                    ),
+                    "status": 409,
+                    "detail": (
+                        f"Reservation {reservation_id} is in "
+                        f"'{reservation.state}' state and cannot be "
+                        f"confirmed as departed."
+                    ),
+                    "instance": (f"/reservations/{reservation_id}/offboarding"),
+                },
+                media_type="application/problem+json",
+            )
+
+        eligible = reservation.checkin_partner_ids.filtered(
+            lambda c: c.state == "onboard"
+        )
+        if eligible:
+            eligible.sudo().action_done()
+        return Response(status_code=204)

--- a/pms_fastapi/routers/pms_service.py
+++ b/pms_fastapi/routers/pms_service.py
@@ -1,0 +1,31 @@
+from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
+from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
+from odoo.addons.pms_fastapi.schemas.pms_service import ServiceProduct
+
+
+@pms_api_router.get(
+    "/services",
+    response_model=list[ServiceProduct],
+    tags=["service"],
+)
+async def get_services(
+    env: AuthenticatedEnv,
+) -> list[ServiceProduct]:
+    """
+    List PMS service products available for folio filtering.
+    """
+    products = (
+        env["product.product"]
+        .sudo()
+        .search([("is_pms_available", "=", True)], order="name")
+    )
+    board_product_ids = set()
+    for model in ("pms.board.service.line", "pms.board.service.room.type.line"):
+        groups = env[model].sudo().read_group([], ["product_id"], ["product_id"])
+        board_product_ids |= {g["product_id"][0] for g in groups if g["product_id"]}
+    return [
+        ServiceProduct.from_product_product(
+            product, is_board_service=product.id in board_product_ids
+        )
+        for product in products
+    ]

--- a/pms_fastapi/schemas/agency.py
+++ b/pms_fastapi/schemas/agency.py
@@ -7,7 +7,15 @@ from odoo import api
 from odoo.osv import expression
 
 from odoo.addons.pms_fastapi.schemas.base import BaseSearch
-from odoo.addons.pms_fastapi.schemas.contact import ContactBase
+from odoo.addons.pms_fastapi.schemas.contact import ContactBase, ContactIdImage
+
+
+class AgencyIdImage(ContactIdImage):
+    """Identifier + image for an agency partner.
+
+    Same shape as ContactIdImage. Localization modules may extend the factory
+    to resolve the name via locale-specific fields (e.g. trade name).
+    """
 
 
 class AgencyOrderField(str, Enum):

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -13,6 +13,7 @@ from .contact import ContactId
 from .currency import CurrencySummary
 from .journal import JournalSummary
 from .payment_method import PaymentMethodSummary
+from .pms_folio import FolioId
 
 
 class ShareUrl(PmsBaseModel):
@@ -148,11 +149,13 @@ class InvoiceSummary(PmsBaseModel):
     invoice_date: date | None = Field(None, alias="invoiceDate")
     ref: str | None = Field(None, alias="reference")
     amount_total_signed: CurrencyAmount = Field(0.0, alias="totalAmount")
+    amount_residual_signed: CurrencyAmount = Field(0.0, alias="pendingAmount")
     currency_id: CurrencySummary = Field(alias="currency")
     state: InvoiceStateEnum
     paymentState: InvoicePaymentStateEnum
     min_overdue_date: date | None = Field(None, alias="overdueDate")
     payments: list[InvoicePayment] = Field(default_factory=list)
+    folio_ids: list[FolioId] = Field(default_factory=list, alias="folios")
 
     @classmethod
     def from_account_move(cls, account_move):
@@ -170,6 +173,9 @@ class InvoiceSummary(PmsBaseModel):
                 InvoicePayment.from_widget_item(item, account_move.env)
                 for item in account_move.invoice_payments_widget["content"]
             ]
+        data["folio_ids"] = [
+            FolioId.from_pms_folio(folio) for folio in account_move.folio_ids
+        ]
         if account_move.has_overdue_payments:
             data["paymentState"] = InvoicePaymentStateEnum.overdue
         else:

--- a/pms_fastapi/schemas/pms_folio.py
+++ b/pms_fastapi/schemas/pms_folio.py
@@ -9,6 +9,7 @@ from pydantic import Field, field_validator
 from odoo import api
 from odoo.osv import expression
 
+from .agency import AgencyIdImage
 from .base import BaseSearch, CurrencyAmount, PmsBaseModel
 from .contact import ContactIdImage
 from .country import CountrySummary
@@ -45,6 +46,7 @@ class reservationStateEnum(str, Enum):
     IN_HOUSE = "inHouse"
     COMPLETED = "completed"
     CANCELLED = "cancelled"
+    NO_SHOW = "noShow"
     OVERBOOKING = "overbooking"
 
 
@@ -79,7 +81,7 @@ class reservationSummary(PmsBaseModel):
     rooms: list[RoomId]
     services: list[ServiceId]
     saleChannel: SaleChannelDetail | None = None
-    agency: ContactIdImage | None = None
+    agency: AgencyIdImage | None = None
     state: reservationStateEnum
     price_room_services_set: CurrencyAmount = Field(0.0, alias="totalAmount")
     currency: CurrencySummary | None = None
@@ -106,7 +108,7 @@ class reservationSummary(PmsBaseModel):
                 reservation.sale_channel_origin_id
             )
         if reservation.agency_id:
-            filtered_data["agency"] = ContactIdImage.from_res_partner(
+            filtered_data["agency"] = AgencyIdImage.from_res_partner(
                 reservation.agency_id
             )
         if reservation.overbooking and reservation.state != "cancel":
@@ -114,7 +116,10 @@ class reservationSummary(PmsBaseModel):
         elif reservation.state == "draft":
             filtered_data["state"] = reservationStateEnum.DRAFT
         elif reservation.state == "cancel":
-            filtered_data["state"] = reservationStateEnum.CANCELLED
+            if reservation.cancelled_reason == "noshow":
+                filtered_data["state"] = reservationStateEnum.NO_SHOW
+            else:
+                filtered_data["state"] = reservationStateEnum.CANCELLED
         elif reservation.state in ("confirm", "arrival_delayed"):
             filtered_data["state"] = reservationStateEnum.ARRIVAL
         elif reservation.state in ("onboard", "departure_delayed"):
@@ -134,6 +139,20 @@ class reservationSummary(PmsBaseModel):
         return cls(**filtered_data)
 
 
+class FolioId(PmsBaseModel):
+    id: int
+    name: str | None = None
+
+    @classmethod
+    def from_pms_folio(cls, folio):
+        return cls(id=folio.id, name=folio.name)
+
+
+class FolioCountSummary(PmsBaseModel):
+    foliosCount: int = Field(0)
+    reservationsCount: int = Field(0)
+
+
 class FolioSummary(PmsBaseModel):
     id: int
     partner_name: str = Field("", alias="customerName")
@@ -141,6 +160,7 @@ class FolioSummary(PmsBaseModel):
     external_reference: str = Field("", alias="externalReference")
     nationality: CountrySummary | None = None
     amount_total: CurrencyAmount = Field(0.0, alias="totalAmount")
+    amount_to_invoice: CurrencyAmount = Field(0.0, alias="pendingAmountToInvoice")
     currency: CurrencySummary | None = None
     create_date: date = Field(alias="creationDate")
     reservations: list[reservationSummary]
@@ -377,7 +397,7 @@ class FolioSearch(BaseSearch):
         services: Annotated[
             list[int] | None,
             Query(
-                description="Filter by service IDs. "
+                description="Filter by service IDs, as returned by GET /services. "
                 "Repeated query param, e.g. ?services=1&services=5",
             ),
         ] = None,
@@ -464,7 +484,27 @@ class FolioSearch(BaseSearch):
         if reservation_folio_ids is not None:
             domain.append(("id", "in", reservation_folio_ids))
 
+        service_folio_ids = self._get_service_folio_ids(env)
+        if service_folio_ids is not None:
+            domain.append(("id", "in", service_folio_ids))
+
         return domain
+
+    def _get_service_folio_ids(self, env: api.Environment) -> list | None:
+        """Search folios through service lines by product_id.
+        Returns a list of folio IDs, or None if no service filter is active.
+        """
+        if not self.services:
+            return None
+        service_domain = [("product_id", "in", self.services)]
+        if self.pmsProperty:
+            service_domain.append(("pms_property_id", "=", self.pmsProperty))
+        else:
+            service_domain.append(
+                ("pms_property_id", "in", env.user.pms_property_ids.ids)
+            )
+        groups = env["pms.service"].sudo().read_group(service_domain, [], ["folio_id"])
+        return [g["folio_id"][0] for g in groups if g["folio_id"]]
 
     def _get_reservation_folio_ids(self, env: api.Environment) -> list | None:
         """Search folios through reservation fields, excluding reservations
@@ -533,8 +573,6 @@ class FolioSearch(BaseSearch):
             domain.append(("price_room_services_set", "=", self.totalAmountEq))
         if self.preCheckinState:
             domain.extend(self._get_precheckin_state_domain())
-        if self.services:
-            domain.append(("service_ids", "in", self.services))
         if domain:
             domain.append(("cancelled_reason", "!=", "modified"))
         return domain
@@ -545,7 +583,14 @@ class FolioSearch(BaseSearch):
                 ("overbooking", "=", True),
                 ("state", "!=", "cancel"),
             ],
-            reservationStateEnum.CANCELLED: [("state", "=", "cancel")],
+            reservationStateEnum.CANCELLED: [
+                ("state", "=", "cancel"),
+                ("cancelled_reason", "!=", "noshow"),
+            ],
+            reservationStateEnum.NO_SHOW: [
+                ("state", "=", "cancel"),
+                ("cancelled_reason", "=", "noshow"),
+            ],
             reservationStateEnum.ARRIVAL: [
                 ("state", "in", ["confirm", "arrival_delayed"])
             ],

--- a/pms_fastapi/schemas/pms_service.py
+++ b/pms_fastapi/schemas/pms_service.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from .base import PmsBaseModel
 
 
@@ -9,3 +11,21 @@ class ServiceId(PmsBaseModel):
     def from_pms_service(cls, service):
         filtered_data = cls._read_odoo_record(service)
         return cls(**filtered_data)
+
+
+class ServiceProduct(PmsBaseModel):
+    id: int
+    name: str
+    is_board_service: bool = Field(False, alias="isBoardService")
+    per_day: bool = Field(False, alias="perDay")
+    per_person: bool = Field(False, alias="perPerson")
+
+    @classmethod
+    def from_product_product(cls, product, is_board_service: bool = False):
+        return cls(
+            id=product.id,
+            name=product.name,
+            is_board_service=is_board_service,
+            per_day=product.per_day,
+            per_person=product.per_person,
+        )

--- a/pms_fastapi_l10n_es/schemas/__init__.py
+++ b/pms_fastapi_l10n_es/schemas/__init__.py
@@ -1,1 +1,2 @@
+from . import agency
 from . import contact

--- a/pms_fastapi_l10n_es/schemas/agency.py
+++ b/pms_fastapi_l10n_es/schemas/agency.py
@@ -1,0 +1,9 @@
+from odoo.addons.pms_fastapi.schemas import agency
+
+
+class AgencyIdImageComercial(agency.AgencyIdImage, extends=True):
+    @classmethod
+    def parse_common_fields(cls, partner) -> dict:
+        data = super().parse_common_fields(partner)
+        data["name"] = partner.comercial or partner.name
+        return data

--- a/roomdoo_fastapi/routers/pms_folio.py
+++ b/roomdoo_fastapi/routers/pms_folio.py
@@ -8,7 +8,7 @@ from odoo.addons.fastapi.schemas import Paging
 from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
 from odoo.addons.pms_fastapi.routers.pms_folio import folio_order
-from odoo.addons.pms_fastapi.schemas.pms_folio import FolioSummary
+from odoo.addons.pms_fastapi.schemas.pms_folio import FolioCountSummary, FolioSummary
 from odoo.addons.roomdoo_fastapi.schemas.pms_folio import FolioPendingSearch
 
 
@@ -32,4 +32,23 @@ async def list_folios_pending_closure(
     return PagedCollection[FolioSummary](
         count=count,
         items=[FolioSummary.from_pms_folio(folio) for folio in folios],
+    )
+
+
+@pms_api_router.get(
+    "/folios/pending-closure/count",
+    response_model=FolioCountSummary,
+    tags=["folio"],
+)
+async def count_folios_pending_closure(
+    env: AuthenticatedEnv,
+    filters: Annotated[FolioPendingSearch, Depends()],
+) -> FolioCountSummary:
+    """Get the counts of folios pending closure and their reservations."""
+    folios_count, reservations_count = (
+        env["pms_api_folio.folio_router.helper"].new().count(filters)
+    )
+    return FolioCountSummary(
+        foliosCount=folios_count,
+        reservationsCount=reservations_count,
     )

--- a/roomdoo_fastapi/schemas/contact_id_number.py
+++ b/roomdoo_fastapi/schemas/contact_id_number.py
@@ -41,3 +41,9 @@ class IdDocument(id_document.IdDocument, extends=True):
         id_document_record = super().from_id_number(document_rec)
         id_document_record.type = document_rec.category_id.short_code or ""
         return id_document_record
+
+    @classmethod
+    def from_pms_checkin_partner(cls, checkin_partner):
+        id_document_record = super().from_id_number(checkin_partner)
+        id_document_record.type = checkin_partner.document_type.short_code or ""
+        return id_document_record


### PR DESCRIPTION
- Add amount_to_invoice on pms.folio and folio.sale.line (taxes included), exposed as pendingAmountToInvoice in FolioSummary.
- Add GET /services endpoint listing PMS service products, and switch the folio services filter to match by product_id.
- Add POST /invoices/report batch PDF endpoint (limit 100 records). Rename the existing xlsx/pdf endpoint to POST /invoices/accounting-report.
- Add pendingAmount and folios to InvoiceSummary.
- GET /folios/count now returns {foliosCount, reservationsCount}, resolved with a single materialized CTE.
- Split noShow from cancelled in reservationStateEnum and filter mapping.
- Add AgencyIdImage schema; extend it in pms_fastapi_l10n_es to use the partner comercial name.