### PR TITLE
[FIX] pms_api_rest: use reservation_id variable instead of pms_checki…

### DIFF
--- a/pms_api_rest/services/pms_reservation_service.py
+++ b/pms_api_rest/services/pms_reservation_service.py
@@ -1988,7 +1988,7 @@ class PmsReservationService(Component):
             folio_id = (
                 self.env["pms.reservation"]
                 .sudo()
-                .browse(pms_checkin_partner_info.reservationId)
+                .browse(reservation_id)
                 .folio_id.id
             )
             record_checkin_partner_legal_representative = (


### PR DESCRIPTION
…n_partner_info.reservationId in folio lookup