### PR TITLE
[FIX] pms_fastapi: elevate user when rendering invoice accounting XLSX

### DIFF
--- a/pms_fastapi/routers/invoice.py
+++ b/pms_fastapi/routers/invoice.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends, Query
 from fastapi.responses import JSONResponse, Response
 
-from odoo import api, models
+from odoo import SUPERUSER_ID, api, models
 from odoo.exceptions import MissingError, UserError
 from odoo.osv import expression
 
@@ -399,8 +399,12 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
 
     def _render_invoice_xlsx(self, invoices):
         report_name = self._get_invoice_xlsx_report_name()
+        # `report_xlsx._render_xlsx` forces `.sudo(False)` on the report
+        # model, so `.sudo()` here would not bypass ACL inside the export.
         content, _report_type = (
-            self.env["ir.actions.report"].sudo()._render(report_name, invoices.ids)
+            self.env["ir.actions.report"]
+            .with_user(SUPERUSER_ID)
+            ._render(report_name, invoices.ids)
         )
         return Response(
             content=content,


### PR DESCRIPTION
## Summary

`POST /pmsApi/invoices/accounting-report?format=xlsx` returned **403 Forbidden** to authenticated PMS users who lacked accounting groups, with a backend warning like *"No puede ingresar a los registros 'Apunte contable' (account.move.line)"*.

Root cause: `report_xlsx._render_xlsx` (OCA `reporting-engine`) calls `.sudo(False)` on the report model before invoking `generate_xlsx_report`. That silently undoes the `.sudo()` chained on `ir.actions.report` in the FastAPI router, so the XLSX export ran with the API user's ACLs and failed when reading `account.move.line` / `account.payment`.

## Change

Replace `.sudo()` with `.with_user(SUPERUSER_ID)` on the `_render` call. Changing the env user survives the `.sudo(False)` downgrade applied by the framework, while keeping the privilege elevation strictly at the API boundary — the report model itself is untouched and continues to enforce ACLs when invoked from anywhere else (backend menu, scheduled actions, etc.).

The same pattern is already used in `pms_api_rest` for invoice PDF rendering and template-based emails.

## Scope

- Only the XLSX endpoint had this bug. The QWeb PDF endpoints (`/invoices/{id}/report`, `/invoices/report`) work because `report_xlsx`'s downgrade does not apply to QWeb rendering, where `.sudo()` propagates as expected.
- The folio reports (`pms_folio_report`) sudo the recordset inside the report model itself, so they were not affected.

## Test plan

- [ ] Authenticate against `/pmsApi/login` as a PMS user without `account.group_account_invoice`.
- [ ] `POST /pmsApi/invoices/accounting-report?pmsPropertyId=<id>&format=xlsx` → expect `200 OK` with a populated XLSX (Invoices / Payments / Summary sheets) instead of `403`.
- [ ] `POST /pmsApi/invoices/accounting-report?ids=...&format=xlsx` with a subset of invoice ids → expect `200 OK` and the corresponding rows.
- [ ] Sanity check the existing PDF endpoints still respond `200` and that the regular Odoo backend menu for the XLSX export keeps requiring accounting ACLs (no regression in the report model).