### PR TITLE
[FIX] pms_api_rest + pms_autoinvoice: autoinvoice date, journal selection and future-line safety net

### DIFF
--- a/pms_api_rest/__manifest__.py
+++ b/pms_api_rest/__manifest__.py
@@ -17,6 +17,7 @@
         "sql_export_excel",
         "feed_rss",
         "pms_partner_type_residence",
+        "pms_autoinvoice",
     ],
     "external_dependencies": {
         "python": ["simplejson", "marshmallow", "jose"],

--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -1593,13 +1593,40 @@ class PmsFolioService(Component):
                         self.env["ir.config_parameter"].sudo().get_param("web.base.url")
                         + move_url
                     )
-                    invoice_date = (
-                        move.invoice_date.strftime("%d/%m/%Y")
-                        if move.invoice_date
-                        else move.invoice_date_due.strftime("%d/%m/%Y")
-                        if move.invoice_date_due
-                        else None
-                    )
+                    # TEMP: for draft invoices, surface the autoinvoice_date
+                    # computed by pms_autoinvoice for the folio sale lines
+                    # bound to this move (or today() if all of them resolve
+                    # to manual policy and have no date), so the front-end
+                    # can preview when the move will be auto-validated and
+                    # stop interpreting a null `date` as a hard block on the
+                    # manual invoice-validation flow. Posted moves keep
+                    # returning their real invoice_date with the
+                    # invoice_date_due fallback. Drop this branch once a
+                    # dedicated field (e.g. an explicit can-validate flag or
+                    # a display-only invoice-date field) is exposed to the
+                    # front-end.
+                    if move.state == "draft":
+                        autoinvoice_dates = [
+                            d
+                            for d in move.invoice_line_ids.mapped(
+                                "folio_line_ids.autoinvoice_date"
+                            )
+                            if d
+                        ]
+                        display_date = (
+                            max(autoinvoice_dates)
+                            if autoinvoice_dates
+                            else fields.Date.today()
+                        )
+                        invoice_date = display_date.strftime("%d/%m/%Y")
+                    else:
+                        invoice_date = (
+                            move.invoice_date.strftime("%d/%m/%Y")
+                            if move.invoice_date
+                            else move.invoice_date_due.strftime("%d/%m/%Y")
+                            if move.invoice_date_due
+                            else None
+                        )
                     invoices.append(
                         PmsFolioInvoiceInfo(
                             id=move.id if move.id else None,

--- a/pms_api_rest/services/pms_invoice_service.py
+++ b/pms_api_rest/services/pms_invoice_service.py
@@ -135,15 +135,44 @@ class PmsInvoiceService(Component):
                         isDownPayment=move_line.move_id._is_downpayment(),
                     )
                 )
-            invoice_date = (
-                datetime.combine(invoice.invoice_date, datetime.min.time()).isoformat()
-                if invoice.invoice_date
-                else datetime.combine(
-                    invoice.invoice_date_due, datetime.min.time()
+            # TEMP: for draft invoices, surface the autoinvoice_date computed
+            # by pms_autoinvoice for the folio sale lines bound to this move
+            # (or today() if all of them resolve to manual policy and have no
+            # date), so the front-end can preview when the move will be
+            # auto-validated and stop interpreting a null `date` as a hard
+            # block on the manual invoice-validation flow. Posted moves keep
+            # returning their real invoice_date with the invoice_date_due
+            # fallback. Drop this branch once a dedicated field (e.g. an
+            # explicit can-validate flag or a display-only invoice-date
+            # field) is exposed to the front-end.
+            if invoice.state == "draft":
+                autoinvoice_dates = [
+                    d
+                    for d in invoice.invoice_line_ids.mapped(
+                        "folio_line_ids.autoinvoice_date"
+                    )
+                    if d
+                ]
+                display_date = (
+                    max(autoinvoice_dates)
+                    if autoinvoice_dates
+                    else fields.Date.today()
+                )
+                invoice_date = datetime.combine(
+                    display_date, datetime.min.time()
                 ).isoformat()
-                if invoice.invoice_date_due
-                else None
-            )
+            else:
+                invoice_date = (
+                    datetime.combine(
+                        invoice.invoice_date, datetime.min.time()
+                    ).isoformat()
+                    if invoice.invoice_date
+                    else datetime.combine(
+                        invoice.invoice_date_due, datetime.min.time()
+                    ).isoformat()
+                    if invoice.invoice_date_due
+                    else None
+                )
             invoice_url = (
                 invoice.get_proforma_portal_url()
                 if invoice.state == "draft"

--- a/pms_api_rest/services/pms_partner_service.py
+++ b/pms_api_rest/services/pms_partner_service.py
@@ -541,13 +541,39 @@ class PmsPartnerService(Component):
                     self.env["ir.config_parameter"].sudo().get_param("web.base.url")
                     + move_url
                 )
-                invoice_date = (
-                    move.invoice_date.strftime("%d/%m/%Y")
-                    if move.invoice_date
-                    else move.invoice_date_due.strftime("%d/%m/%Y")
-                    if move.invoice_date_due
-                    else None
-                )
+                # TEMP: for draft invoices, surface the autoinvoice_date
+                # computed by pms_autoinvoice for the folio sale lines bound
+                # to this move (or today() if all of them resolve to manual
+                # policy and have no date), so the front-end can preview
+                # when the move will be auto-validated and stop interpreting
+                # a null `date` as a hard block on the manual invoice-
+                # validation flow. Posted moves keep returning their real
+                # invoice_date with the invoice_date_due fallback. Drop this
+                # branch once a dedicated field (e.g. an explicit can-
+                # validate flag or a display-only invoice-date field) is
+                # exposed to the front-end.
+                if move.state == "draft":
+                    autoinvoice_dates = [
+                        d
+                        for d in move.invoice_line_ids.mapped(
+                            "folio_line_ids.autoinvoice_date"
+                        )
+                        if d
+                    ]
+                    display_date = (
+                        max(autoinvoice_dates)
+                        if autoinvoice_dates
+                        else date.today()
+                    )
+                    invoice_date = display_date.strftime("%d/%m/%Y")
+                else:
+                    invoice_date = (
+                        move.invoice_date.strftime("%d/%m/%Y")
+                        if move.invoice_date
+                        else move.invoice_date_due.strftime("%d/%m/%Y")
+                        if move.invoice_date_due
+                        else None
+                    )
                 invoices.append(
                     PmsFolioInvoiceInfo(
                         id=move.id if move.id else None,

--- a/pms_autoinvoice/models/pms_property.py
+++ b/pms_autoinvoice/models/pms_property.py
@@ -29,8 +29,11 @@ class PmsProperty(models.Model):
     def _get_folio_default_journal(self, partner_invoice_id, room_ids=False):
         self.ensure_one()
         partner = self.env["res.partner"].browse(partner_invoice_id)
-        if not not partner._check_enought_invoice_data() and self._context.get(
-            "autoinvoice"
+        # Partners without enough invoicing data fall back to the simplified
+        # journal during autoinvoicing. Partners with a complete fiscal
+        # profile keep the normal flow and are billed as nominal invoices.
+        if self._context.get("autoinvoice") and not (
+            partner._check_enought_invoice_data()
         ):
             return self._get_journal(is_simplified_invoice=True, room_ids=room_ids)
         return super()._get_folio_default_journal(partner_invoice_id, room_ids=room_ids)

--- a/pms_autoinvoice/models/pms_property.py
+++ b/pms_autoinvoice/models/pms_property.py
@@ -210,6 +210,34 @@ class PmsProperty(models.Model):
                     grouped=True,
                     final=False,
                 )
+                # Safety net: abort if a folio sale line with a future
+                # autoinvoice_date leaked into the draft. The autoinvoice
+                # filter is meant to exclude these, but recomputations
+                # triggered during _create_invoices have been observed
+                # to let some through; rolling back protects against
+                # early invoicing of reservations still in the future.
+                today = fields.Date.today()
+                for invoice in invoices:
+                    leaked = invoice.invoice_line_ids.folio_line_ids.filtered(
+                        lambda fl, t=today: fl.autoinvoice_date
+                        and fl.autoinvoice_date > t
+                    )
+                    if leaked:
+                        folio.sudo().message_post(
+                            body=_(
+                                "Autoinvoice aborted: folio sale lines "
+                                "with a future autoinvoice_date leaked "
+                                "into the draft invoice (%s)."
+                            )
+                            % ", ".join(leaked.mapped("name"))
+                        )
+                        raise ValidationError(
+                            _(
+                                "Future folio sale lines leaked into "
+                                "automatic invoice for folio %s"
+                            )
+                            % folio.name
+                        )
                 downpayments = folio.sale_line_ids.filtered(
                     lambda r: r.is_downpayment and r.qty_invoiced > 0
                 )


### PR DESCRIPTION
## Context

This PR bundles three related fixes around the autoinvoice flow. The PR was originally scoped to the `pms_api_rest` serializer change; the two `pms_autoinvoice` commits were added on top while investigating an incident where partners with full fiscal data were being booked into the simplified journal and future-checkout reservations were leaking into autoinvoices.

## 1. `pms_api_rest`: surface `autoinvoice_date` on draft invoice serialization

The invoice-info serializer used by the legacy `pms_api_rest` endpoints returns `date` from `move.invoice_date or move.invoice_date_due`, with a null fallback otherwise. The front-end interprets a null `date` as a **block on the manual invoice-validation flow**.

Draft invoices created for folios with `invoicing_policy='manual'` (directly on the partner or inherited from the property) typically land here with neither `invoice_date` nor `invoice_date_due` populated, silently blocking the validation flow.

This commit supersedes the partial fix `ecdff516` (removed from `HOTFIX-16-pms_api_rest`), which surfaced `autoinvoice_date` only for `checkout` / `month_day` policies and still left `manual` returning null.

For draft invoices, surface the `autoinvoice_date` already computed by `pms_autoinvoice` on the folio sale lines bound to the move:

- **`checkout` / `month_day` policy** → return the max `autoinvoice_date` of the bound sale lines (same date the autoinvoicing cron uses to post the move).
- **`manual` policy** (no folio sale line has a date) → return `today()` so the front-end can offer immediate manual validation.

Posted moves keep returning their real `invoice_date` with the `invoice_date_due` fallback. Nothing is persisted on the `account.move` record: the existing PATCH endpoint already converts the incoming `date` to `invoice_date` only when the user confirms validation.

Applied to the three serializer paths that expose invoices to the front-end: `pms_invoice_service`, `pms_folio_service` and `pms_partner_service`.

`pms_autoinvoice` is added as a dependency of `pms_api_rest` to reflect the implicit coupling.

### Why not at model level

An earlier attempt set `folio_sale_line.autoinvoice_date = today()` for `manual` policy on the model itself. Side-effect: lines without `default_invoice_to` (e.g. extra services) that fell back to the property's `default_invoicing_policy='manual'` also got `autoinvoice_date=today()` and were silently included by the `autoinvoicing()` cron, blowing past the `max_amount_simplified_invoice` limit and breaking two existing `pms_autoinvoice` tests. Moving the workaround to the API serializer keeps the cron untouched.

## 2. `pms_autoinvoice`: route partners with full fiscal data to the normal journal

The autoinvoice journal selector was guarded by a double-negated condition (`not not partner._check_enought_invoice_data()`) that inverted the intended logic, sending every partner with a complete fiscal profile (VAT, address, etc.) to the simplified journal. As a consequence, nominal invoices below the simplified-amount ceiling were silently being booked into the simplified journal during autoinvoicing, while partners without enough data fell back to the standard `super()` selection and ended up in nominal journals.

The condition is flipped so the simplified journal is only chosen as a fallback for partners that do not have enough invoicing data, and the standard selection handles the rest as nominal invoices.

## 3. `pms_autoinvoice`: abort autoinvoice when future folio lines leak into the draft

The autoinvoice override of `_get_lines_to_invoice` filters out folio sale lines whose `autoinvoice_date` is still in the future, so they should never reach `_create_invoices`. In practice, recomputations triggered during `_create_invoices` have been observed to bypass that filter, leaving lines bound to future-checkout reservations attached to the freshly created draft invoice and posted alongside the legitimate ones.

After creating the invoices, walk their `folio_line_ids` looking for any line with `autoinvoice_date > today`. If any are found, log the offending line names on the folio chatter and raise so the surrounding savepoint rolls back, preventing the early invoice from being persisted. This is a defensive guard while the root cause of the recomputation race is being addressed.

## Follow-up

- Expose a dedicated field to the front-end (an explicit `canValidate` flag or a display-only invoice-date field) instead of overloading the null state of `date`. The legacy `pms_api_rest` path is being replaced by `pms_fastapi`, where the new schema can model this explicitly.
- Investigate the recomputation race that lets future-dated folio sale lines reach the autoinvoice draft and replace the defensive guard with a proper fix.
- Refactor the autoinvoice cron towards per-reservation invoicing at checkout with advanced configurations, removing the need for the safety net altogether.

## Test plan

- [ ] Open a folio with `invoicing_policy='manual'` and a draft invoice from the front-end — validation button no longer blocked.
- [ ] Open a folio with `invoicing_policy='checkout'` and a draft invoice — `date` matches the autoinvoicing cron's planned post date.
- [ ] Trigger the autoinvoicing cron on a folio whose partner has full fiscal data (VAT + address) and total below the simplified ceiling — invoice ends up in the **normal** journal, not the simplified one.
- [ ] Trigger the autoinvoicing cron on a folio with one already-checked-out reservation and a future reservation — only the past line is invoiced; if the future line leaks in, the cron rolls back and posts a chatter message on the folio.
- [ ] CI `pms_autoinvoice` tests pass.
