### PR TITLE
[FIX] pms_autoinvoice: isolate per-folio errors in synchronous autoinvoicing

### DIFF
--- a/pms_autoinvoice/__manifest__.py
+++ b/pms_autoinvoice/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "pms autoinvoice",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "",
     "author": "Commitsun",
     "license": "AGPL-3",

--- a/pms_autoinvoice/models/pms_property.py
+++ b/pms_autoinvoice/models/pms_property.py
@@ -1,9 +1,12 @@
+import logging
 from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class PmsProperty(models.Model):
@@ -74,7 +77,15 @@ class PmsProperty(models.Model):
             if with_delay:
                 self.with_delay().autoinvoice_folio(folio, delay_post=True)
             else:
-                self.autoinvoice_folio(folio)
+                # Isolate failures per folio: a single folio that cannot be
+                # invoiced (e.g. simplified invoice over the limit without
+                # enough fiscal data) must not abort the whole cron run.
+                try:
+                    self.autoinvoice_folio(folio)
+                except Exception as e:
+                    _logger.warning(
+                        "Autoinvoicing skipped folio %s: %s", folio.name, e
+                    )
         # 2- Validate draft invoices ready for posting. Invoices created
         # in step 1 schedule their own posting job from inside
         # autoinvoice_folio; this search catches orphan drafts left over
@@ -101,7 +112,14 @@ class PmsProperty(models.Model):
             if with_delay:
                 self.with_delay().autovalidate_folio_invoice(invoice)
             else:
-                self.autovalidate_folio_invoice(invoice)
+                # Isolate failures per invoice so one draft that cannot be
+                # posted does not abort posting of the remaining drafts.
+                try:
+                    self.autovalidate_folio_invoice(invoice)
+                except Exception as e:
+                    _logger.warning(
+                        "Autovalidate skipped invoice %s: %s", invoice.name, e
+                    )
 
         if not with_delay:
             # 3- Reverse the downpayment invoices not included in final invoice


### PR DESCRIPTION
## Problem

When the autoinvoicing cron runs synchronously (`autoinvoicing(with_delay=False)`), the per-folio loop calls `autoinvoice_folio` / `autovalidate_folio_invoice`, both of which re-raise any error as a `ValidationError`. That exception was **not caught in the loop**, so a single problematic record aborted the whole nightly run and left every remaining folio uninvoiced.

Typical trigger: a folio whose simplified invoice exceeds the maximum allowed amount and whose guest lacks enough fiscal data to issue a normal invoice.

The asynchronous mode (`with_delay=True`) isolates failures per queue job, but instead suffers PostgreSQL serialization conflicts (`could not serialize access due to concurrent update`) when many jobs post in parallel against shared records, and those retryable errors are swallowed by the `except ... raise ValidationError` wrapper.

## Change

Wrap each folio invoicing and each draft validation in a `try/except` that logs a warning and skips the offending record, letting the rest of the run complete. Both helpers already roll back their own work via an internal savepoint, so the cursor stays valid after a caught failure.

This makes synchronous mode safe to use as the default (no concurrency conflicts, no single-record abort).

## Test plan

- Run the cron synchronously on a property with a mix of invoiceable folios and at least one that fails fiscal validation: the valid folios are invoiced and posted, the failing one is logged and skipped.