### PR TITLE
[HOTFIX-16][FIX] connector_pms: retry export jobs on transient API client network errors

### DIFF
--- a/connector_pms/components_custom/mapper.py
+++ b/connector_pms/components_custom/mapper.py
@@ -4,11 +4,14 @@ import collections.abc
 import logging
 import uuid
 
+import requests
+
 from odoo import _, fields
 from odoo.exceptions import ValidationError
 
 from odoo.addons.component.core import AbstractComponent
 from odoo.addons.connector.components.mapper import m2o_to_external
+from odoo.addons.queue_job.exception import RetryableJobError
 
 _logger = logging.getLogger(__name__)
 
@@ -219,9 +222,25 @@ class ChannelChildMapperImport(AbstractComponent):
                     )
             if payload:
                 _logger.info("Exporting to PMS API client %s", client.login)
-                response = pms_property.pms_api_push_payload(
-                    payload=payload, endpoint=endpoint, client=client
-                )
+                try:
+                    response = pms_property.pms_api_push_payload(
+                        payload=payload, endpoint=endpoint, client=client
+                    )
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ) as err:
+                    # Transient network failure against the API client
+                    # (read timeout, connection reset...). Do NOT let it
+                    # kill the export job permanently: the export ships
+                    # the full dirty state, so retrying the whole job
+                    # later is safe and idempotent. queue_job marks the
+                    # job failed only after max_retries.
+                    raise RetryableJobError(
+                        "PMS API client %s unreachable (%s), "
+                        "job will be retried" % (client.login, err),
+                        seconds=300,
+                    ) from err
                 self.env["pms.api.log"].sudo().create(
                     {
                         "pms_property_id": pms_property_id,

--- a/pms_api_rest/models/pms_property.py
+++ b/pms_api_rest/models/pms_property.py
@@ -314,7 +314,7 @@ class PmsProperty(models.Model):
             endpoint,
             headers=headers,
             data=json.dumps(payload),
-            timeout=10,
+            timeout=30,
         )
         return response
 


### PR DESCRIPTION
## Problema

El push a los API clients dentro del child mapper (`get_all_items`) corre sin protección: un `ReadTimeout` o `ConnectionError` contra el endpoint del cliente mata el **job de export entero** en estado `failed`, sin reintento (`queue_job` solo reintenta ante `RetryableJobError`).

En las últimas 2 semanas se perdieron así varios cientos de exports de plan/disponibilidad/tarifa (timeouts de lectura esporádicos con `timeout=10`). Como el export envía estado *dirty*, el dato queda sin sincronizar hasta que otro cambio del mismo scope vuelve a exportarlo — indefinidamente en propiedades sin movimiento.

## Fix

1. **`connector_pms/components_custom/mapper.py`**: envolver `pms_api_push_payload` en `try/except (ConnectionError, Timeout)` → `RetryableJobError(seconds=300)`. El export es idempotente (estado dirty completo), así que reintentar el job es seguro. Con los defaults de queue_job: 5 reintentos antes de `failed`.
2. **`pms_api_rest/models/pms_property.py`**: `timeout` 10s → 30s en `pms_api_push_payload` — los fallos observados son respuestas lentas, no endpoints caídos.

Nota: el rollback del job al reintentar también descarta el `pms.api.log` parcial, así que no quedan logs duplicados.

Base `HOTFIX-16-connector_based` porque el piggyback a API clients solo existe en esta rama (no está en `16.0`); es la rama que mergea el `repos.yaml` de producción.