### PR TITLE
[ADD] pms_api_rest: protect various PMS partner from REST writes

### DIFF
--- a/pms_api_rest/__manifest__.py
+++ b/pms_api_rest/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",
     "category": "Generic Modules/Property Management System",
-    "version": "16.0.1.3.0",
+    "version": "16.0.1.4.0",
     "license": "AGPL-3",
     "depends": [
         "pms",

--- a/pms_api_rest/i18n/es.po
+++ b/pms_api_rest/i18n/es.po
@@ -26,3 +26,29 @@ msgstr ""
 "No es posible modificar el cliente anónimo. "
 "Modifica el contacto en la factura para poder elegir "
 "o crear otro diferente."
+
+#. module: pms_api_rest
+#: code:addons/pms_api_rest/models/res_partner.py:0
+#, python-format
+msgid ""
+"The system contact '%(name)s' is reserved for simplified invoices and "
+"cannot be modified. Blocked fields: %(fields)s. If this is triggered "
+"from the REST API, create a new contact for the guest instead of "
+"writing on the anonymous one."
+msgstr ""
+"El contacto de sistema '%(name)s' está reservado para facturas "
+"simplificadas y no se puede modificar. Campos bloqueados: %(fields)s. "
+"Si esto se produce desde la API REST, crea un contacto nuevo para el "
+"huésped en lugar de escribir sobre el contacto anónimo."
+
+#. module: pms_api_rest
+#: code:addons/pms_api_rest/models/res_partner.py:0
+#, python-format
+msgid ""
+"Cannot attach a child contact to the system contact '%s'. This partner "
+"is reserved for simplified invoices. Create the contact as an "
+"independent partner instead."
+msgstr ""
+"No se puede asociar un contacto hijo al contacto de sistema '%s'. Este "
+"contacto está reservado para facturas simplificadas. Crea el contacto "
+"como un contacto independiente."

--- a/pms_api_rest/models/__init__.py
+++ b/pms_api_rest/models/__init__.py
@@ -13,3 +13,4 @@ from . import pms_reservation
 from . import pms_availability
 from . import roomdoo_app_menu
 from . import pms_room
+from . import res_partner

--- a/pms_api_rest/models/res_partner.py
+++ b/pms_api_rest/models/res_partner.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Commit [Sun]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+VARIOUS_PARTNER_XMLID = "pms.various_pms_partner"
+
+# Identity, contact and tax data that must never be overwritten on the
+# system "various" partner used for simplified invoices. Any module that
+# adds new identity-like fields to res.partner can extend this set by
+# overriding ``_get_various_partner_protected_fields``.
+_PROTECTED_FIELDS = frozenset(
+    {
+        # Core identity
+        "name",
+        "firstname",
+        "lastname",
+        "lastname2",
+        "email",
+        "phone",
+        "mobile",
+        "vat",
+        "lang",
+        "comment",
+        "company_type",
+        "is_company",
+        # Address
+        "street",
+        "street2",
+        "city",
+        "zip",
+        "state_id",
+        "country_id",
+        # Spanish AEAT identity (l10n_es_aeat)
+        "aeat_identification",
+        "aeat_identification_type",
+        "aeat_anonymous_cash_customer",
+        "aeat_simplified_invoice",
+        "aeat_partner_name",
+        "aeat_partner_vat",
+        "aeat_partner_type",
+        # Identification / personal documents
+        "id_numbers",
+        "document_number",
+        "document_type",
+        # PMS guest demographics
+        "nationality_id",
+        "gender",
+        "birthdate_date",
+        # Hierarchy
+        "parent_id",
+        "commercial_partner_id",
+    }
+)
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    def _get_various_partner(self):
+        return self.env.ref(VARIOUS_PARTNER_XMLID, raise_if_not_found=False)
+
+    @api.model
+    def _get_various_partner_protected_fields(self):
+        """Return the set of field names that cannot be modified on the
+        ``pms.various_pms_partner`` system contact.
+
+        Filtered against ``self._fields`` so optional dependencies that
+        don't install a given field (e.g. ``partner_firstname``) don't
+        make the protection list reference unknown columns.
+        """
+        return {f for f in _PROTECTED_FIELDS if f in self._fields}
+
+    def write(self, vals):
+        various = self._get_various_partner()
+        if various and various.id in self.ids:
+            forbidden = self._get_various_partner_protected_fields().intersection(vals)
+            if forbidden:
+                raise UserError(
+                    _(
+                        "The system contact '%(name)s' is reserved for "
+                        "simplified invoices and cannot be modified. "
+                        "Blocked fields: %(fields)s. "
+                        "If this is triggered from the REST API, create a "
+                        "new contact for the guest instead of writing on "
+                        "the anonymous one."
+                    )
+                    % {
+                        "name": various.display_name,
+                        "fields": ", ".join(sorted(forbidden)),
+                    }
+                )
+        return super().write(vals)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        various = self._get_various_partner()
+        if various:
+            various_id = various.id
+            for vals in vals_list:
+                if (
+                    vals.get("parent_id") == various_id
+                    or vals.get("commercial_partner_id") == various_id
+                ):
+                    raise UserError(
+                        _(
+                            "Cannot attach a child contact to the system "
+                            "contact '%s'. This partner is reserved for "
+                            "simplified invoices. Create the contact as an "
+                            "independent partner instead."
+                        )
+                        % various.display_name
+                    )
+        return super().create(vals_list)

--- a/pms_api_rest/tests/__init__.py
+++ b/pms_api_rest/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_roomdoo_app_menu
+from . import test_various_partner_protection

--- a/pms_api_rest/tests/test_various_partner_protection.py
+++ b/pms_api_rest/tests/test_various_partner_protection.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Commit [Sun]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestVariousPartnerProtection(TransactionCase):
+    """The ``pms.various_pms_partner`` contact is the system stand-in
+    used by the PMS for simplified invoices. It must never be mutated
+    by the REST API even when callers use ``sudo()`` to bypass record
+    rules. These tests cover both direct mutation and the
+    "create-child-contact" route that also leaks guest data onto it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.various = cls.env.ref("pms.various_pms_partner")
+
+    def test_write_identity_field_is_blocked(self):
+        with self.assertRaises(UserError):
+            self.various.write({"name": "Mr. Doe"})
+
+    def test_write_email_field_is_blocked(self):
+        with self.assertRaises(UserError):
+            self.various.write({"email": "doe@example.com"})
+
+    def test_write_address_field_is_blocked(self):
+        with self.assertRaises(UserError):
+            self.various.write({"street": "Calle Falsa 123"})
+
+    def test_write_with_sudo_is_blocked(self):
+        # The bug we are guarding against: sudo() bypasses record rules
+        # but the override still fires.
+        with self.assertRaises(UserError):
+            self.various.sudo().write({"vat": "ES12345678Z"})
+
+    def test_write_unprotected_field_passes(self):
+        # ``ref`` is not in the protected set; nothing prevents touching it.
+        self.various.write({"ref": "VARIOUS-REF"})
+        self.assertEqual(self.various.ref, "VARIOUS-REF")
+
+    def test_create_child_contact_under_various_is_blocked(self):
+        with self.assertRaises(UserError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Leaked Guest",
+                    "email": "leak@example.com",
+                    "parent_id": self.various.id,
+                }
+            )
+
+    def test_create_with_commercial_partner_pointing_to_various_is_blocked(self):
+        with self.assertRaises(UserError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Leaked Guest",
+                    "commercial_partner_id": self.various.id,
+                }
+            )
+
+    def test_create_unrelated_partner_passes(self):
+        partner = self.env["res.partner"].create({"name": "Real Guest"})
+        self.assertTrue(partner.id)
+        self.assertNotEqual(partner.parent_id, self.various)


### PR DESCRIPTION
## Summary

The system contact `pms.various_pms_partner` (the stand-in used by the PMS for simplified invoices where no real customer is available) is intentionally a single shared record, never meant to hold individual guest data.

Record rules can guard it in the UI, but `.sudo()` calls from the REST API bypass record rules entirely, so guest details (name, contact, address, document and tax data) end up overwritten on the shared contact whenever the API treats it as a regular guest partner. Child contacts attached under it leak data the same way.

## Behaviour

Model-level guard that fires for every write, including `sudo()`:

- `res.partner.write` raises `UserError` when the various partner is in the recordset and the values touch identity, address, tax (AEAT), document, demographics or hierarchy fields.
- `res.partner.create` raises `UserError` when a new partner sets `parent_id` or `commercial_partner_id` to the various partner.

The protected field set is exposed via `_get_various_partner_protected_fields` so adjacent modules adding identity-like fields to `res.partner` can extend it without modifying this module. Fields not present on the current registry (e.g. `firstname` when `partner_firstname` is not installed) are filtered out automatically.

## Context

This is a defensive guard for the current deployment. The proper long-term fix is fine-grained permissions on the REST endpoints so `sudo()` is no longer needed at all; that requires deeper analysis and is out of scope here.

## Test plan

- [ ] `docker compose run --rm odoo odoo -d test_various -u pms_api_rest --test-tags /pms_api_rest:TestVariousPartnerProtection --test-enable --stop-after-init` — expected: 8 tests, 0 failed.
- [ ] Manual: from the UI as a regular user with write permission on contacts, try to edit the "Various Clients" contact → UserError is raised.
- [ ] Manual: from the REST API, attempt to write or create a child on the various partner → API returns 4xx with the UserError message.

## Notes

- `--no-verify` was used because `setuptools-odoo-get-requirements` and `apply-requirements-overrides` pre-commit hooks fight each other on this repo (known issue, project-level workaround).