### PR TITLE
[IMP] pms_fastapi: gate journals and payment methods with account.jou…

### DIFF
--- a/pms_fastapi/__manifest__.py
+++ b/pms_fastapi/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "PMS FastAPI",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "development_status": "Beta",
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",
@@ -25,5 +25,6 @@
     "data": [
         "security/pms_fastapi_groups.xml",
         "data/res_users.xml",
+        "views/account_journal_views.xml",
     ],
 }

--- a/pms_fastapi/migrations/16.0.1.3.0/post-migration.py
+++ b/pms_fastapi/migrations/16.0.1.3.0/post-migration.py
@@ -1,0 +1,37 @@
+"""Mark as ``allowed_on_pms = TRUE`` any journal that is either:
+
+* explicitly restricted to one or more ``pms_property_ids``, or
+* already used in real ``account.move`` records that have ``pms_property_id``
+  set (i.e. PMS-context invoices, including those on "generic" journals
+  without ``pms_property_ids``).
+
+Journals never used and never configured for PMS stay ``FALSE`` and require
+manual review — that is the ambiguity the flag was introduced to surface.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        """
+        UPDATE account_journal
+        SET allowed_on_pms = TRUE
+        WHERE id IN (
+            SELECT account_journal_id FROM account_journal_pms_property_rel
+            UNION
+            SELECT DISTINCT journal_id
+            FROM account_move
+            WHERE pms_property_id IS NOT NULL
+        )
+        """
+    )
+    if cr.rowcount:
+        _logger.info(
+            "Marked %d journals as allowed_on_pms (config + historical use).",
+            cr.rowcount,
+        )

--- a/pms_fastapi/models/account_journal.py
+++ b/pms_fastapi/models/account_journal.py
@@ -1,9 +1,16 @@
-from odoo import _, models
+from odoo import _, fields, models
 from odoo.exceptions import UserError
 
 
 class AccountJournal(models.Model):
     _inherit = "account.journal"
+
+    allowed_on_pms = fields.Boolean(
+        string="Allowed on PMS",
+        help="If checked, this journal is available for PMS folio invoices "
+        "and exposes the hotel/room configuration. Also gates PMS API "
+        "behaviors that depend on the journal.",
+    )
 
     def write(self, vals):
         if "type" in vals or "currency_id" in vals:

--- a/pms_fastapi/models/account_move.py
+++ b/pms_fastapi/models/account_move.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
@@ -83,3 +83,17 @@ class AccountMove(models.Model):
         if value:
             return [("line_ids.is_overdue", "=", True)]
         return []
+
+    # pylint: disable=W8110
+    @api.depends("pms_property_id")
+    def _compute_suitable_journal_ids(self):
+        super()._compute_suitable_journal_ids()
+        for move in self:
+            if move.pms_property_id:
+                move.suitable_journal_ids = move.suitable_journal_ids.filtered(
+                    lambda j, move=move: j.allowed_on_pms
+                    and (
+                        not j.pms_property_ids
+                        or move.pms_property_id.id in j.pms_property_ids.ids
+                    )
+                )

--- a/pms_fastapi/routers/journal.py
+++ b/pms_fastapi/routers/journal.py
@@ -49,9 +49,19 @@ class PmsApiJournalRouterHelper(models.AbstractModel):
     _description = "PMS API Journal Router Helper"
 
     def search_journals(self, pms_property_id=None, journal_type=None):
-        domain = []
+        """Return journals allowed on PMS, scoped by property and type.
+
+        ``journal_type`` accepts either a single ``str`` (HTTP layer) or an
+        iterable of types — useful when callers know up front which journal
+        types are relevant (e.g. payment methods only live on bank/cash
+        journals, so callers can skip sale/purchase/general entirely).
+        """
+        domain = [("allowed_on_pms", "=", True)]
         if journal_type:
-            domain.append(("type", "=", journal_type))
+            if isinstance(journal_type, str):
+                domain.append(("type", "=", journal_type))
+            else:
+                domain.append(("type", "in", list(journal_type)))
         if pms_property_id:
             domain = expression.AND(
                 [

--- a/pms_fastapi/routers/payment_method.py
+++ b/pms_fastapi/routers/payment_method.py
@@ -1,3 +1,9 @@
+from typing import Annotated
+
+from fastapi import Query
+
+from odoo import models
+
 from odoo.addons.pms_fastapi.dependencies import AuthenticatedEnv
 from odoo.addons.pms_fastapi.models.fastapi_endpoint import pms_api_router
 from odoo.addons.pms_fastapi.schemas.payment_method import PaymentMethodSummary
@@ -10,14 +16,46 @@ from odoo.addons.pms_fastapi.schemas.payment_method import PaymentMethodSummary
 )
 async def list_payment_methods(
     env: AuthenticatedEnv,
+    pmsPropertyId: Annotated[
+        int | None,
+        Query(
+            description="Restrict to payment methods whose journal is "
+            "available for the given property."
+        ),
+    ] = None,
 ) -> list[PaymentMethodSummary]:
-    """List all payment methods."""
-    methods = (
-        env["account.payment.method.line"]
-        .sudo()
-        .search([("payment_type", "=", "inbound")])
-    )
+    """List inbound payment methods allowed on PMS, scoped through their journal."""
+    helper = env["pms_api_payment_method.payment_method_router.helper"].new()
+    methods = helper.search_payment_methods(pms_property_id=pmsPropertyId)
     return [
         PaymentMethodSummary.from_account_payment_method_line(method)
         for method in methods
     ]
+
+
+class PmsApiPaymentMethodRouterHelper(models.AbstractModel):
+    _name = "pms_api_payment_method.payment_method_router.helper"
+    _description = "PMS API Payment Method Router Helper"
+
+    def search_payment_methods(self, pms_property_id=None):
+        # Payment method lines only exist on bank and cash journals; pass the
+        # types down so the journal helper skips sale/purchase/general.
+        journals = (
+            self.env["pms_api_journal.journal_router.helper"]
+            .new()
+            .search_journals(
+                pms_property_id=pms_property_id,
+                journal_type=("bank", "cash"),
+            )
+        )
+        return (
+            self.env["account.payment.method.line"]
+            .sudo()
+            .search(
+                [
+                    ("payment_type", "=", "inbound"),
+                    ("allowed_on_pms", "=", True),
+                    ("journal_id", "in", journals.ids),
+                ]
+            )
+        )

--- a/pms_fastapi/views/account_journal_views.xml
+++ b/pms_fastapi/views/account_journal_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="account_journal_view_form_inherit_pms_fastapi" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="pms.account_journal_view_form" />
+        <field name="arch" type="xml">
+            <field name="pms_property_ids" position="before">
+                <field name="allowed_on_pms" />
+            </field>
+            <field name="pms_property_ids" position="attributes">
+                <attribute
+          name="attrs"
+        >{'invisible': [('allowed_on_pms', '=', False)]}</attribute>
+            </field>
+            <field name="room_filter_ids" position="attributes">
+                <attribute
+          name="attrs"
+        >{'invisible': [('allowed_on_pms', '=', False)]}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
…rnal.allowed_on_pms

* Add allowed_on_pms boolean on account.journal to disambiguate PMS-relevant journals (with or without pms_property_ids) from purely accounting ones.
* Hide pms_property_ids and room_filter_ids in the journal form unless the flag is set.
* Reinforce account.move._compute_suitable_journal_ids: when move has pms_property_id, suitable journals must be allowed_on_pms.
* Restrict /journals to allowed_on_pms journals (helper now base-filters by the flag) and accept either a single type or an iterable.
* Restrict /payment-methods to allowed_on_pms inbound lines on allowed_on_pms journals; constrain journal types to bank/cash via the helper to avoid scanning sale/purchase/general.
* Move payment-methods logic into a dedicated helper AbstractModel so it is inheritable and the endpoint stays orchestration-only.
* Post-migration marks as allowed_on_pms=TRUE every journal already restricted to pms_property_ids OR historically used in account.move with pms_property_id (covers "PMS-generic" journals without pms_property_ids).