### PR TITLE
[16.0][FIX] connector_pms_wubook: export avail counts on quota/max_avail changes

### DIFF
--- a/connector_pms_wubook/models/pms_availability_plan_rule/listener.py
+++ b/connector_pms_wubook/models/pms_availability_plan_rule/listener.py
@@ -57,10 +57,18 @@ _RULE_PLAN_FIELDS = frozenset(
 
 # Rule fields whose change must re-push the property availability.
 # ``plan_avail`` = min(real_avail, quota, max_avail) is the bookable
-# count actually shipped to Wubook. A change in ``real_avail`` does NOT
-# necessarily change ``plan_avail`` (the cap may absorb it), so we
-# trigger on ``plan_avail`` itself to avoid no-op pushes.
-_RULE_AVAIL_FIELDS = frozenset({"plan_avail"})
+# count actually shipped to Wubook, but it is a stored COMPUTED field:
+# its recompute is flushed through ``_write()`` and never fires
+# ``on_record_write`` (component_event only hooks the public
+# ``write()``), so triggering on ``plan_avail`` alone never happens in
+# practice. The public writes that drive it are ``quota`` /
+# ``max_avail`` (e.g. the front calendar sale-availability edit), so we
+# trigger on those. ``real_avail`` changes flow through the reservation
+# / line listeners instead. ``plan_avail`` is kept for the (unlikely)
+# case of an explicit write. No-op pushes are cheap: the export only
+# ships bindings whose ``sale_avail`` flush bumped ``actual_write_date``
+# (see ``pms_availability/binding.py::_write``).
+_RULE_AVAIL_FIELDS = frozenset({"plan_avail", "quota", "max_avail"})
 
 
 def _flush_plan_rules_buffer(env):
@@ -173,8 +181,9 @@ class ChannelWubookPmsAvailabilityPlanRuleListener(Component):
     of the parent plan payload. So every change on a rule may schedule:
 
     * a re-export of its parent **plan** (when business fields change),
-    * a re-export of the property **availability** (when ``plan_avail``
-      — the bookable count actually shipped to Wubook — changes).
+    * a re-export of the property **availability** (when ``quota`` /
+      ``max_avail`` change — they drive ``plan_avail``, the bookable
+      count actually shipped to Wubook — and on rule create / unlink).
 
     Both paths coalesce through per-transaction buffers so that massive
     operations (e.g. ``wizard_massive_changes`` touching hundreds of
@@ -237,6 +246,14 @@ class ChannelWubookPmsAvailabilityPlanRuleListener(Component):
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_create(self, record, fields=None):
         self._stage_plan_rule(record)
+        # A rule created on a date whose ``pms.availability`` record
+        # already exists (e.g. capping a busy date from the calendar)
+        # changes ``plan_avail`` without any avail-create event firing,
+        # so the property availability must be staged here too. On
+        # fresh dates ``_compute_avail_id`` creates the availability
+        # record and its own create listener stages the same pair —
+        # the staging set deduplicates.
+        self._stage_plan_avail(record)
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_write(self, record, fields=None):
@@ -252,3 +269,6 @@ class ChannelWubookPmsAvailabilityPlanRuleListener(Component):
     def on_record_unlink(self, record, fields=None):
         # Read the plan / property before the rule is gone.
         self._stage_plan_rule(record)
+        # Deleting a rule lifts its quota / max_avail cap, so the
+        # bookable count changes too.
+        self._stage_plan_avail(record)

--- a/connector_pms_wubook/tests/test_master_sync.py
+++ b/connector_pms_wubook/tests/test_master_sync.py
@@ -1410,3 +1410,60 @@ class TestAvailabilityListener(TransactionComponentCase):
                 r.write({"plan_avail": 1})
             self.env.cr.precommit.run()
         trap.assert_jobs_count(1)
+
+    def test_write_quota_enqueues_property_export(self):
+        # ``quota`` / ``max_avail`` are the PUBLIC writes that drive
+        # ``plan_avail`` (a stored compute whose flush never fires
+        # ``on_record_write``), so the front calendar sale-availability
+        # edit must enqueue the property export through them. The same
+        # write also re-exports the plan (restrictions payload), hence
+        # two jobs.
+        rule = self._make_rule()
+        self.env.cr.precommit.run()  # flush buffers from rule create
+        with trap_jobs() as trap:
+            rule.write({"quota": 0})
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(2)
+        trap.assert_enqueued_job(
+            self.plan_binding.export_record,
+            args=(self.backend, self.plan),
+        )
+        trap.assert_enqueued_job(
+            self.property_avail_binding.export_record,
+            args=(self.backend, self.pms_property),
+            properties={
+                "identity_key": (
+                    f"wubook_export_property_avail:{self.backend.id}"
+                    f":{self.pms_property.id}"
+                )
+            },
+        )
+
+    def test_rule_create_on_existing_avail_enqueues_property_export(self):
+        # Capping a date whose ``pms.availability`` record already
+        # exists creates a rule but no availability record, so the rule
+        # create itself must stage the property export.
+        self._make_avail()
+        self.env.cr.precommit.run()  # flush avail-create buffer
+        with trap_jobs() as trap:
+            self._make_rule(quota=0)
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(2)
+        trap.assert_enqueued_job(
+            self.property_avail_binding.export_record,
+            args=(self.backend, self.pms_property),
+        )
+
+    def test_rule_unlink_enqueues_property_export(self):
+        # Deleting a rule lifts its quota cap → the bookable count
+        # changes → property export (plus the plan re-export).
+        rule = self._make_rule()
+        self.env.cr.precommit.run()
+        with trap_jobs() as trap:
+            rule.unlink()
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(2)
+        trap.assert_enqueued_job(
+            self.property_avail_binding.export_record,
+            args=(self.backend, self.pms_property),
+        )


### PR DESCRIPTION
## Problem

Editing sale availability (`quota` / `max_avail` on an availability plan rule) only re-exported the plan payload (restrictions: min/max stay, closures), never the **availability counters**.

The counter trigger was conditioned on `plan_avail`, which is a stored computed field: its recompute is flushed via `_write()`, and `component_event` only hooks the public `write()`, so that branch **never fired in practice** (dead code).

Consequence: after closing sales in the calendar, the counter on the channel stayed out of sync until a reservation event on the same property re-exported the dirty data as a side effect — or indefinitely on properties with no activity. Typical outcome: overbooking after a sales closure.

## Fix

In the `pms.availability.plan.rule` listener:

- `_RULE_AVAIL_FIELDS` now triggers on `quota` / `max_avail` (the public writes that feed `plan_avail`). `plan_avail` is kept for the unlikely case of an explicit write.
- `on_record_create` also enqueues the availability export: a rule created on a date whose `pms.availability` already exists (capping a date with reservations) does not fire any availability creation event.
- `on_record_unlink` likewise: deleting the rule lifts the cap.

No-op exports remain cheap: the exporter only sends bindings whose `sale_avail` flush updated `actual_write_date` (dirty), and the precommit buffer + `identity_key` preserve the existing coalescing.

## Tests

3 new tests in `TestAvailabilityListener` (quota write, create over existing availability, unlink). Full module suite: **151 tests OK**.
