### PR TITLE
[FIX] pms_fastapi: identification_number search hook ignored

### DIFF
--- a/pms_fastapi/__manifest__.py
+++ b/pms_fastapi/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "PMS FastAPI",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "development_status": "Beta",
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",

--- a/pms_fastapi/migrations/16.0.1.3.0/pre-migrate.py
+++ b/pms_fastapi/migrations/16.0.1.3.0/pre-migrate.py
@@ -1,0 +1,18 @@
+import logging
+
+from odoo.tools.sql import column_exists
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    if not column_exists(cr, "res_partner", "identification_number"):
+        return
+
+    _logger.info(
+        "Dropping orphan res_partner.identification_number column "
+        "(field is now non-stored, search-only)."
+    )
+    cr.execute("ALTER TABLE res_partner DROP COLUMN identification_number")

--- a/pms_fastapi/models/res_partner.py
+++ b/pms_fastapi/models/res_partner.py
@@ -13,7 +13,17 @@ class ResPartner(models.Model):
     in_house = fields.Boolean(
         compute="_compute_reservation_data", search="_search_in_house"
     )
-    identification_number = fields.Char(search="_search_identification_number")
+    identification_number = fields.Char(
+        compute="_compute_identification_number",
+        search="_search_identification_number",
+    )
+
+    def _compute_identification_number(self):
+        # No-op compute on purpose: this field is a search-only proxy over
+        # res.partner.id_number. Without a `compute=`, Odoo treats the field
+        # as a stored Char column and resolves domains against the (empty)
+        # column instead of calling `_search_identification_number`.
+        self.identification_number = False
 
     def _search_identification_number(self, operator, value):
         id_numbers = self.env["res.partner.id_number"].search(


### PR DESCRIPTION
The field was declared with only `search=` and no `compute=`, so Odoo created it as a real stored Char column on res_partner. The ORM then resolved domains directly against the (empty) column instead of calling _search_identification_number, so global searches by id number returned nothing.

Add a no-op compute so the field is non-stored and the search hook is used. Drop the orphan column in a pre-migration.