### PR TITLE
[IMP] pms_api_rest: track cleaning_status and add per-property housekeeping mode

### DIFF
--- a/pms_api_rest/__manifest__.py
+++ b/pms_api_rest/__manifest__.py
@@ -30,6 +30,7 @@
         "data/roomdoo_data.xml",
         "data/roomdoo_app_menu.xml",
         "views/pms_property_views.xml",
+        "views/pms_room_views.xml",
         "views/res_users_views.xml",
         "views/pms_room_type_class_views.xml",
         "views/product_template_views.xml",

--- a/pms_api_rest/data/cron_jobs.xml
+++ b/pms_api_rest/data/cron_jobs.xml
@@ -11,10 +11,26 @@
             <field name="state">code</field>
             <field name="model_id" ref="model_pms_api_log" />
             <field
-            name="nextcall"
-            eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 06:00:00')"
-        />
+      name="nextcall"
+      eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 06:00:00')"
+    />
             <field name="code">model.clean_log_data(offset=60)</field>
+        </record>
+
+        <record model="ir.cron" id="mark_rooms_dirty_daily">
+            <field name="name">Mark Rooms Dirty Daily</field>
+            <field name="interval_number">1</field>
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False" />
+            <field name="state">code</field>
+            <field name="model_id" ref="pms.model_pms_property" />
+            <field
+      name="nextcall"
+      eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 06:00:00')"
+    />
+            <field name="code">model._cron_mark_rooms_dirty_daily()</field>
         </record>
 
 </odoo>

--- a/pms_api_rest/models/pms_property.py
+++ b/pms_api_rest/models/pms_property.py
@@ -14,6 +14,24 @@ _logger = logging.getLogger(__name__)
 class PmsProperty(models.Model):
     _inherit = "pms.property"
 
+    cleaning_mode = fields.Selection(
+        selection=[
+            ("per_stay", "Per stay (dirty on checkout)"),
+            ("daily", "Daily (dirty every morning by cron)"),
+        ],
+        string="Housekeeping Mode",
+        default="per_stay",
+        required=True,
+        help=(
+            "How rooms are flagged as dirty:\n"
+            " * Per stay: a room becomes dirty only when its reservation is "
+            "checked out (default — apartments).\n"
+            " * Daily: a daily cron also flags as dirty every room whose "
+            "reservation occupied it the previous night (hotels, daily "
+            "housekeeping)."
+        ),
+    )
+
     color_option_config = fields.Selection(
         string="Color Option Configuration",
         help="Configuration of the color code for the planning.",
@@ -35,7 +53,10 @@ class PmsProperty(models.Model):
 
     simple_future_color = fields.Char(
         string="Future Reservations",
-        help="Color for confirm, arrival_delayed and draft reservations in the planning.",
+        help=(
+            "Color for confirm, arrival_delayed and draft reservations in "
+            "the planning."
+        ),
         default="rgba(1,182,227)",
     )
 
@@ -123,6 +144,39 @@ class PmsProperty(models.Model):
         selection=[],
     )
 
+    @api.model
+    def _cron_mark_rooms_dirty_daily(self):
+        """Flag rooms as dirty on properties with daily housekeeping.
+
+        For each property with ``cleaning_mode = 'daily'``, find rooms whose
+        reservation_line occupied them the previous night (regardless of
+        whether the guest stays another night, is checking out today, or
+        has already been checked out) and write ``cleaning_status = 'dirty'``
+        if they are not already dirty.
+        """
+        properties = self.search([("cleaning_mode", "=", "daily")])
+        if not properties:
+            return
+        yesterday = fields.Date.context_today(self) - datetime.timedelta(days=1)
+        lines = self.env["pms.reservation.line"].search(
+            [
+                ("pms_property_id", "in", properties.ids),
+                ("date", "=", yesterday),
+                ("overnight_room", "=", True),
+                (
+                    "reservation_id.state",
+                    "in",
+                    ("onboard", "departure_delayed", "done"),
+                ),
+                ("room_id", "!=", False),
+            ]
+        )
+        rooms_to_dirty = lines.mapped("room_id").filtered(
+            lambda r: r.cleaning_status != "dirty"
+        )
+        if rooms_to_dirty:
+            rooms_to_dirty.write({"cleaning_status": "dirty"})
+
     # PUSH API NOTIFICATIONS
     def get_payload_avail(self, avails, client):
         self.ensure_one()
@@ -143,7 +197,9 @@ class PmsProperty(models.Model):
         ]
         for room_type_id in room_type_ids:
             room_type_avails = sorted(
-                avails.filtered(lambda r: r.room_type_id.id == room_type_id),
+                avails.filtered(
+                    lambda r, rt_id=room_type_id: r.room_type_id.id == rt_id
+                ),
                 key=lambda r: r.date,
             )
             avail_room_type_index = {}
@@ -212,7 +268,7 @@ class PmsProperty(models.Model):
                 self.env["pms.room.type"].search([("product_id", "=", product_id)]).id
             )
             product_prices = sorted(
-                prices.filtered(lambda r: r.product_id.id == product_id),
+                prices.filtered(lambda r, pid=product_id: r.product_id.id == pid),
                 key=lambda r: r.date_end_consumption,
             )
             price_product_index = {}
@@ -263,7 +319,9 @@ class PmsProperty(models.Model):
         ]
         for room_type_id in room_type_ids:
             room_type_rules = sorted(
-                rules.filtered(lambda r: r.room_type_id.id == room_type_id),
+                rules.filtered(
+                    lambda r, rt_id=room_type_id: r.room_type_id.id == rt_id
+                ),
                 key=lambda r: r.date,
             )
             rules_room_type_index = {}
@@ -346,7 +404,7 @@ class PmsProperty(models.Model):
         )
         plan_avail = property_client_conf.main_avail_plan_id
         for date in all_dates:
-            avail_record = avail_records.filtered(lambda r: r.date == date)
+            avail_record = avail_records.filtered(lambda r, d=date: r.date == d)
             if avail_record:
                 avail_rule = avail_record.avail_rule_ids.filtered(
                     lambda r: r.availability_plan_id == plan_avail
@@ -467,7 +525,7 @@ class PmsProperty(models.Model):
             for x in range((date_to - date_from).days + 1)
         ]
         for date in all_dates:
-            rules_record = rules_records.filtered(lambda r: r.date == date)
+            rules_record = rules_records.filtered(lambda r, d=date: r.date == d)
             if rules_record:
                 rule = rules_record[0]
             else:
@@ -651,8 +709,8 @@ class PmsProperty(models.Model):
                         .search([("pms_property_id", "=", pms_property.id)])
                         .mapped("room_type_id")
                         .filtered(
-                            lambda r: r.id
-                            not in property_client_conf.excluded_room_type_ids.ids
+                            lambda r, conf=property_client_conf: r.id
+                            not in conf.excluded_room_type_ids.ids
                         )
                         .ids
                     )

--- a/pms_api_rest/models/pms_room.py
+++ b/pms_api_rest/models/pms_room.py
@@ -2,7 +2,8 @@ from odoo import fields, models
 
 
 class PmsRoom(models.Model):
-    _inherit = "pms.room"
+    _name = "pms.room"
+    _inherit = ["pms.room", "mail.thread"]
 
     cleaning_status = fields.Selection(
         selection=[
@@ -12,4 +13,5 @@ class PmsRoom(models.Model):
         ],
         string="Cleaning Status",
         default="clean",
+        tracking=True,
     )

--- a/pms_api_rest/views/pms_property_views.xml
+++ b/pms_api_rest/views/pms_property_views.xml
@@ -17,6 +17,9 @@
                 </group>
             </xpath>
             <xpath expr="//field[@name='default_departure_hour']" position="after">
+                <group string="Housekeeping">
+                    <field name="cleaning_mode" />
+                </group>
                 <group string="Planning Colors">
                     <field name="color_option_config" />
                     <group>

--- a/pms_api_rest/views/pms_room_views.xml
+++ b/pms_api_rest/views/pms_room_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="pms_room_view_form_inherit_pms_api_rest" model="ir.ui.view">
+        <field name="model">pms.room</field>
+        <field name="inherit_id" ref="pms.pms_room_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="after">
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="message_ids" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Context

`pms.room.cleaning_status` is currently flipped to `dirty` only from the `action_reservation_checkout` override ([pms_api_rest/models/pms_reservation.py:107-115](pms_api_rest/models/pms_reservation.py#L107-L115)) — i.e. only when an effective checkout happens. That has two limitations:

1. Properties whose housekeeping team cleans every morning (rather than only on checkout) cannot express that workflow. Their occupied rooms stay marked as clean even after the previous night was slept in, so the cleaning team has no signal to know which rooms to visit.
2. The field has no `tracking`, so any post-hoc diagnosis of inconsistencies between expected and actual state is blind.

## Changes

- **`pms.room`**: add `mail.thread` to `_inherit` and `tracking=True` to `cleaning_status`. The pms.room form view now shows a chatter, so every transition (checkout override, `update_room` REST endpoint, manual write) is recorded.
- **`pms.property.cleaning_mode`**: new Selection
  - `per_stay` (default) — current behaviour, unchanged for every property.
  - `daily` — opt-in; a daily cron flags rooms dirty every morning.
- **Cron `Mark Rooms Dirty Daily`** (06:00 server time): for each property in `daily`, look up `pms.reservation.line` with `date == yesterday`, `overnight_room`, reservation in `onboard / departure_delayed / done`, and set `cleaning_status='dirty'` on rooms that are not already dirty. Rooms already in `dirty` are skipped to avoid noisy chatter writes.
- **`pms.property` view**: new "Housekeeping" section with the field.
- **Lint cleanup**: 7 pre-existing ruff findings in `pms_property.py` (6× B023 lambda-with-loop-variable closures, 1× E501) fixed so the file passes lint after the edits.

## Deployment

1. Merge and deploy.
2. From Settings, switch the affected properties to `cleaning_mode='daily'`.
3. Wait for the next 06:00 cron run and verify:
   - Rooms occupied the previous night are flagged `dirty`.
   - Each `pms.room` chatter records the change via `mail_tracking_value`.

## Test plan

- [ ] Install the module on demo, verify the migration applies without errors (new field + cron + chatter).
- [ ] Create an onboard reservation covering last night and today on a property with `cleaning_mode='per_stay'`, trigger the cron manually (`env['pms.property']._cron_mark_rooms_dirty_daily()`), confirm it does **not** mark dirty.
- [ ] Switch the property to `daily`, repeat, confirm it **does** mark dirty.
- [ ] Confirm rooms already in `dirty` do not receive a redundant write (no duplicate `mail_tracking_value` entry).
- [ ] Verify the room chatter shows the `clean → dirty` transition.