### PR TITLE
[FIX] pms_api_rest: allow decimal agency commission

### DIFF
--- a/pms_api_rest/datamodels/pms_partner.py
+++ b/pms_api_rest/datamodels/pms_partner.py
@@ -60,7 +60,7 @@ class PmsPartnerInfo(Datamodel):
     pricelistId = fields.Integer(required=False, allow_none=True)
     salesReference = fields.String(required=False, allow_none=True)
     saleChannelId = fields.Integer(required=False, allow_none=True)
-    commission = fields.Integer(required=False, allow_none=True)
+    commission = fields.Float(required=False, allow_none=True)
     invoicingPolicy = fields.String(required=False, allow_none=True)
     daysAutoInvoice = fields.Integer(required=False, allow_none=True)
     invoicingMonthDay = fields.Integer(required=False, allow_none=True)


### PR DESCRIPTION
## Problem

The `commission` field of `PmsPartnerInfo` (REST datamodel) was declared as `Integer`, so a partner/agency commission with a fractional part (e.g. an OTA charging **15.5%**) was truncated to its integer part when read from or written through the REST API. The truncated value then propagated to the reservation `commission_percent`/`commission_amount`, producing an incorrect amount to invoice.

## Fix

Change the datamodel `commission` field to `Float`, aligning it with the underlying `res.partner.default_commission` field (which is being changed to `Float` in OCA/pms). Decimals are now preserved end to end.

## Notes

- Companion change in OCA/pms makes `default_commission` a `Float`.
- The FastAPI schema (`pms_fastapi/schemas/contact.py`) was already `float`.