### PR TITLE
[connector_pms_wubook] Support WuBook permanent token auth

### DIFF
--- a/connector_pms_wubook/__manifest__.py
+++ b/connector_pms_wubook/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "PMS Connector Wubook",
     "summary": "Channel PMS connector Wubook",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "license": "AGPL-3",
     "development_status": "Alpha",
     "category": "Connector",

--- a/connector_pms_wubook/components/adapter.py
+++ b/connector_pms_wubook/components/adapter.py
@@ -90,6 +90,7 @@ class ChannelWubookAdapter(AbstractComponent):
         self.username = self.backend_record.username
         self.password = self.backend_record.password
         self.apikey = self.backend_record.pkey
+        self.permanent_token = self.backend_record.permanent_token
         self.property_code = self.backend_record.property_code
 
     def _exec(self, funcname, *args, pms_property=True):
@@ -98,11 +99,18 @@ class ChannelWubookAdapter(AbstractComponent):
             cc.add_result(1, "Export disabled")
             return False
         s = xmlrpc.client.Server(self.url)
-        res, token = s.acquire_token(self.username, self.password, self.apikey)
-        if res:
-            raise ChannelAdapterError(
-                _("Error authorizing to endpoint. %(code)s") % {"code": token}
-            )
+        # WuBook deprecated the acquire_token/release_token flow in favour of a
+        # permanent token created in the Wired API section of the account. If the
+        # backend has one configured, use it directly; otherwise fall back to the
+        # legacy temporary token flow.
+        if self.permanent_token:
+            token = self.permanent_token
+        else:
+            res, token = s.acquire_token(self.username, self.password, self.apikey)
+            if res:
+                raise ChannelAdapterError(
+                    _("Error authorizing to endpoint. %(code)s") % {"code": token}
+                )
         if pms_property:
             args = (self.property_code, *args)
         func = getattr(s, funcname)
@@ -179,13 +187,16 @@ class ChannelWubookAdapter(AbstractComponent):
                 )
             return data
         finally:
+            # Permanent tokens must not be released; only temporary tokens
+            # acquired via acquire_token are released here.
             # TODO: reutilize token on multiple calls acoording the limits
             #   https://tdocs.wubook.net/wired/policies.html#token-limits
-            res, info = s.release_token(token)
-            if res:
-                raise ChannelAdapterError(
-                    _("Error releasing token. %(value)s") % {"value": info}
-                )
+            if not self.permanent_token:
+                res, info = s.release_token(token)
+                if res:
+                    raise ChannelAdapterError(
+                        _("Error releasing token. %(value)s") % {"value": info}
+                    )
 
     def _prepare_field_type(self, field_data):
         default_values = {}

--- a/connector_pms_wubook/models/common/backend.py
+++ b/connector_pms_wubook/models/common/backend.py
@@ -36,12 +36,15 @@ class ChannelWubookBackend(models.Model):
     ]
 
     # connection data
-    username = fields.Char(required=True)
-    password = fields.Char(required=True)
+    username = fields.Char()
+    password = fields.Char()
 
     url = fields.Char(default="https://wired.wubook.net/xrws/", required=True)
     property_code = fields.Char(required=True)
-    pkey = fields.Char(required=True)
+    pkey = fields.Char()
+    # Permanent token created in the Wired API section of the WuBook account.
+    # When set, it replaces the legacy username/password/pkey acquire_token flow.
+    permanent_token = fields.Char(string="Permanent Token")
     security_token = fields.Char(required=False)
     pricelist_external_id = fields.Integer(string="Parity Pricelist ID", required=True)
     backend_journal_ota_ids = fields.One2many(

--- a/connector_pms_wubook/tests/__init__.py
+++ b/connector_pms_wubook/tests/__init__.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import test_auth
+
 # from . import server
 # from . import common
 # from . import test_room_type

--- a/connector_pms_wubook/tests/common.py
+++ b/connector_pms_wubook/tests/common.py
@@ -5,12 +5,12 @@
 import json
 import logging
 
-from odoo.addons.component.tests.common import SavepointComponentCase
+from odoo.addons.component.tests.common import TransactionComponentCase
 
 _logger = logging.getLogger(__name__)
 
 
-class TestWubookConnector(SavepointComponentCase):
+class TestWubookConnector(TransactionComponentCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/connector_pms_wubook/tests/test_auth.py
+++ b/connector_pms_wubook/tests/test_auth.py
@@ -1,0 +1,105 @@
+# Copyright 2021 Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+import xmlrpc.client
+from unittest import mock
+
+from . import common, server
+
+_logger = logging.getLogger(__name__)
+
+
+class TestWubookConnectorAuth(common.TestWubookConnector):
+    """Authentication flow of the adapter ``_exec`` method.
+
+    WuBook deprecated the ``acquire_token``/``release_token`` flow in favour of
+    a permanent token. The adapter must use the permanent token directly when
+    configured, and only fall back to the legacy flow otherwise.
+    """
+
+    def _build_backend(self, **overrides):
+        p1 = self.browse_ref("pms.main_pms_property")
+        values = {
+            "name": "Test backend",
+            "pms_property_id": p1.id,
+            "user_id": self.user1(p1).id,
+            "backend_type_id": self.backend_type1.parent_id.id,
+            **self.fake_credentials,
+        }
+        values.update(overrides)
+        return self.env["channel.wubook.backend"].create(values)
+
+    def _get_adapter(self, backend):
+        with backend.work_on("channel.wubook.pms.room.type") as work:
+            return work.component(usage="backend.adapter")
+
+    @mock.patch.object(xmlrpc.client, "Server")
+    def test_exec_uses_permanent_token(self, mock_xmlrpc_client_server):
+        """
+        PRE:    - backend has a permanent token configured
+        ACT:    - an API call is performed (search_read -> fetch_rooms)
+        POST:   - acquire_token is not called
+                - release_token is not called
+                - the permanent token is forwarded as the token argument
+        """
+        # mock object
+        mock_server = server.MockWubookServer()
+        m = mock_server.get_mock()
+        mock_xmlrpc_client_server.return_value = m
+
+        # record the token forwarded to the wired function
+        captured = {}
+        original_fetch_rooms = m.fetch_rooms
+
+        def recording_fetch_rooms(token, lcode, **kwargs):
+            captured["token"] = token
+            return original_fetch_rooms(token, lcode, **kwargs)
+
+        m.fetch_rooms = recording_fetch_rooms
+
+        # ARRANGE
+        backend = self._build_backend(permanent_token="PERMANENT-TOKEN-XYZ")
+        adapter = self._get_adapter(backend)
+
+        # ACT
+        adapter.search_read([])
+
+        # ASSERT
+        with self.subTest():
+            m.acquire_token.assert_not_called()
+        with self.subTest():
+            m.release_token.assert_not_called()
+        with self.subTest():
+            self.assertEqual(
+                captured.get("token"),
+                "PERMANENT-TOKEN-XYZ",
+                "The permanent token should be forwarded to the wired function",
+            )
+
+    @mock.patch.object(xmlrpc.client, "Server")
+    def test_exec_legacy_acquire_token(self, mock_xmlrpc_client_server):
+        """
+        PRE:    - backend has no permanent token (only username/password/pkey)
+        ACT:    - an API call is performed (search_read -> fetch_rooms)
+        POST:   - acquire_token is called once (legacy flow)
+                - release_token is called once (legacy flow)
+        """
+        # mock object
+        mock_server = server.MockWubookServer()
+        m = mock_server.get_mock()
+        mock_xmlrpc_client_server.return_value = m
+
+        # ARRANGE (fake_credentials carry no permanent token)
+        backend = self._build_backend()
+        adapter = self._get_adapter(backend)
+
+        # ACT
+        adapter.search_read([])
+
+        # ASSERT
+        with self.subTest():
+            m.acquire_token.assert_called_once_with(
+                backend.username, backend.password, backend.pkey
+            )
+        with self.subTest():
+            m.release_token.assert_called_once()

--- a/connector_pms_wubook/tests/test_auth.py
+++ b/connector_pms_wubook/tests/test_auth.py
@@ -4,11 +4,16 @@ import logging
 import xmlrpc.client
 from unittest import mock
 
+from odoo.tests import tagged
+
 from . import common, server
 
 _logger = logging.getLogger(__name__)
 
 
+# post_install so the accounting set up by other modules (chart of accounts and
+# its payment method lines) is already in place when the backend is created.
+@tagged("post_install", "-at_install")
 class TestWubookConnectorAuth(common.TestWubookConnector):
     """Authentication flow of the adapter ``_exec`` method.
 
@@ -19,14 +24,19 @@ class TestWubookConnectorAuth(common.TestWubookConnector):
 
     def _build_backend(self, **overrides):
         p1 = self.browse_ref("pms.main_pms_property")
+        payment_method_line = self.env["account.payment.method.line"].search(
+            [("company_id", "=", p1.company_id.id)], limit=1
+        ) or self.env["account.payment.method.line"].search([], limit=1)
         values = {
             "name": "Test backend",
             "pms_property_id": p1.id,
             "user_id": self.user1(p1).id,
             "backend_type_id": self.backend_type1.parent_id.id,
+            "pricelist_external_id": 1,
+            "wubook_payment_method_line_id": payment_method_line.id,
             **self.fake_credentials,
+            **overrides,
         }
-        values.update(overrides)
         return self.env["channel.wubook.backend"].create(values)
 
     def _get_adapter(self, backend):
@@ -42,8 +52,9 @@ class TestWubookConnectorAuth(common.TestWubookConnector):
                 - release_token is not called
                 - the permanent token is forwarded as the token argument
         """
-        # mock object
+        # mock object: the property must exist so fetch_rooms returns a result
         mock_server = server.MockWubookServer()
+        mock_server.data[self.fake_credentials["property_code"]] = {}
         m = mock_server.get_mock()
         mock_xmlrpc_client_server.return_value = m
 
@@ -84,8 +95,9 @@ class TestWubookConnectorAuth(common.TestWubookConnector):
         POST:   - acquire_token is called once (legacy flow)
                 - release_token is called once (legacy flow)
         """
-        # mock object
+        # mock object: the property must exist so fetch_rooms returns a result
         mock_server = server.MockWubookServer()
+        mock_server.data[self.fake_credentials["property_code"]] = {}
         m = mock_server.get_mock()
         mock_xmlrpc_client_server.return_value = m
 

--- a/connector_pms_wubook/views/channel_wubook_backend_views.xml
+++ b/connector_pms_wubook/views/channel_wubook_backend_views.xml
@@ -12,6 +12,7 @@
                     <group>
                         <field name="username" />
                         <field name="password" password="1" />
+                        <field name="permanent_token" password="1" />
                     </group>
                     <group>
                         <field name="url" />


### PR DESCRIPTION
## Context

WuBook is deprecating the Wired API authentication via `acquire_token` (user / password / api key) in favour of the **Permanent Token** created in the Wired API section of the account.

> This function will be deprecated and you should now use the Permanent Token.

The connector called `acquire_token`/`release_token` on **every** request, inside the single entry point `ChannelWubookAdapter._exec`.

## Changes

- **`models/common/backend.py`**: new `permanent_token` field. `username`, `password` and `pkey` are no longer required (the permanent token replaces them).
- **`components/adapter.py`** (`_exec`): when the backend has a `permanent_token`, it is used directly as the `token` argument and `acquire_token`/`release_token` are skipped (a permanent token must not be released). Otherwise the legacy flow is kept as a fallback.
- **`views/channel_wubook_backend_views.xml`**: `permanent_token` field added to the form (hidden).
- **`tests/test_auth.py`**: tests for the auth branch (permanent token → acquire/release not called and the token is forwarded; no token → legacy flow). `test_auth` is enabled in `tests/__init__.py`.

## Approach: backwards-compatible / transition

The legacy flow is kept so backends can be migrated one by one: just paste the permanent token into each `channel.wubook.backend`. Once every backend is migrated, a follow-up PR can drop the legacy code and the `username`/`password`/`pkey` fields.

## Notes for the reviewer / deployment

- The module must be **updated** (`-u connector_pms_wubook`) to create the `permanent_token` column and reload the view.
- Pre-existing lint debt in `adapter.py` (unrelated to this change) is left untouched; the diff is kept scoped to the feature.
