### PR TITLE
[FIX] pms_autoinvoice: validate orphan draft invoices in with_delay mode

### DIFF
--- a/pms_autoinvoice/models/pms_property.py
+++ b/pms_autoinvoice/models/pms_property.py
@@ -72,30 +72,35 @@ class PmsProperty(models.Model):
                 self.with_delay().autoinvoice_folio(folio, delay_post=True)
             else:
                 self.autoinvoice_folio(folio)
-        if not with_delay:
-            # 2- Validate the draft invoices created by the folios
-            draft_invoices_to_post = self.env["account.move"].search(
-                [
-                    ("state", "=", "draft"),
-                    (
-                        "invoice_line_ids.folio_line_ids.autoinvoice_date",
-                        "=",
-                        date_reference,
-                    ),
-                    ("folio_ids", "!=", False),
-                    ("amount_total", ">", 0),
-                ]
+        # 2- Validate draft invoices ready for posting. Invoices created
+        # in step 1 schedule their own posting job from inside
+        # autoinvoice_folio; this search catches orphan drafts left over
+        # from previous runs or created manually outside the cron flow.
+        draft_invoices_to_post = self.env["account.move"].search(
+            [
+                ("state", "=", "draft"),
+                (
+                    "invoice_line_ids.folio_line_ids.autoinvoice_date",
+                    "=",
+                    date_reference,
+                ),
+                ("folio_ids", "!=", False),
+                ("amount_total", ">", 0),
+            ]
+        )
+        # Skip invoices that still have lines with future autoinvoice dates
+        draft_invoices_to_post = draft_invoices_to_post.filtered(
+            lambda inv: not inv.invoice_line_ids.folio_line_ids.filtered(
+                lambda fl: fl.autoinvoice_date and fl.autoinvoice_date > date_reference
             )
-            # Skip invoices that still have lines with future autoinvoice dates
-            draft_invoices_to_post = draft_invoices_to_post.filtered(
-                lambda inv: not inv.invoice_line_ids.folio_line_ids.filtered(
-                    lambda fl: fl.autoinvoice_date
-                    and fl.autoinvoice_date > date_reference
-                )
-            )
-            for invoice in draft_invoices_to_post:
+        )
+        for invoice in draft_invoices_to_post:
+            if with_delay:
+                self.with_delay().autovalidate_folio_invoice(invoice)
+            else:
                 self.autovalidate_folio_invoice(invoice)
 
+        if not with_delay:
             # 3- Reverse the downpayment invoices not included in final invoice
             downpayments_invoices_to_reverse = self.env["account.move.line"].search(
                 [


### PR DESCRIPTION
## Summary

- After 2895c9d, `autoinvoicing(with_delay=True)` no longer revalidates pre-existing draft invoices — it only schedules posting jobs for the invoices the cron itself creates inside `autoinvoice_folio(delay_post=True)`.
- Drafts created manually from a folio (or left over from a previous failed/interrupted run) whose `invoice_line_ids.folio_line_ids.autoinvoice_date` matches today stay in draft forever: their folio's `invoice_status` flips to `to_confirm` (`qty_invoiced = 1` on the linked sale lines, since they belong to a draft invoice), so step 1 of the cron skips that folio too.
- Fix: move step 2 (validate drafts) out of the `if not with_delay:` block so it always runs. In `with_delay=True` each draft is enqueued via `self.with_delay().autovalidate_folio_invoice(invoice)`. Step 3 (reverse stale downpayment invoices) stays gated on synchronous mode since it depends on the new invoices already being posted.
- Step 1 still enqueues `autoinvoice_folio(delay_post=True)` for each matching folio; those run asynchronously, so when step 2's `search` executes the invoices those jobs will create do not exist yet and are not double-queued. The eta=15min in `autoinvoice_folio` keeps the original anti-contention behavior for newly-created invoices.

## Test plan

- [ ] Run `model.autoinvoicing(offset=0, with_delay=True)` on a database with at least one orphan draft (state=draft, folio_ids set, `invoice_line_ids.folio_line_ids.autoinvoice_date = today`, amount_total > 0).
- [ ] Verify a queue job `pms.property.autovalidate_folio_invoice` is enqueued for each orphan draft.
- [ ] Verify the orphan drafts get posted after the queue runs.
- [ ] Verify `with_delay=False` path keeps the original behavior (step 2 inline + step 3 reverse).