### PR TITLE
[FIX] roomdoo_invoices_exporter: use get_vat()

### DIFF
--- a/roomdoo_invoices_exporter/__manifest__.py
+++ b/roomdoo_invoices_exporter/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Invoice & Payment XLSX Report",
-    "version": "16.0.2.0.0",
+    "version": "16.0.2.1.0",
     "author": "Commitsun",
     "website": "https://www.roomdoo.com",
     "category": "Accounting",

--- a/roomdoo_invoices_exporter/report/invoice_payment_xlsx.py
+++ b/roomdoo_invoices_exporter/report/invoice_payment_xlsx.py
@@ -260,7 +260,7 @@ class InvoicePaymentXlsx(models.AbstractModel):
             (inv.invoice_date, "date"),
             (inv.invoice_date_due, "date"),
             (partner.name or "", "text"),
-            (partner.vat or "", "text"),
+            (partner.get_vat(), "text"),
             (", ".join(address_parts), "text"),
             (partner.zip or "", "text"),
             (partner.city or "", "text"),

--- a/roomdoo_invoices_exporter/wizard/invoices_export_wizard.py
+++ b/roomdoo_invoices_exporter/wizard/invoices_export_wizard.py
@@ -173,24 +173,19 @@ class RoomdooInvoicesExporter(models.TransientModel):
             data_format = next(data_formats)
             date_format = next(date_formats)
             money_format = next(money_formats)
-            country_code = ""
-            vat_partner = False
-            if inv.partner_id.vat:
-                vat_partner = inv.partner_id.vat
-            elif inv.partner_id.aeat_identification:
-                vat_partner = inv.partner_id.aeat_identification
-            country_partner = inv.partner_id.country_id
-            if country_partner:
-                country_code = country_partner.code
-                if inv.partner_id.vat:
-                    vat_partner = (
-                        inv.partner_id.vat[2:]
-                        if inv.partner_id.vat[2:] == country_code
-                        else inv.partner_id.vat
-                    )
-
-            if not vat_partner and inv.partner_id.vat:
-                vat_partner = inv.partner_id.vat
+            vat_partner = inv.partner_id.get_vat()
+            country_code = inv.partner_id.country_id.code or ""
+            # Strip duplicated country prefix from VAT, but only when the
+            # value is the VAT itself (not an AEAT alternative identification
+            # such as passport or residence permit, which has no country
+            # prefix).
+            if (
+                vat_partner
+                and country_code
+                and not inv.partner_id.aeat_identification_type
+                and vat_partner[:2] == country_code
+            ):
+                vat_partner = vat_partner[2:]
             origin = ""
             signed = 1
             if inv.move_type == "out_refund":


### PR DESCRIPTION
Replace `partner.vat or ""` with `partner.get_vat()` so the invoice XLSX exports the AEAT identification (passport, residence permit, etc.) when the partner is not VAT-registered. Without this, non-VAT guests had an empty fiscal identifier in the export, which is a bug in a PMS context where invoicing non-residents is the norm.

Depends on res.partner.get_vat() (pms 16.0.4.2.0 + pms_l10n_es 16.0.2.2.0).

cross-dependency: https://github.com/OCA/pms/pull/397