### PR TITLE
[FIX] pms_autoinvoice: skip line_notes from partners without billable lines

### DIFF
--- a/pms_autoinvoice/models/pms_folio.py
+++ b/pms_autoinvoice/models/pms_folio.py
@@ -8,19 +8,33 @@ class PmsFolio(models.Model):
 
     def _get_lines_to_invoice(self, final=False):
         self = self.with_context(lines_auto_add=True)
-        lines_to_invoice = dict()
         res = super()._get_lines_to_invoice(final=final)
         if not self._context.get("autoinvoice"):
             return res
-        for line in self.sale_line_ids.filtered(
-            lambda r: r.qty_to_invoice > 0
-            or (r.qty_to_invoice < 0 and final)
-            or r.display_type == "line_note"
-        ):
-            if line.autoinvoice_date and line.autoinvoice_date <= fields.Date.today():
-                lines_to_invoice[line.id] = (
-                    0 if line.display_type else line.qty_to_invoice
-                )
+        due_lines = self.sale_line_ids.filtered(
+            lambda r: r.autoinvoice_date
+            and r.autoinvoice_date <= fields.Date.today()
+            and (
+                r.qty_to_invoice > 0
+                or (r.qty_to_invoice < 0 and final)
+                or r.display_type == "line_note"
+            )
+        )
+        # Drop line_notes whose partner_invoice has no billable line in this
+        # batch — otherwise _create_invoices would group them into a 0€
+        # invoice for that partner (e.g. late reservations added as orphan
+        # notes after the original folio was already invoiced).
+        billable_partner_ids = {
+            line.default_invoice_to.id for line in due_lines if not line.display_type
+        }
+        lines_to_invoice = dict()
+        for line in due_lines:
+            if (
+                line.display_type == "line_note"
+                and line.default_invoice_to.id not in billable_partner_ids
+            ):
+                continue
+            lines_to_invoice[line.id] = 0 if line.display_type else line.qty_to_invoice
         return lines_to_invoice
 
     def _get_invoice_date(self, partner_invoice_id, lines_to_invoice, date=None):


### PR DESCRIPTION
## Summary

When `_get_lines_to_invoice` runs in `autoinvoice` mode it was including every `line_note` whose `autoinvoice_date` had landed, regardless of whether the `partner_invoice` that owns those notes had any billable line in the batch. `_create_invoices(grouped=True)` then groups by `partner_invoice` and produces a draft `account.move` for that partner containing only zero-priced notes — i.e. a 0€ invoice that `autoinvoice_folio` still queues for posting.

This typically happens when extra reservations are added to an already-invoiced folio: their `line_notes` become orphan and trigger a phantom 0€ invoice.

## Fix

In [pms_folio._get_lines_to_invoice](pms_autoinvoice/models/pms_folio.py):

- Compute `due_lines` (autoinvoice_date due today, billable or `line_note`).
- Build `billable_partner_ids` from the lines that actually have something to bill.
- Drop `line_notes` whose `default_invoice_to` is not in that set, so they never enter `lines_to_invoice` in the first place.

No more 0€ drafts created; no need to `unlink` anything afterwards.

## Test plan

- [ ] Run `autoinvoicing(with_delay=True)` against a database that contains a folio with an already-invoiced partner_invoice plus a late reservation whose `line_notes` point to a different partner with no billable line.
- [ ] Verify `_create_invoices` does NOT generate a draft `out_invoice` for that orphan partner.
- [ ] Verify normal folios (partner has billable lines + accompanying notes) still produce a single invoice including both.