### PR TITLE
[FIX] spreadsheet_dasbhoard_pms: month filter off-by-one (date filter type)

### DIFF
--- a/spreadsheet_dasbhoard_pms/__manifest__.py
+++ b/spreadsheet_dasbhoard_pms/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'PMS dashboards',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.0.1',
     'summary': '',
     'category': '',
     'author': '',

--- a/spreadsheet_dasbhoard_pms/data/files/production.json
+++ b/spreadsheet_dasbhoard_pms/data/files/production.json
@@ -1148,7 +1148,8 @@
             "stacked": true,
             "fieldMatching": {
               "549a2007-bd74-4236-944d-60b4accd27f5": {
-                "chain": "day"
+                "chain": "day",
+                "type": "date"
               },
               "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
                 "chain": "pms_property_id"
@@ -1528,7 +1529,8 @@
             "stacked": true,
             "fieldMatching": {
               "549a2007-bd74-4236-944d-60b4accd27f5": {
-                "chain": "day"
+                "chain": "day",
+                "type": "date"
               },
               "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
                 "chain": "pms_property_id"
@@ -1908,7 +1910,8 @@
             "stacked": true,
             "fieldMatching": {
               "549a2007-bd74-4236-944d-60b4accd27f5": {
-                "chain": "day"
+                "chain": "day",
+                "type": "date"
               },
               "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
                 "chain": "pms_property_id"
@@ -2286,7 +2289,8 @@
             "type": "odoo_pie",
             "fieldMatching": {
               "549a2007-bd74-4236-944d-60b4accd27f5": {
-                "chain": "day"
+                "chain": "day",
+                "type": "date"
               },
               "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
                 "chain": "pms_property_id"
@@ -3796,7 +3800,8 @@
       "sortedColumn": null,
       "fieldMatching": {
         "549a2007-bd74-4236-944d-60b4accd27f5": {
-          "chain": "day"
+          "chain": "day",
+          "type": "date"
         },
         "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
           "chain": "pms_property_id"
@@ -3859,7 +3864,8 @@
       "sortedColumn": null,
       "fieldMatching": {
         "549a2007-bd74-4236-944d-60b4accd27f5": {
-          "chain": "checkin"
+          "chain": "checkin",
+          "type": "date"
         },
         "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
           "chain": "pms_property_id"
@@ -3922,7 +3928,8 @@
       "sortedColumn": null,
       "fieldMatching": {
         "549a2007-bd74-4236-944d-60b4accd27f5": {
-          "chain": "checkin"
+          "chain": "checkin",
+          "type": "date"
         },
         "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
           "chain": "pms_property_id"
@@ -3967,7 +3974,8 @@
       "sortedColumn": null,
       "fieldMatching": {
         "549a2007-bd74-4236-944d-60b4accd27f5": {
-          "chain": "date"
+          "chain": "date",
+          "type": "date"
         },
         "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
           "chain": "pms_property_id"
@@ -4023,7 +4031,8 @@
       "sortedColumn": null,
       "fieldMatching": {
         "549a2007-bd74-4236-944d-60b4accd27f5": {
-          "chain": "day"
+          "chain": "day",
+          "type": "date"
         },
         "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
           "chain": "pms_property_id"
@@ -4079,7 +4088,8 @@
       "sortedColumn": null,
       "fieldMatching": {
         "549a2007-bd74-4236-944d-60b4accd27f5": {
-          "chain": "day"
+          "chain": "day",
+          "type": "date"
         },
         "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
           "chain": "pms_property_id"
@@ -4135,7 +4145,8 @@
       "sortedColumn": null,
       "fieldMatching": {
         "549a2007-bd74-4236-944d-60b4accd27f5": {
-          "chain": "day"
+          "chain": "day",
+          "type": "date"
         },
         "942c3859-f759-4b6a-a737-e7c45cec5f9b": {
           "chain": "pms_property_id"


### PR DESCRIPTION
## Problem

In the production spreadsheet dashboard (`spreadsheet_dasbhoard_pms`), the global date filter **"Fecha"** (month range) selected the wrong range: when picking a month, it **included the last day of the previous month**.

Effect: every month was inflated by the previous month's last day, boundary days were double-counted between consecutive months, and the **month-by-month sum did not reconcile with the total**. It affected accommodation revenue, extra-service revenue and reservation/cancellation counts alike.

## Cause

The "Fecha" filter is mapped to **Date** fields (`day` in `hotel.room.type.daily.summary`, `checkin` in `pms.reservation`, `date` in `pms.service.line`), but the `fieldMatching` entries had no `type` key.

With `type` undefined, the spreadsheet engine (`constructDateRange` in `web/.../search/utils/dates.js`, via `global_filters_ui_plugin._getDateDomain`) takes the **datetime** branch and serializes the bounds with `serializeDateTime` → `setZone('utc')`. Under positive-offset timezones, the local month start is converted to the previous day in UTC and, when compared against the Date field, pulls that previous day into the range. The upper bound stays correct; only the lower bound is shifted (-1 day).

## Fix

Add `"type": "date"` to the date-filter matching in the **7 pivots and 4 charts** that use it. With type `date`, the `serializeDate` path (no UTC conversion) is used and the month maps to its natural calendar boundaries.

Data-only change (dashboard JSON) plus a module version bump. `data/dashboards.xml` is not `noupdate`, so upgrading the module applies the corrected JSON to existing instances.

## Verification

After the fix, the monthly dashboard cards match the per-natural-month production (by stay date), and the month-by-month sum reconciles with the total.