### PR TITLE
[IMP] kellys_daily_report: add adults/children columns to Excel export

### DIFF
--- a/kellys_daily_report/__manifest__.py
+++ b/kellys_daily_report/__manifest__.py
@@ -21,7 +21,7 @@
 
 {
     "name": "Hotel Kellys Daily Report",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "Jose Luis Algara <osotranquilo@gmail.com>,"
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",

--- a/kellys_daily_report/wizard/kellys_daily_pdf.py
+++ b/kellys_daily_report/wizard/kellys_daily_pdf.py
@@ -161,6 +161,15 @@ class KellysWizard(models.TransientModel):
                     room = reservation.reservation_line_ids.filtered(
                         lambda line: line.date == fechalimpieza
                     ).room_id
+                # Reserva entrante para conteo de adultos/niños:
+                # con 2 reservas (salida+entrada) la entrante es reservations[1];
+                # si solo hay salida (checkin "no prevista") o avería, no entra nadie.
+                if tipos == "5" or checkinhour == "no prevista":
+                    incoming = self.env["pms.reservation"]
+                elif len(reservations) == 2:
+                    incoming = reservations[1]
+                else:
+                    incoming = reservations[0]
                 listid.append(
                     grids2.create(
                         {
@@ -182,6 +191,8 @@ class KellysWizard(models.TransientModel):
                             "checkout": checkouthour,
                             # 'kelly': 5,
                             "clean_date": fechalimpieza,
+                            "adults": incoming.adults if incoming else 0,
+                            "children": incoming.children if incoming else 0,
                         }
                     ).id
                 )
@@ -231,6 +242,9 @@ class KellysWizard(models.TransientModel):
         worksheet.write("D1", _("Entrada"), xls_cell_format_header)
         worksheet.write("E1", _("Salida"), xls_cell_format_header)
         worksheet.write("F1", _("Asignado"), xls_cell_format_header)
+        worksheet.write("G1", _("Adultos"), xls_cell_format_header)
+        worksheet.write("H1", _("Niños"), xls_cell_format_header)
+        worksheet.write("I1", _("Total"), xls_cell_format_header)
 
         worksheet.set_column("A:A", 10)
         worksheet.set_column("B:B", 10)
@@ -238,6 +252,9 @@ class KellysWizard(models.TransientModel):
         worksheet.set_column("D:D", 15)
         worksheet.set_column("E:E", 15)
         worksheet.set_column("F:F", 10)
+        worksheet.set_column("G:G", 8)
+        worksheet.set_column("H:H", 8)
+        worksheet.set_column("I:I", 8)
 
         rooms = self.env["kellysrooms"].search(
             [("id", "in", self.habitaciones.ids)], order="habitacion ASC"
@@ -251,6 +268,9 @@ class KellysWizard(models.TransientModel):
             worksheet.write(k_room + offset, 3, v_room.checkin, xls_cell_format_date)
             worksheet.write(k_room + offset, 4, v_room.checkout, xls_cell_format_date)
             worksheet.write(k_room + offset, 5, v_room.kelly.name)
+            worksheet.write(k_room + offset, 6, v_room.adults)
+            worksheet.write(k_room + offset, 7, v_room.children)
+            worksheet.write(k_room + offset, 8, v_room.total_pax)
 
         workbook.close()
         file_data.seek(0)

--- a/kellys_daily_report/wizard/kellys_daily_rooms.py
+++ b/kellys_daily_report/wizard/kellys_daily_rooms.py
@@ -17,7 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class KellysRooms(models.TransientModel):
@@ -44,3 +44,11 @@ class KellysRooms(models.TransientModel):
         comodel_name="kellysnames",
     )
     clean_date = fields.Date(string="Limpiar fecha")
+    adults = fields.Integer(string="Adultos")
+    children = fields.Integer(string="Niños")
+    total_pax = fields.Integer(string="Total", compute="_compute_total_pax", store=True)
+
+    @api.depends("adults", "children")
+    def _compute_total_pax(self):
+        for rec in self:
+            rec.total_pax = rec.adults + rec.children


### PR DESCRIPTION
## Summary

- Bump version to `16.0.1.1.0`.
- Compute the incoming reservation per cleaning slot (none on out-only or breakdown, second one when both checkout and checkin happen the same day, otherwise the only reservation) to populate `adults` and `children` on each `kellysrooms` row.
- Render `Adultos` / `Niños` / `Total` columns in the daily Excel sheet.

## Test plan

- [ ] Run the Kellys daily report for a day mixing: only-checkin rooms, only-checkout rooms, same-day checkout+checkin rooms, and breakdown ("avería") rooms.
- [ ] Export to Excel and verify Adultos/Niños/Total reflect the incoming reservation (or 0 for out-only / breakdown).
- [ ] PDF output unaffected (this change only touches the Excel export).