### PR TITLE
[FIX] pms_api_rest, connector_pms_wubook: bill board service via pricelist, not raw amount

### DIFF
--- a/connector_pms_wubook/models/pms_reservation_line/mapper_import.py
+++ b/connector_pms_wubook/models/pms_reservation_line/mapper_import.py
@@ -55,23 +55,17 @@ class ChannelWubookPmsReservationLineMapperImport(Component):
             board_service_room = get_board_service_room_type(
                 self, room_type, record["board"], pricelist_id
             )
-            # occupancy is the adults in the reservation
-            board_day_price_adults = (
-                sum(
-                    board_service_room.board_service_line_ids.with_context(
-                        property=self.backend_record.pms_property_id.id
-                    )
-                    .filtered(lambda line: line.adults)
-                    .mapped("amount")
-                )
-                * record["occupancy"]
+            board_day_price = board_service_room._get_billed_day_price(
+                pricelist=self.env["product.pricelist"].browse(pricelist_id),
+                consumption_date=record["day"],
+                pms_property_id=self.backend_record.pms_property_id.id,
+                adults=record["occupancy"],
+                children=record.get("children") or 0,
+                partner_id=agency.id if agency else False,
+                fiscal_position=agency.property_account_position_id
+                if agency
+                else False,
+                company=self.backend_record.pms_property_id.company_id,
             )
-            board_day_price_children = sum(
-                board_service_room.board_service_line_ids.with_context(
-                    property=self.backend_record.pms_property_id.id
-                )
-                .filtered(lambda line: line.children)
-                .mapped("amount")
-            ) * (record.get("children") or 0)
-            price -= board_day_price_adults + board_day_price_children
+            price -= board_day_price
         return {"price": price}

--- a/pms_api_rest/models/__init__.py
+++ b/pms_api_rest/models/__init__.py
@@ -7,6 +7,7 @@ from . import account_bank_statement
 from . import product_template
 from . import ota_property_settings
 from . import pms_api_log
+from . import pms_board_service_room_type
 from . import pms_folio
 from . import pms_checkin_partner
 from . import pms_reservation

--- a/pms_api_rest/models/pms_board_service_room_type.py
+++ b/pms_api_rest/models/pms_board_service_room_type.py
@@ -1,0 +1,68 @@
+from odoo import models
+
+
+class PmsBoardServiceRoomType(models.Model):
+    _inherit = "pms.board.service.room.type"
+
+    def _get_billed_day_price(
+        self,
+        pricelist,
+        consumption_date,
+        pms_property_id,
+        adults=0,
+        children=0,
+        partner_id=False,
+        fiscal_position=False,
+        company=None,
+    ):
+        """Total amount that the system will bill for this board service
+        on a given consumption date with the given (adults, children) mix.
+
+        Mirrors ``pms.service.line._get_price_unit_line``: pricelist with
+        ``board_service_line_id`` + ``consumption_date`` context, then
+        ``_fix_tax_included_price_company`` with the fiscal-position-mapped
+        taxes. External-API callers can use this to split a package price
+        (room + board) into the room portion without diverging from the
+        price the auto-computed service line will ultimately persist.
+        """
+        self.ensure_one()
+        company = company or self.env.user.company_id
+        account_tax = self.env["account.tax"]
+        total = 0.0
+        for bsl in self.board_service_line_ids.with_context(
+            property=pms_property_id,
+        ):
+            if bsl.adults and adults:
+                qty = adults
+            elif bsl.children and children:
+                qty = children
+            else:
+                continue
+            raw_price = pricelist._get_product_price(
+                product=bsl.product_id.with_context(
+                    board_service_line_id=bsl.id,
+                    property=pms_property_id,
+                    consumption_date=consumption_date,
+                ),
+                quantity=qty,
+                partner=partner_id,
+                consumption_date=consumption_date,
+                pms_property_id=pms_property_id,
+                board_service_line_id=bsl.id,
+            )
+            product_taxes = bsl.product_id.taxes_id.filtered(
+                lambda r, c=company: not r.company_id or r.company_id == c,
+            )
+            line_taxes = (
+                fiscal_position.map_tax(product_taxes)
+                if fiscal_position
+                else product_taxes
+            )
+            unit_price = account_tax._fix_tax_included_price_company(
+                raw_price,
+                bsl.product_id.taxes_id,
+                line_taxes,
+                company,
+            )
+            total += unit_price * qty
+        return total

--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -977,9 +977,13 @@ class PmsFolioService(Component):
                     vals["preferred_room_id"] = reservation.preferredRoomId
                 if reservation.reservationLines:
                     vals_lines = []
-                    board_day_price = 0
-                    # The service price is included in day price
-                    # when it is a board service (external api)
+                    # When a board service is set via external api, the
+                    # incoming reservation price represents the full
+                    # package (room + board). Compute the board portion
+                    # per date with the same pricing logic the auto-
+                    # computed pms.service.line will use, so we can
+                    # subtract it cleanly and leave the room price.
+                    board_day_prices = {}
                     if external_app and vals.get("board_service_room_id"):
                         board = (
                             self.env["pms.board.service.room.type"]
@@ -987,27 +991,18 @@ class PmsFolioService(Component):
                             .browse(vals["board_service_room_id"])
                         )
                         pms_api_check_access(user=self.env.user, records=board)
-                        if reservation.adults:
-                            board_day_price += (
-                                sum(
-                                    board.board_service_line_ids.with_context(
-                                        property=folio.pms_property_id.id
-                                    )
-                                    .filtered(lambda line: line.adults)
-                                    .mapped("amount")
-                                )
-                                * reservation.adults
-                            )
-                        if reservation.children:
-                            board_day_price += (
-                                sum(
-                                    board.board_service_line_ids.with_context(
-                                        property=folio.pms_property_id.id
-                                    )
-                                    .filtered(lambda line: line.children)
-                                    .mapped("amount")
-                                )
-                                * reservation.children
+                        for rline in reservation.reservationLines:
+                            board_day_prices[rline.date] = board._get_billed_day_price(
+                                pricelist=folio.pricelist_id,
+                                consumption_date=rline.date,
+                                pms_property_id=folio.pms_property_id.id,
+                                adults=reservation.adults,
+                                children=reservation.children,
+                                partner_id=folio.partner_id.id
+                                if folio.partner_id
+                                else False,
+                                fiscal_position=folio.fiscal_position_id,
+                                company=folio.company_id,
                             )
                     for reservationLine in reservation.reservationLines:
                         price = reservationLine.price - (
@@ -1019,7 +1014,8 @@ class PmsFolioService(Component):
                                 0,
                                 {
                                     "date": reservationLine.date,
-                                    "price": price - board_day_price,
+                                    "price": price
+                                    - board_day_prices.get(reservationLine.date, 0),
                                     "discount": reservationLine.discount,
                                 },
                             )
@@ -2572,12 +2568,13 @@ class PmsFolioService(Component):
             ):
                 # The service price is included in day price
                 # when it is a board service (external api)
-                board_day_price = 0
+                board_day_prices = {}
                 if external_app:
                     # if proposed reservation and not board_service_room_id in vals,
-                    # get board_day_price from board services of proposed reservation
+                    # get board_day_price from the already-billed board services
+                    # of the proposed reservation (same value for every day).
                     if proposed_reservation and not vals.get("board_service_room_id"):
-                        board_day_price = sum(
+                        avg = sum(
                             proposed_reservation.service_ids.filtered(
                                 lambda s: s.is_board_service
                             ).mapped("price_total")
@@ -2588,6 +2585,8 @@ class PmsFolioService(Component):
                             ).days
                             or 1
                         )
+                        for rline in info_reservation.reservationLines:
+                            board_day_prices[rline.date] = avg
                     else:
                         board = (
                             self.env["pms.board.service.room.type"]
@@ -2602,31 +2601,29 @@ class PmsFolioService(Component):
                             )
                         )
                         pms_api_check_access(user=self.env.user, records=board)
-                        if info_reservation.adults:
-                            board_day_price += (
-                                sum(
-                                    board.board_service_line_ids.with_context(
-                                        property=folio.pms_property_id.id
-                                    )
-                                    .filtered(lambda line: line.adults)
-                                    .mapped("amount")
-                                )
-                                * info_reservation.adults
-                            )
-                        if info_reservation.children:
-                            board_day_price += (
-                                sum(
-                                    board.board_service_line_ids.with_context(
-                                        property=folio.pms_property_id.id
-                                    )
-                                    .filtered(lambda line: line.children)
-                                    .mapped("amount")
-                                )
-                                * info_reservation.children
+                        pricelist = (
+                            self.env["product.pricelist"]
+                            .sudo()
+                            .browse(info_reservation.pricelistId)
+                            if info_reservation.pricelistId
+                            else folio.pricelist_id
+                        )
+                        for rline in info_reservation.reservationLines:
+                            board_day_prices[rline.date] = board._get_billed_day_price(
+                                pricelist=pricelist,
+                                consumption_date=rline.date,
+                                pms_property_id=folio.pms_property_id.id,
+                                adults=info_reservation.adults,
+                                children=info_reservation.children,
+                                partner_id=folio.partner_id.id
+                                if folio.partner_id
+                                else False,
+                                fiscal_position=folio.fiscal_position_id,
+                                company=folio.company_id,
                             )
                 reservation_lines_cmds = self.wrapper_reservation_lines(
                     reservation=info_reservation,
-                    board_day_price=board_day_price,
+                    board_day_prices=board_day_prices,
                     proposed_reservation=proposed_reservation,
                     commission_percent_to_deduct=commision_percent_to_deduct,
                 )
@@ -2652,12 +2649,14 @@ class PmsFolioService(Component):
     def wrapper_reservation_lines(
         self,
         reservation,
-        board_day_price=0,
+        board_day_prices=None,
         proposed_reservation=False,
         commission_percent_to_deduct=0,
     ):
+        board_day_prices = board_day_prices or {}
         cmds = []
         for line in reservation.reservationLines:
+            board_day_price = board_day_prices.get(line.date, 0)
             if proposed_reservation:
                 # Not is necesay check new dates, becouse a if the dates change,
                 # the reservation is new

--- a/pms_api_rest/tests/__init__.py
+++ b/pms_api_rest/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_pms_board_service_room_type
 from . import test_roomdoo_app_menu
 from . import test_various_partner_protection

--- a/pms_api_rest/tests/test_pms_board_service_room_type.py
+++ b/pms_api_rest/tests/test_pms_board_service_room_type.py
@@ -1,0 +1,123 @@
+from datetime import date, timedelta
+
+from odoo.addons.pms.tests.common import TestPms
+
+
+class TestBilledDayPrice(TestPms):
+    """Unit tests for pms.board.service.room.type._get_billed_day_price.
+
+    The helper must mirror the pricing path of
+    ``pms.service.line._get_price_unit_line`` so external-API callers
+    (POST /folios from OTAs, Wubook connector) can split a package
+    price (room + board) into the room portion without diverging from
+    the price the auto-computed service line will ultimately persist.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.room_type_class1.pms_property_ids = [(6, 0, [cls.pms_property1.id])]
+        cls.room_type1 = cls.env["pms.room.type"].create(
+            {
+                "name": "Room Type 1",
+                "default_code": "RT1",
+                "class_id": cls.room_type_class1.id,
+                "pms_property_ids": [(6, 0, [cls.pms_property1.id])],
+                "list_price": 50.0,
+            }
+        )
+        cls.breakfast = cls.env["product.product"].create(
+            {
+                "name": "Breakfast",
+                "list_price": 8.0,
+                "per_person": True,
+            }
+        )
+        cls.board = cls.env["pms.board.service"].create(
+            {
+                "name": "Board BB",
+                "default_code": "BB",
+                "pms_property_ids": [(6, 0, [cls.pms_property1.id])],
+                "board_service_line_ids": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": cls.breakfast.id,
+                            "amount": 8.0,
+                            "adults": True,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.bsrt = cls.env["pms.board.service.room.type"].create(
+            {
+                "pms_board_service_id": cls.board.id,
+                "pms_room_type_id": cls.room_type1.id,
+                "pms_property_id": cls.pms_property1.id,
+                "board_service_line_ids": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": cls.breakfast.id,
+                            "amount": 5.5,
+                            "adults": True,
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def test_no_adults_no_children_returns_zero(self):
+        self.assertEqual(
+            self.bsrt._get_billed_day_price(
+                pricelist=self.pricelist1,
+                consumption_date=date.today() + timedelta(days=10),
+                pms_property_id=self.pms_property1.id,
+                adults=0,
+                children=0,
+            ),
+            0.0,
+        )
+
+    def test_adults_uses_bsrt_line_amount(self):
+        """Without fiscal position remapping, the helper routes through
+        the pricelist path and returns ``bsrt_line.amount × adults``.
+        The previous buggy code computed this directly from ``amount``
+        without going through the pricelist, missing property- and
+        pricelist-specific overrides — this test pins the new behavior
+        so future regressions surface immediately."""
+        self.assertEqual(
+            self.bsrt._get_billed_day_price(
+                pricelist=self.pricelist1,
+                consumption_date=date.today() + timedelta(days=10),
+                pms_property_id=self.pms_property1.id,
+                adults=2,
+                children=0,
+            ),
+            11.0,
+        )
+
+    def test_skips_children_line_when_children_zero(self):
+        """A children-only line must not contribute when ``children=0``,
+        even if the line ``amount`` is non-zero."""
+        self.env["pms.board.service.room.type.line"].create(
+            {
+                "pms_board_service_room_type_id": self.bsrt.id,
+                "product_id": self.breakfast.id,
+                "amount": 4.0,
+                "children": True,
+            }
+        )
+        self.assertEqual(
+            self.bsrt._get_billed_day_price(
+                pricelist=self.pricelist1,
+                consumption_date=date.today() + timedelta(days=10),
+                pms_property_id=self.pms_property1.id,
+                adults=2,
+                children=0,
+            ),
+            11.0,
+        )


### PR DESCRIPTION
## Summary

When an external channel (OTA via `/folios` POST, Wubook connector) sends a reservation with a **package price** (room + board) plus a `boardServiceId`, the room price is computed by subtracting the per-adult/children board service amount from the package. The previous code subtracted `pms.board.service.room.type.line.amount × (adults|children)` directly, but the auto-computed `pms.service.line` bills the board service through the pricelist + fiscal-position tax path. When these two computations disagree (different pricelist override, intracommunity fiscal position mapping a price-include tax to a non-include one, etc), the reservation line ends up under-priced by the gap and the folio total falls below what the channel actually sent.

The fix routes the API-side computation through the same pricing path the service line will use, so the split is always consistent.

## Changes

- New helper `pms.board.service.room.type._get_billed_day_price(...)` in `pms_api_rest/models/pms_board_service_room_type.py`. Mirrors `pms.service.line._get_price_unit_line`: pricelist `_get_product_price` with `board_service_line_id` + `consumption_date` context, then `_fix_tax_included_price_company` against the fiscal-position-mapped taxes.
- `pms_api_rest/services/pms_folio_service.py`: replaces the three buggy callsites that subtracted the raw amount (POST `/folios`, the update-reservations flow, and `wrapper_reservation_lines`). The per-day amount is now computed via the helper and threaded as a dict by date.
- `connector_pms_wubook/models/pms_reservation_line/mapper_import.py`: same swap for the Wubook import mapper.
- Unit tests for the helper: zero composition, adults-only path, and the children-line skip.

## Test plan

- [x] `docker-compose run --rm odoo odoo --test-tags /pms_api_rest -d devel --no-http -u pms_api_rest` — 13 tests, 0 failures
- [x] Manually reproduced the original bug payload against staging (demo-alda): folio total post-fix matches the package price exactly.
- [x] Smoke-tested against production (transaction rollback): folio `amount_total = 59.9 €` for the original failing payload, matching what the OTA sent.