### PR TITLE
[FIX] partner_identification_unique: archived partners must not block identification numbers

### DIFF
--- a/partner_identification_unique/__manifest__.py
+++ b/partner_identification_unique/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "Commitsun, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Generic Modules/Property Management System",
-    "version": "16.0.2.0.0",
+    "version": "16.0.2.0.1",
     "license": "AGPL-3",
     "depends": [
         "pms_partner_identification",

--- a/partner_identification_unique/migrations/16.0.2.0.1/post-migration.py
+++ b/partner_identification_unique/migrations/16.0.2.0.1/post-migration.py
@@ -1,0 +1,20 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # The archive cascade in res.partner.write never ran (broken guard), so
+    # archived partners kept active identification documents that blocked the
+    # uniqueness checks for new contacts/check-ins reusing the same number.
+    # Archive those orphaned documents.
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_partner_id_number n
+        SET active = false
+        FROM res_partner p
+        WHERE n.partner_id = p.id
+          AND p.active = false
+          AND n.active = true
+        """,
+    )

--- a/partner_identification_unique/models/res_partner.py
+++ b/partner_identification_unique/models/res_partner.py
@@ -158,8 +158,16 @@ class ResPartner(models.Model):
                 )
 
     def write(self, vals):
-        if vals.get("active") and not vals["active"]:
+        res = super().write(vals)
+        # When a partner is archived, archive its identification documents too.
+        # Otherwise the documents stay active and keep reserving the
+        # (name, country, category) namespace used by the uniqueness checks,
+        # so an archived (invisible) partner blocks new contacts/check-ins that
+        # legitimately reuse the same number. The previous guard
+        # (``vals.get("active") and not vals["active"]``) could never be true,
+        # so this cascade never ran.
+        if "active" in vals and not vals["active"]:
             self.env["res.partner.id_number"].search(
                 [("partner_id", "in", self.ids)]
             ).write({"active": False})
-        return super().write(vals)
+        return res

--- a/partner_identification_unique/tests/test_unique_identification.py
+++ b/partner_identification_unique/tests/test_unique_identification.py
@@ -27,6 +27,50 @@ class TestPms(common.TransactionCase):
         with self.assertRaises(ValidationError):
             self.partner_2.with_context(test_vat=True).write({"vat": "12345678Z"})
 
+    def test_archive_partner_archives_id_numbers(self):
+        """Archiving a partner must cascade-archive its identification documents
+        so they stop reserving the uniqueness namespace."""
+        dni_type = self.env["res.partner.id_category"].create(
+            {"name": "test_dni_type", "code": "DNI"}
+        )
+        id_number = self.env["res.partner.id_number"].create(
+            {
+                "partner_id": self.partner_1.id,
+                "category_id": dni_type.id,
+                "name": "49572983W",
+                "country_id": self.env.ref("base.es").id,
+            }
+        )
+        self.partner_1.action_archive()
+        self.assertFalse(id_number.active)
+
+    def test_archived_partner_does_not_block(self):
+        """After archiving a partner, the same document number can be created
+        on another (active) partner: the cascade archived the document, so it
+        no longer counts as a duplicate."""
+        dni_type = self.env["res.partner.id_category"].create(
+            {"name": "test_dni_type_2", "code": "DNI"}
+        )
+        self.env["res.partner.id_number"].create(
+            {
+                "partner_id": self.partner_1.id,
+                "category_id": dni_type.id,
+                "name": "49572983W",
+                "country_id": self.env.ref("base.es").id,
+            }
+        )
+        self.partner_1.action_archive()
+        # Must not raise: the previous document was archived with its partner.
+        new_id_number = self.env["res.partner.id_number"].create(
+            {
+                "partner_id": self.partner_2.id,
+                "category_id": dni_type.id,
+                "name": "49572983W",
+                "country_id": self.env.ref("base.es").id,
+            }
+        )
+        self.assertTrue(new_id_number)
+
     def test_unique_vat_identification_vat_type(self):
         """
         Check the constraints with a partner with a country code in VAT and


### PR DESCRIPTION
## Problem

Registering a contact / check-in guest with an identification number (e.g. a DNI) failed with **"The identification number X already exists in another partner"**, while that contact was nowhere to be found in the UI.

Root cause: the document belonged to an **archived** partner. Archived partners are invisible and cannot be selected or reused, yet their `res.partner.id_number` records stayed active and kept reserving the `(name, country, category)` uniqueness namespace — deadlocking any new record that legitimately reuses the same number.

This produced a hard block on a live deployment: every check-in attempt with the affected document was rejected.

## Cause

The archive cascade in `res.partner.write` was guarded by a condition that can **never** be true:

```python
if vals.get("active") and not vals["active"]:   # active True AND False at once
```

so identification documents were never archived together with their partner, and those orphaned active documents kept blocking the duplicate check forever.

## Fix

- `res.partner.write`: correct the guard to `"active" in vals and not vals["active"]` so archiving a partner cascade-archives its `id_number` records. Archived documents are excluded from the duplicate search by the default active filtering, so no domain change is needed.
- Post-migration script (16.0.2.0.1): archive the documents left active on archived partners by the broken cascade, so pre-existing orphans stop blocking too.

## Tests

- `test_archive_partner_archives_id_numbers`: archiving a partner archives its documents.
- `test_archived_partner_does_not_block`: after archiving a partner, the same document number can be created on another partner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
