### PR TITLE
[IMP] pms_api_rest: make reservation wizard-state messages translatable

### DIFF
--- a/pms_api_rest/i18n/de.po
+++ b/pms_api_rest/i18n/de.po
@@ -10,201 +10,164 @@ msgstr ""
 "PO-Revision-Date: 2026-03-22 00:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: pms_api_rest
-#: code:addons/pms_api_rest/services/pms_partner_service.py:0
-#, python-format
-msgid ""
-"Cannot modify the anonymous customer. "
-"Edit the contact on the invoice to select "
-"or create a different one."
-msgstr ""
-"No es posible modificar el cliente anónimo. "
-"Modifica el contacto en la factura para poder elegir "
-"o crear otro diferente."
-
-#. module: pms_api_rest
-#: code:addons/pms_api_rest/models/res_partner.py:0
-#, python-format
-msgid ""
-"The system contact '%(name)s' is reserved for simplified invoices and "
-"cannot be modified. Blocked fields: %(fields)s. If this is triggered "
-"from the REST API, create a new contact for the guest instead of "
-"writing on the anonymous one."
-msgstr ""
-"El contacto de sistema '%(name)s' está reservado para facturas "
-"simplificadas y no se puede modificar. Campos bloqueados: %(fields)s. "
-"Si esto se produce desde la API REST, crea un contacto nuevo para el "
-"huésped en lugar de escribir sobre el contacto anónimo."
-
-#. module: pms_api_rest
-#: code:addons/pms_api_rest/models/res_partner.py:0
-#, python-format
-msgid ""
-"Cannot attach a child contact to the system contact '%s'. This partner "
-"is reserved for simplified invoices. Create the contact as an "
-"independent partner instead."
-msgstr ""
-"No se puede asociar un contacto hijo al contacto de sistema '%s'. Este "
-"contacto está reservado para facturas simplificadas. Crea el contacto "
-"como un contacto independiente."
-
-#. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Overbooking"
-msgstr "Overbooking"
+msgstr "Überbuchung"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Split"
-msgstr "Divididas"
+msgstr "Aufgeteilt"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "To assign"
-msgstr "Por asignar"
+msgstr "Zuzuweisen"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "To confirm"
-msgstr "Por confirmar"
+msgstr "Zu bestätigen"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Arrival today"
-msgstr "Entrada hoy"
+msgstr "Anreise heute"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Future confirmed, unpaid and without pre-checkin"
-msgstr "Confirmadas a futuro sin pagar y sin precheckin realizado"
+msgstr "Künftig, bestätigt, unbezahlt und ohne Pre-Check-in"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Future confirmed, unpaid"
-msgstr "Confirmadas a futuro sin pagar"
+msgstr "Künftig, bestätigt, unbezahlt"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Cancelled with charges and unpaid"
-msgstr "Cancelada con cargos y sin cobrar"
+msgstr "Storniert mit Gebühren und unbezahlt"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Pending payment (in-house)"
-msgstr "Por cobrar dentro"
+msgstr "Offene Zahlung (im Haus)"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Pending payment (past stays)"
-msgstr "Por cobrar pasadas"
+msgstr "Offene Zahlung (vergangene Aufenthalte)"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Checkout"
-msgstr "Checkout"
+msgstr "Check-out"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like a reservation came in without availability for %s."
-msgstr "Parece que ha entrado una reserva sin haber disponibilidad para %s."
+msgstr "Es sieht so aus, als sei eine Reservierung ohne Verfügbarkeit für %s eingegangen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like a reservation came in without availability for %s. Unfortunately, there does not seem to be any room available with enough capacity for this reservation."
-msgstr "Parece que ha entrado una reserva sin haber disponibilidad para %s. Por desgracia, no parece que haya ninguna habitación disponible con la capacidad suficiente para esta reserva."
+msgstr "Es sieht so aus, als sei eine Reservierung ohne Verfügbarkeit für %s eingegangen. Leider scheint kein Zimmer mit ausreichender Kapazität für diese Reservierung verfügbar zu sein."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like %s has had to sleep in different rooms, but there is no room available to assign. You can try moving other reservations to give them a single room."
-msgstr "Parece que a %s le ha tocado dormir en habitaciones diferentes, pero no hay ninguna habitación disponible para asignarle. Puedes probar a mover otras reservas para poder establecerle una única habitación."
+msgstr "Es sieht so aus, als hätte %s in verschiedenen Zimmern schlafen müssen, aber es ist kein Zimmer zur Zuweisung verfügbar. Du kannst versuchen, andere Reservierungen zu verschieben, um ein einziges Zimmer bereitzustellen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like %s has had to sleep in different rooms, but you can move them to 1 available room."
-msgstr "Parece que a %s le ha tocado dormir en habitaciones diferentes, pero tienes la posibilidad de moverlo a 1 habitación disponible."
+msgstr "Es sieht so aus, als hätte %s in verschiedenen Zimmern schlafen müssen, aber du kannst sie in 1 verfügbares Zimmer verschieben."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like %(name)s has had to sleep in different rooms, but you can move them to %(count)s available rooms."
-msgstr "Parece que a %(name)s le ha tocado dormir en habitaciones diferentes, pero tienes la posibilidad de moverlo a %(count)s habitaciones disponibles."
+msgstr "Es sieht so aus, als hätte %(name)s in verschiedenen Zimmern schlafen müssen, aber du kannst sie in %(count)s verfügbare Zimmer verschieben."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "1 guest still needs to register their details. You can open the check-in assistant to complete the data."
-msgstr "Falta 1 huésped por registrar sus datos. Puedes abrir el asistente de checkin para completar los datos."
+msgstr "Es fehlt noch 1 Gast, der seine Daten angeben muss. Du kannst den Check-in-Assistenten öffnen, um die Daten zu vervollständigen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%s guests still need to register their details. You can open the check-in assistant to complete the data."
-msgstr "Faltan %s huéspedes por registrar sus datos. Puedes abrir el asistente de checkin para completar los datos."
+msgstr "Es fehlen noch %s Gäste, die ihre Daten angeben müssen. Du kannst den Check-in-Assistenten öffnen, um die Daten zu vervollständigen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%(name)s's reservation has been assigned to room %(room)s. You can confirm the room or change it to another one from here."
-msgstr "La reserva de %(name)s ha sido asignada a la habitación %(room)s. Puedes confirmar la habitación o cambiar a otra desde aquí."
+msgstr "Die Reservierung von %(name)s wurde dem Zimmer %(room)s zugewiesen. Du kannst das Zimmer bestätigen oder hier ein anderes auswählen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%s's reservation is pending confirmation. You can confirm it from here."
-msgstr "La reserva de %s está pendiente de confirmar. Puedes confirmarla desde aquí."
+msgstr "Die Reservierung von %s steht zur Bestätigung aus. Du kannst sie hier bestätigen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "All guests in this reservation have their details registered. You can check them in directly from here."
-msgstr "Todos los huéspedes de esta reserva tienen los datos registrados. Puedes marcar la entrada directamente desde aquí."
+msgstr "Alle Gäste dieser Reservierung haben ihre Daten angegeben. Du kannst sie direkt von hier aus einchecken."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Register the guests' details from the check-in assistant."
-msgstr "Registra los datos de los huéspedes desde el asistente del checkin."
+msgstr "Erfasse die Daten der Gäste über den Check-in-Assistenten."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "This reservation is pending payment and the guests still need to register their details: you can send them a reminder from here."
-msgstr "Esta reserva está pendiente de cobro y de que los huéspedes registren sus datos: puedes enviarles un recordatorio desde aquí."
+msgstr "Diese Reservierung steht zur Zahlung aus und die Gäste müssen noch ihre Daten angeben: Du kannst ihnen von hier aus eine Erinnerung senden."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "This reservation is pending payment. You can send a reminder from here."
-msgstr "Esta reserva está pendiente de cobro. Puedes enviar un recordatorio desde aquí."
+msgstr "Diese Reservierung steht zur Zahlung aus. Du kannst von hier aus eine Erinnerung senden."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "This reservation does not have the guests' details registered. You can send them a reminder from here."
-msgstr "Esta reserva no tiene los datos de los huéspedes registrados. Puedes enviarles un recordatorio desde aquí."
+msgstr "Bei dieser Reservierung sind die Daten der Gäste nicht erfasst. Du kannst ihnen von hier aus eine Erinnerung senden."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%(name)s's reservation has been cancelled with a penalty of %(amount).2f€. You can remove the penalty if it is not going to be charged."
-msgstr "La reserva de %(name)s ha sido cancelada con una penalización de %(amount).2f€. Puedes eliminar la penalización en caso de que no se vaya a cobrar."
+msgstr "Die Reservierung von %(name)s wurde mit einer Stornogebühr von %(amount).2f€ storniert. Du kannst die Gebühr entfernen, falls sie nicht berechnet wird."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "This reservation has a pending payment of %.2f. You can register the payment from here."
-msgstr "En esta reserva tenemos un pago pendiente de %.2f. Puedes registrar el pago desde aquí."
+msgstr "Diese Reservierung hat eine offene Zahlung von %.2f. Du kannst die Zahlung von hier aus erfassen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "This reservation has a pending charge of %.2f€. When you handle the payment you can register it from here."
-msgstr "Esta reserva ha quedado con un cargo pendiente de %.2f€. Cuando gestiones el cobro puedes registrarlo desde aquí."
+msgstr "Diese Reservierung hat eine offene Forderung von %.2f€. Wenn du die Zahlung bearbeitest, kannst du sie von hier aus erfassen."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Reservation ready for checkout. You can check out directly from here."
-msgstr "Reserva lista para el checkout. Marca la salida directamente desde aquí."
+msgstr "Reservierung bereit zum Check-out. Du kannst direkt von hier aus auschecken."

--- a/pms_api_rest/i18n/it.po
+++ b/pms_api_rest/i18n/it.po
@@ -10,48 +10,11 @@ msgstr ""
 "PO-Revision-Date: 2026-03-22 00:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: pms_api_rest
-#: code:addons/pms_api_rest/services/pms_partner_service.py:0
-#, python-format
-msgid ""
-"Cannot modify the anonymous customer. "
-"Edit the contact on the invoice to select "
-"or create a different one."
-msgstr ""
-"No es posible modificar el cliente anónimo. "
-"Modifica el contacto en la factura para poder elegir "
-"o crear otro diferente."
-
-#. module: pms_api_rest
-#: code:addons/pms_api_rest/models/res_partner.py:0
-#, python-format
-msgid ""
-"The system contact '%(name)s' is reserved for simplified invoices and "
-"cannot be modified. Blocked fields: %(fields)s. If this is triggered "
-"from the REST API, create a new contact for the guest instead of "
-"writing on the anonymous one."
-msgstr ""
-"El contacto de sistema '%(name)s' está reservado para facturas "
-"simplificadas y no se puede modificar. Campos bloqueados: %(fields)s. "
-"Si esto se produce desde la API REST, crea un contacto nuevo para el "
-"huésped en lugar de escribir sobre el contacto anónimo."
-
-#. module: pms_api_rest
-#: code:addons/pms_api_rest/models/res_partner.py:0
-#, python-format
-msgid ""
-"Cannot attach a child contact to the system contact '%s'. This partner "
-"is reserved for simplified invoices. Create the contact as an "
-"independent partner instead."
-msgstr ""
-"No se puede asociar un contacto hijo al contacto de sistema '%s'. Este "
-"contacto está reservado para facturas simplificadas. Crea el contacto "
-"como un contacto independiente."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
@@ -61,47 +24,47 @@ msgstr "Overbooking"
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Split"
-msgstr "Divididas"
+msgstr "Divise"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "To assign"
-msgstr "Por asignar"
+msgstr "Da assegnare"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "To confirm"
-msgstr "Por confirmar"
+msgstr "Da confermare"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Arrival today"
-msgstr "Entrada hoy"
+msgstr "Arrivo oggi"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Future confirmed, unpaid and without pre-checkin"
-msgstr "Confirmadas a futuro sin pagar y sin precheckin realizado"
+msgstr "Confermate future, non pagate e senza pre-checkin"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Future confirmed, unpaid"
-msgstr "Confirmadas a futuro sin pagar"
+msgstr "Confermate future, non pagate"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Cancelled with charges and unpaid"
-msgstr "Cancelada con cargos y sin cobrar"
+msgstr "Annullata con addebiti e non pagata"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Pending payment (in-house)"
-msgstr "Por cobrar dentro"
+msgstr "Da incassare (in casa)"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Pending payment (past stays)"
-msgstr "Por cobrar pasadas"
+msgstr "Da incassare (soggiorni passati)"
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
@@ -112,99 +75,99 @@ msgstr "Checkout"
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like a reservation came in without availability for %s."
-msgstr "Parece que ha entrado una reserva sin haber disponibilidad para %s."
+msgstr "Sembra che sia entrata una prenotazione senza disponibilità per %s."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like a reservation came in without availability for %s. Unfortunately, there does not seem to be any room available with enough capacity for this reservation."
-msgstr "Parece que ha entrado una reserva sin haber disponibilidad para %s. Por desgracia, no parece que haya ninguna habitación disponible con la capacidad suficiente para esta reserva."
+msgstr "Sembra che sia entrata una prenotazione senza disponibilità per %s. Purtroppo non sembra esserci nessuna camera disponibile con capacità sufficiente per questa prenotazione."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like %s has had to sleep in different rooms, but there is no room available to assign. You can try moving other reservations to give them a single room."
-msgstr "Parece que a %s le ha tocado dormir en habitaciones diferentes, pero no hay ninguna habitación disponible para asignarle. Puedes probar a mover otras reservas para poder establecerle una única habitación."
+msgstr "Sembra che %s abbia dovuto dormire in camere diverse, ma non c'è nessuna camera disponibile da assegnare. Puoi provare a spostare altre prenotazioni per dargli un'unica camera."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like %s has had to sleep in different rooms, but you can move them to 1 available room."
-msgstr "Parece que a %s le ha tocado dormir en habitaciones diferentes, pero tienes la posibilidad de moverlo a 1 habitación disponible."
+msgstr "Sembra che %s abbia dovuto dormire in camere diverse, ma puoi spostarlo in 1 camera disponibile."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "It looks like %(name)s has had to sleep in different rooms, but you can move them to %(count)s available rooms."
-msgstr "Parece que a %(name)s le ha tocado dormir en habitaciones diferentes, pero tienes la posibilidad de moverlo a %(count)s habitaciones disponibles."
+msgstr "Sembra che %(name)s abbia dovuto dormire in camere diverse, ma puoi spostarlo in %(count)s camere disponibili."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "1 guest still needs to register their details. You can open the check-in assistant to complete the data."
-msgstr "Falta 1 huésped por registrar sus datos. Puedes abrir el asistente de checkin para completar los datos."
+msgstr "Manca ancora 1 ospite che deve registrare i propri dati. Puoi aprire l'assistente di check-in per completare i dati."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%s guests still need to register their details. You can open the check-in assistant to complete the data."
-msgstr "Faltan %s huéspedes por registrar sus datos. Puedes abrir el asistente de checkin para completar los datos."
+msgstr "Mancano ancora %s ospiti che devono registrare i propri dati. Puoi aprire l'assistente di check-in per completare i dati."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%(name)s's reservation has been assigned to room %(room)s. You can confirm the room or change it to another one from here."
-msgstr "La reserva de %(name)s ha sido asignada a la habitación %(room)s. Puedes confirmar la habitación o cambiar a otra desde aquí."
+msgstr "La prenotazione di %(name)s è stata assegnata alla camera %(room)s. Puoi confermare la camera o cambiarla con un'altra da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%s's reservation is pending confirmation. You can confirm it from here."
-msgstr "La reserva de %s está pendiente de confirmar. Puedes confirmarla desde aquí."
+msgstr "La prenotazione di %s è in attesa di conferma. Puoi confermarla da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "All guests in this reservation have their details registered. You can check them in directly from here."
-msgstr "Todos los huéspedes de esta reserva tienen los datos registrados. Puedes marcar la entrada directamente desde aquí."
+msgstr "Tutti gli ospiti di questa prenotazione hanno i dati registrati. Puoi registrarne l'arrivo direttamente da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Register the guests' details from the check-in assistant."
-msgstr "Registra los datos de los huéspedes desde el asistente del checkin."
+msgstr "Registra i dati degli ospiti dall'assistente di check-in."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "This reservation is pending payment and the guests still need to register their details: you can send them a reminder from here."
-msgstr "Esta reserva está pendiente de cobro y de que los huéspedes registren sus datos: puedes enviarles un recordatorio desde aquí."
+msgstr "Questa prenotazione è in attesa di pagamento e gli ospiti devono ancora registrare i propri dati: puoi inviare loro un promemoria da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "This reservation is pending payment. You can send a reminder from here."
-msgstr "Esta reserva está pendiente de cobro. Puedes enviar un recordatorio desde aquí."
+msgstr "Questa prenotazione è in attesa di pagamento. Puoi inviare un promemoria da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "This reservation does not have the guests' details registered. You can send them a reminder from here."
-msgstr "Esta reserva no tiene los datos de los huéspedes registrados. Puedes enviarles un recordatorio desde aquí."
+msgstr "Questa prenotazione non ha i dati degli ospiti registrati. Puoi inviare loro un promemoria da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "%(name)s's reservation has been cancelled with a penalty of %(amount).2f€. You can remove the penalty if it is not going to be charged."
-msgstr "La reserva de %(name)s ha sido cancelada con una penalización de %(amount).2f€. Puedes eliminar la penalización en caso de que no se vaya a cobrar."
+msgstr "La prenotazione di %(name)s è stata annullata con una penale di %(amount).2f€. Puoi rimuovere la penale se non verrà addebitata."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "This reservation has a pending payment of %.2f. You can register the payment from here."
-msgstr "En esta reserva tenemos un pago pendiente de %.2f. Puedes registrar el pago desde aquí."
+msgstr "Questa prenotazione ha un pagamento in sospeso di %.2f. Puoi registrare il pagamento da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 #, python-format
 msgid "This reservation has a pending charge of %.2f€. When you handle the payment you can register it from here."
-msgstr "Esta reserva ha quedado con un cargo pendiente de %.2f€. Cuando gestiones el cobro puedes registrarlo desde aquí."
+msgstr "Questa prenotazione ha un addebito in sospeso di %.2f€. Quando gestisci il pagamento puoi registrarlo da qui."
 
 #. module: pms_api_rest
 #: code:addons/pms_api_rest/services/pms_reservation_service.py:0
 msgid "Reservation ready for checkout. You can check out directly from here."
-msgstr "Reserva lista para el checkout. Marca la salida directamente desde aquí."
+msgstr "Prenotazione pronta per il checkout. Puoi effettuare il checkout direttamente da qui."

--- a/pms_api_rest/services/pms_reservation_service.py
+++ b/pms_api_rest/services/pms_reservation_service.py
@@ -1401,10 +1401,43 @@ class PmsReservationService(Component):
             raise MissingError(_("Reservation not found"))
         pms_api_check_access(user=self.env.user, records=reservation)
         today = datetime.now().strftime("%Y-%m-%d")
+        # Values reused across the assistant messages below.
+        partner_name = reservation.partner_name
+        room_type_name = reservation.room_type_id.name
+        room_name = reservation.preferred_room_id.name
+        alt_rooms = reservation.count_alternative_free_rooms
+        pending_checkin = reservation.pending_checkin_data
+        pending_amount = reservation.folio_pending_amount
+        penalty_amount = reservation.service_ids.filtered(
+            lambda s: s.is_cancel_penalty
+        ).price_total
+        # Messages with singular/plural forms, resolved before building the list.
+        if alt_rooms == 1:
+            splitted_with_text = (
+                _(
+                    "It looks like %s has had to sleep in different rooms, but you can move them to 1 available room."
+                )
+                % partner_name
+            )
+        else:
+            splitted_with_text = _(
+                "It looks like %(name)s has had to sleep in different rooms, but you can move them to %(count)s available rooms."
+            ) % {"name": partner_name, "count": alt_rooms}
+        if pending_checkin == 1:
+            checkin_partial_text = _(
+                "1 guest still needs to register their details. You can open the check-in assistant to complete the data."
+            )
+        else:
+            checkin_partial_text = (
+                _(
+                    "%s guests still need to register their details. You can open the check-in assistant to complete the data."
+                )
+                % pending_checkin
+            )
         wizard_states = [
             {
                 "code": "overbooking_with_availability",
-                "title": "Overbooking",
+                "title": _("Overbooking"),
                 "domain": "["
                 "('state', 'in', ['draft', 'confirm', 'arrival_delayed']), "
                 "('overbooking', '=', True), "
@@ -1412,12 +1445,15 @@ class PmsReservationService(Component):
                 "('reservation_type', 'in', ['normal', 'staff'])"
                 "]",
                 "filtered": "lambda r: r.count_alternative_free_rooms",
-                "text": f"Parece que ha entrado una reserva sin haber disponibilidad para {reservation.room_type_id.name}.",
+                "text": _(
+                    "It looks like a reservation came in without availability for %s."
+                )
+                % room_type_name,
                 "priority": 100,
             },
             {
                 "code": "overbooking_without_availability",
-                "title": "Overbooking",
+                "title": _("Overbooking"),
                 "domain": "["
                 "('state', 'in', ['draft', 'confirm', 'arrival_delayed']), "
                 "('overbooking', '=', True), "
@@ -1425,175 +1461,192 @@ class PmsReservationService(Component):
                 "('reservation_type', 'in', ['normal', 'staff'])"
                 "]",
                 "filtered": "lambda r: r.count_alternative_free_rooms <= 0",
-                "text": f"Parece que ha entrado una reserva sin haber disponibilidad para {reservation.room_type_id.name}."
-                f"Por desgracia no parece que hay ninguna "
-                f"habitación disponible con la capacidad suficiente para esta reserva",
+                "text": _(
+                    "It looks like a reservation came in without availability for %s. Unfortunately, there does not seem to be any room available with enough capacity for this reservation."
+                )
+                % room_type_name,
                 "priority": 150,
             },
             {
                 "code": "splitted_without_availability",
-                "title": "Divididas",
+                "title": _("Split"),
                 "domain": "[('state', 'in', ['draft', 'confirm', 'arrival_delayed']),"
                 "('splitted', '=', True),"
                 f"('checkin', '>=', '{today}'),"
                 "('reservation_type', 'in', ['normal', 'staff'])"
                 "]",
                 "filtered": "lambda r: r.count_alternative_free_rooms <= 0",
-                "text": f"Parece que a {reservation.partner_name} le ha tocado dormir en habitaciones diferentes "
-                f"pero no hay ninguna habitación disponible para asignarle, puedes probar a mover otras reservas "
-                f"para poder establecerle una única habitación.  ",
+                "text": _(
+                    "It looks like %s has had to sleep in different rooms, but there is no room available to assign. You can try moving other reservations to give them a single room."
+                )
+                % partner_name,
                 "priority": 200,
             },
             {
                 "code": "splitted_with_availability",
-                "title": "Divididas",
+                "title": _("Split"),
                 "domain": "[('state', 'in', ['draft', 'confirm', 'arrival_delayed']),"
                 "('splitted', '=', True),"
                 f"('checkin', '>=', '{today}'),"
                 "('reservation_type', 'in', ['normal', 'staff'])"
                 "]",
                 "filtered": "lambda r: r.count_alternative_free_rooms",
-                "text": f"Parece que a {reservation.partner_name} le ha tocado dormir en habitaciones diferentes"
-                f" pero tienes la posibilidad de moverlo a {reservation.count_alternative_free_rooms} "
-                f" {' habitación' if reservation.count_alternative_free_rooms == 1 else ' habitaciones'}.",
+                "text": splitted_with_text,
                 "priority": 220,
             },
             {
                 "code": "to_assign",
-                "title": "Por asignar",
+                "title": _("To assign"),
                 "domain": "[('state', 'in', ['draft', 'confirm', 'arrival_delayed']),"
                 "('to_assign', '=', True),"
                 "('reservation_type', 'in', ['normal', 'staff']),"
                 f"('checkin', '>=', '{today}'),"
                 "]",
-                "text": f"La reserva de {reservation.partner_name} ha sido asignada a la habitación {reservation.preferred_room_id.name},"
-                " puedes confirmar la habitación o cambiar a otra desde aquí.",
+                "text": _(
+                    "%(name)s's reservation has been assigned to room %(room)s. You can confirm the room or change it to another one from here."
+                )
+                % {"name": partner_name, "room": room_name},
                 "priority": 300,
             },
             {
                 "code": "to_confirm",
-                "title": "Por confirmar",
+                "title": _("To confirm"),
                 "domain": "[('state', '=', 'draft'),"
                 f"('checkin', '>=', '{today}'),"
                 "('reservation_type', 'in', ['normal', 'staff']),"
                 "]",
-                "text": f"La reserva de {reservation.partner_name} está pendiente de confirmar, puedes confirmarla desde aquí.",
+                "text": _(
+                    "%s's reservation is pending confirmation. You can confirm it from here."
+                )
+                % partner_name,
                 "priority": 400,
             },
             {
                 "code": "checkin_done_precheckin",
-                "title": "Entrada Hoy",
+                "title": _("Arrival today"),
                 "domain": "[('state', '=',  'confirm'),"
                 f"('checkin', '=', '{today}'),"
                 "('pending_checkin_data', '=', 0),"
                 "('reservation_type', 'in', ['normal', 'staff'])"
                 "]",
-                "text": "Todos los huéspedes de esta reserva tienen los datos registrados, "
-                " puedes marcar la entrada directamente desde aquí",
+                "text": _(
+                    "All guests in this reservation have their details registered. You can check them in directly from here."
+                ),
                 "priority": 500,
             },
             {
                 "code": "checkin_partial_precheckin",
-                "title": "Entrada Hoy",
+                "title": _("Arrival today"),
                 "domain": "[('state', '=',  'confirm'),"
                 f"('checkin', '=', '{today}'),"
                 "('pending_checkin_data', '>', 0),"
                 "('checkin_partner_ids.state','=', 'precheckin'),"
                 "('reservation_type', 'in', ['normal', 'staff'])"
                 "]",
-                "text": f"Faltan {reservation.pending_checkin_data} {' huésped ' if reservation.pending_checkin_data == 1 else ' huéspedes '} "
-                f"por registrar sus datos.Puedes abrir el asistente de checkin "
-                f" para completar los datos.",
+                "text": checkin_partial_text,
                 "priority": 530,
             },
             {
                 "code": "checkin_no_precheckin",
-                "title": "Entrada Hoy",
+                "title": _("Arrival today"),
                 "domain": "[('state', '=', 'confirm'),"
                 f"('checkin', '=', '{today}'),"
                 "('pending_checkin_data', '>', 0),"
                 "('reservation_type', 'in', ['normal', 'staff'])"
                 "]",
                 "filtered": "lambda r: all([c.state in ('draft','dummy') for c in r.checkin_partner_ids]) ",
-                "text": "Registra los datos de los huéspedes desde el asistente del checkin.",
+                "text": _("Register the guests' details from the check-in assistant."),
                 "priority": 580,
             },
             {
                 "code": "confirmed_without_payment_and_precheckin",
-                "title": "Confirmadas a futuro sin pagar y sin precheckin realizado",
+                "title": _("Future confirmed, unpaid and without pre-checkin"),
                 "domain": "[('state', 'in', ['draft', 'confirm', 'arrival_delayed']),"
                 "('reservation_type', 'in', ['normal', 'staff']),"
                 f"('checkin', '>', '{today}'),"
                 "('pending_checkin_data', '>', 0),"
                 "('folio_payment_state', 'in', ['not_paid', 'partial'])"
                 "]",
-                "text": "Esta reserva está pendiente de cobro y de que los huéspedes "
-                " registren sus datos: puedes enviarles un recordatorio desde aquí",
+                "text": _(
+                    "This reservation is pending payment and the guests still need to register their details: you can send them a reminder from here."
+                ),
                 "priority": 600,
             },
             {
                 "code": "confirmed_without_payment",
-                "title": "Confirmadas a futuro sin pagar",
+                "title": _("Future confirmed, unpaid"),
                 "domain": "[('state', 'in', ['draft', 'confirm', 'arrival_delayed']),"
                 "('reservation_type', 'in', ['normal', 'staff']),"
                 f"('checkin', '>', '{today}'),"
                 "('pending_checkin_data', '=', 0),"
                 "('folio_payment_state', 'in', ['not_paid', 'partial'])"
                 "]",
-                "text": "Esta reserva está pendiente de cobro, puedes enviarle sun recordatorio desde aquí",
+                "text": _(
+                    "This reservation is pending payment. You can send a reminder from here."
+                ),
                 "priority": 630,
             },
             {
                 "code": "confirmed_without_precheckin",
-                "title": "Confirmadas a futuro sin pagar",
+                "title": _("Future confirmed, unpaid"),
                 "domain": "[('state', 'in', ['draft', 'confirm', 'arrival_delayed']),"
                 "('reservation_type', 'in', ['normal', 'staff']),"
                 f"('checkin', '>', '{today}'),"
                 "('pending_checkin_data', '>', 0),"
                 "('folio_payment_state', 'in', ['paid', 'overpayment','nothing_to_pay'])"
                 "]",
-                "text": "Esta reserva no tiene los datos de los huéspedes registrados, puedes enviarles un recordatorio desde aquí",
+                "text": _(
+                    "This reservation does not have the guests' details registered. You can send them a reminder from here."
+                ),
                 "priority": 660,
             },
             {
                 "code": "cancelled",
-                "title": "Cancelada con cargos y sin cobrar",
+                "title": _("Cancelled with charges and unpaid"),
                 "domain": "[('state', '=', 'cancel'),"
                 "('cancelled_reason', 'in',['late','noshow']),"
                 "('folio_payment_state', 'in', ['not_paid', 'partial']),"
                 "]",
                 "filtered": "lambda r: r.service_ids.filtered(lambda s: s.is_cancel_penalty and s.price_total > 0)",
-                "text": f"La reserva de {reservation.partner_name} ha sido cancelada con una penalización de {reservation.service_ids.filtered(lambda s: s.is_cancel_penalty).price_total:.2f}€, "
-                "puedes eliminar la penalización en caso de que no se vaya a cobrar.",
+                "text": _(
+                    "%(name)s's reservation has been cancelled with a penalty of %(amount).2f€. You can remove the penalty if it is not going to be charged."
+                )
+                % {"name": partner_name, "amount": penalty_amount},
                 "priority": 700,
             },
             {
                 "code": "onboard_without_payment",
-                "title": "Por cobrar dentro",
+                "title": _("Pending payment (in-house)"),
                 "domain": "[('state', 'in', ['onboard', 'departure_delayed']),"
                 "('folio_payment_state', 'in', ['not_paid', 'partial'])"
                 "]",
-                "text": f"En esta reserva tenemos un pago pendiente de {reservation.folio_pending_amount:.2f}. "
-                "Puedes registrar el pago desde aquí.",
+                "text": _(
+                    "This reservation has a pending payment of %.2f. You can register the payment from here."
+                )
+                % pending_amount,
                 "priority": 800,
             },
             {
                 "code": "done_without_payment",
-                "title": "Por cobrar pasadas",
+                "title": _("Pending payment (past stays)"),
                 "domain": "[('state', '=', 'done'),"
                 "('folio_payment_state', 'in', ['not_paid', 'partial'])"
                 "]",
-                "text": f"Esta reserva ha quedado con un cargo pendiente de {reservation.folio_pending_amount:.2f}€. "
-                "Cuando gestiones el cobro puedes registrarlo desde aquí.",
+                "text": _(
+                    "This reservation has a pending charge of %.2f€. When you handle the payment you can register it from here."
+                )
+                % pending_amount,
                 "priority": 900,
             },
             {
                 "code": "checkout",
-                "title": "Checkout",
+                "title": _("Checkout"),
                 "domain": "[('state', 'in', ['onboard', 'departure_delayed']),"
                 f"('checkout', '=', '{today}'),"
                 "]",
-                "text": "Reserva lista para el checkout, marca la salida directamente desde aquí.",
+                "text": _(
+                    "Reservation ready for checkout. You can check out directly from here."
+                ),
                 "priority": 1000,
             },
         ]
@@ -1996,10 +2049,7 @@ class PmsReservationService(Component):
             and pms_checkin_partner_info.relationship
         ):
             folio_id = (
-                self.env["pms.reservation"]
-                .sudo()
-                .browse(reservation_id)
-                .folio_id.id
+                self.env["pms.reservation"].sudo().browse(reservation_id).folio_id.id
             )
             record_checkin_partner_legal_representative = (
                 self.env["pms.checkin.partner"]


### PR DESCRIPTION
## What

The `wizard_states` endpoint (`GET /<reservation_id>/wizard-states`) returns the assistant `title` and `text` shown in the front-end depending on the reservation state. These were hardcoded Spanish f-strings, so they were **never extracted for translation** and always rendered in Spanish regardless of the user/request language.

## Changes

- Move the base strings to **English** wrapped in `_()`.
- Switch from f-string interpolation to `%`-formatting so the strings are extractable by the translation tooling. Singular/plural variants are resolved into local variables before building the list.
- Fix a few pre-existing typos along the way (`sun recordatorio` → `un recordatorio`, duplicated spaces).
- Add translations for the languages shipped by the PMS in 16.0:
  - **es** (Spanish) — completed in `i18n/es.po`
  - **de** (German) — new `i18n/de.po`
  - **it** (Italian) — new `i18n/it.po`

## Notes

- No behavioural change: the same message is shown for each state; only the source language and the translation mechanism change.
- All 29 assistant strings (11 titles + 18 texts) are covered in the three `.po` files; placeholder consistency was validated.