### PR TITLE
[FIX] roomdoo_fastapi: rename pending-closure route

### DIFF
--- a/roomdoo_fastapi/routers/pms_folio.py
+++ b/roomdoo_fastapi/routers/pms_folio.py
@@ -13,7 +13,7 @@ from odoo.addons.roomdoo_fastapi.schemas.pms_folio import FolioPendingSearch
 
 
 @pms_api_router.get(
-    "/folios/pending-closure",
+    "/folios-pending-closure",
     response_model=PagedCollection[FolioSummary],
     tags=["folio"],
 )
@@ -36,7 +36,7 @@ async def list_folios_pending_closure(
 
 
 @pms_api_router.get(
-    "/folios/pending-closure/count",
+    "/folios-pending-closure/count",
     response_model=FolioCountSummary,
     tags=["folio"],
 )


### PR DESCRIPTION
Move /folios/pending-closure to /folios-pending-closure to avoid collision with /folios/{folio_id} declared in pms_fastapi, which matches first and returns 422 trying to coerce "pending-closure" to int.