### PR TITLE
[pms_smartlock_base] serialize gateway ops with advisory lock

### DIFF
--- a/pms_smartlock_base/models/lock_code.py
+++ b/pms_smartlock_base/models/lock_code.py
@@ -1,3 +1,4 @@
+import random
 from datetime import timezone
 
 from roomdoo_locks_base import (
@@ -13,6 +14,18 @@ from odoo.osv import expression
 from odoo.addons.queue_job.exception import RetryableJobError
 
 _TRANSIENT_RETRY_SECONDS = 300
+
+# A vendor gateway cannot service two requests at once: two jobs programming
+# the same physical lock concurrently make the second fail with "busy". We
+# serialise per ``lock_device_id`` with a PostgreSQL transaction-level advisory
+# lock taken before the vendor call. ``_GATEWAY_LOCK_CLASSID`` namespaces these
+# locks (first arg of the two-int ``pg_try_advisory_xact_lock``) so they never
+# collide with advisory locks taken elsewhere (e.g. queue_job's jobrunner).
+_GATEWAY_LOCK_CLASSID = 0x10C  # "LOCK"
+# A job that loses the race re-enqueues after this delay (base + jitter) to
+# spread retries and avoid a thundering herd on the contended gateway.
+_GATEWAY_LOCK_RETRY_BASE = 10
+_GATEWAY_LOCK_RETRY_JITTER = 20
 
 _SYNCING_JOB_STATES = ("pending", "enqueued", "started")
 
@@ -267,6 +280,37 @@ class LockCode(models.Model):
             vals["target_ids"] = [(5, 0, 0)] + [(0, 0, spec) for spec in specs]
         self.write(vals)
 
+    def _try_lock_gateways(self, device_ids):
+        """Acquire a transaction-level advisory lock per ``lock_device_id``
+        this operation will program, so no two jobs hit the same gateway at
+        once. Returns True only if every lock was acquired; False as soon as
+        one is held by another job's transaction. Locks already acquired in
+        this call are released when the job's transaction ends — which, on a
+        False result, happens immediately because the caller raises
+        ``RetryableJobError`` and queue_job rolls back. Ids are sorted for a
+        deterministic acquisition order."""
+        cr = self.env.cr
+        for device_id in sorted(set(device_ids)):
+            cr.execute(
+                "SELECT pg_try_advisory_xact_lock(%s, hashtext(%s))",
+                (_GATEWAY_LOCK_CLASSID, device_id),
+            )
+            if not cr.fetchone()[0]:
+                return False
+        return True
+
+    def _raise_gateway_busy(self):
+        """Re-enqueue the sync because another job holds a gateway it needs.
+        ``ignore_retry=True`` keeps this off the ``max_retries`` counter: a
+        credential must never end up ``failed`` just for losing a gateway
+        race, only for a real vendor error."""
+        raise RetryableJobError(
+            "Gateway busy: another sync holds one of these locks; retrying",
+            seconds=_GATEWAY_LOCK_RETRY_BASE
+            + random.randint(0, _GATEWAY_LOCK_RETRY_JITTER),
+            ignore_retry=True,
+        )
+
     def _sync_create(self):
         self.ensure_one()
         # Vendor sync jobs run under the enqueueing operator's user. ACL
@@ -276,6 +320,8 @@ class LockCode(models.Model):
         if self.cancelled:
             return
         specs = self._grant_target_specs()
+        if not self._try_lock_gateways([s["lock_device_id"] for s in specs]):
+            self._raise_gateway_busy()
         try:
             connector = self.vendor_id.get_connector()
             grant = connector.grant_access(
@@ -296,6 +342,8 @@ class LockCode(models.Model):
     def _sync_modify(self, date_from, date_to):
         self.ensure_one()
         self = self.sudo()
+        if not self._try_lock_gateways(self.target_ids.mapped("lock_device_id")):
+            self._raise_gateway_busy()
         try:
             connector = self.vendor_id.get_connector()
             grant = connector.modify_access(
@@ -313,6 +361,8 @@ class LockCode(models.Model):
     def _sync_remove(self):
         self.ensure_one()
         self = self.sudo()
+        if not self._try_lock_gateways(self.target_ids.mapped("lock_device_id")):
+            self._raise_gateway_busy()
         try:
             connector = self.vendor_id.get_connector()
             connector.revoke_access(grant_ref=self.vendor_grant_ref)

--- a/pms_smartlock_base/tests/test_lock_code_sync.py
+++ b/pms_smartlock_base/tests/test_lock_code_sync.py
@@ -10,6 +10,13 @@ from roomdoo_locks_base import (
     LockOfflineError,
 )
 
+from odoo.sql_db import db_connect
+
+from odoo.addons.pms_smartlock_base.models.lock_code import (
+    _GATEWAY_LOCK_CLASSID,
+    _GATEWAY_LOCK_RETRY_BASE,
+    _GATEWAY_LOCK_RETRY_JITTER,
+)
 from odoo.addons.queue_job.exception import RetryableJobError
 
 from .common import CommonSmartlock
@@ -231,3 +238,90 @@ class TestSyncRemove(_SyncTestBase):
             self.code._sync_remove()
         self.assertTrue(self.code.failed)
         self.assertFalse(self.code.cancelled)
+
+
+class TestGatewaySerialization(_SyncTestBase):
+    """A vendor gateway can't service two requests at once. Before any
+    vendor call the sync grabs a transaction-level advisory lock per
+    ``lock_device_id``; if another job holds it the sync re-enqueues
+    instead of hitting the busy gateway. The contention retry must not
+    count against ``max_retries`` (``ignore_retry``), so a credential
+    never ends up ``failed`` just for losing a gateway race."""
+
+    @contextmanager
+    def _hold_gateway_lock(self, device_id):
+        """Hold the same advisory lock the model takes, from a *separate*
+        DB connection (advisory locks are connection/transaction scoped),
+        so the code under test — running on the test cursor — sees it as
+        held by someone else. Released on rollback when the block exits."""
+        connection = db_connect(self.env.cr.dbname)
+        cr2 = connection.cursor()
+        try:
+            cr2.execute(
+                "SELECT pg_try_advisory_xact_lock(%s, hashtext(%s))",
+                (_GATEWAY_LOCK_CLASSID, device_id),
+            )
+            self.assertTrue(
+                cr2.fetchone()[0], "test setup: external lock should acquire"
+            )
+            yield
+        finally:
+            cr2.rollback()
+            cr2.close()
+
+    def test_try_lock_gateways_true_when_free(self):
+        self.assertTrue(self.code._try_lock_gateways(["device-unused"]))
+
+    def test_try_lock_gateways_false_when_held_elsewhere(self):
+        with self._hold_gateway_lock("device-A"):
+            self.assertFalse(self.code._try_lock_gateways(["device-A"]))
+        # External holder gone → the device is acquirable again.
+        self.assertTrue(self.code._try_lock_gateways(["device-A"]))
+
+    def test_empty_device_list_acquires(self):
+        """No devices to program → nothing to serialise on."""
+        self.assertTrue(self.code._try_lock_gateways([]))
+
+    def test_raise_gateway_busy_off_retry_counter(self):
+        with self.assertRaises(RetryableJobError) as cm:
+            self.code._raise_gateway_busy()
+        # ``ignore_retry`` keeps contention off ``max_retries`` (job.py
+        # decrements ``retry`` for these), so no ``failed`` from a race.
+        self.assertTrue(cm.exception.ignore_retry)
+        self.assertGreaterEqual(cm.exception.seconds, _GATEWAY_LOCK_RETRY_BASE)
+        self.assertLessEqual(
+            cm.exception.seconds,
+            _GATEWAY_LOCK_RETRY_BASE + _GATEWAY_LOCK_RETRY_JITTER,
+        )
+
+    def test_create_skips_vendor_when_gateway_busy(self):
+        """The bottleneck scenario: many checkins share the main entrance.
+        While another job holds that gateway, this create must re-enqueue
+        without calling the vendor and without dirtying its state."""
+        self.code.sudo().write({"vendor_grant_ref": False, "pin": False})
+        with self._hold_gateway_lock(self.code.room_id.lock_device_id):
+            with expect_raises(self, RetryableJobError):
+                self.code._sync_create()
+        self.connector.grant_access.assert_not_called()
+        self.assertFalse(self.code.failed)
+        self.assertFalse(self.code.vendor_grant_ref)
+
+    def test_remove_skips_vendor_when_gateway_busy(self):
+        """Remove reads the locks from the grant snapshot. While the
+        shared door is busy, revoke must not run — and crucially
+        ``cancelled`` must stay False (safety-first invariant)."""
+        common = self._add_common_lock(self.code.room_id)
+        self.env["lock.code.target"].sudo().create(
+            {
+                "lock_code_id": self.code.id,
+                "kind": "common",
+                "lock_device_id": common.lock_device_id,
+                "common_lock_id": common.id,
+            }
+        )
+        with self._hold_gateway_lock(common.lock_device_id):
+            with expect_raises(self, RetryableJobError):
+                self.code._sync_remove()
+        self.connector.revoke_access.assert_not_called()
+        self.assertFalse(self.code.cancelled)
+        self.assertFalse(self.code.failed)


### PR DESCRIPTION
## Problema

Muchas reservas que comparten la **entrada principal** (una `pms.common.lock`) generan sus códigos alrededor de la hora habitual de checkin. Los jobs de sync corren en paralelo (canal `root` de queue_job, capacity 13) y cada grant cubre la cerradura de la habitación **+** la entrada compartida en **una sola** llamada al vendor, así que el gateway de la entrada recibe N peticiones simultáneas y responde **"busy" (`-3003`)** → `LockOfflineError` → `RetryableJobError(300s)`. Se auto-recupera, pero con reintentos lentos, ruidosos y que cuentan contra `max_retries`.

## Solución

Antes de cada llamada al vendor, `_sync_create`/`_sync_modify`/`_sync_remove` adquieren un **advisory lock de PostgreSQL a nivel de transacción** por cada `lock_device_id` que tocan (`pg_try_advisory_xact_lock`). Si otro job tiene alguno, el sync se re-encola con `RetryableJobError(ignore_retry=True)` en vez de golpear el gateway ocupado.

- Serializa **solo** los jobs que tocan la **misma puerta**; mantiene el paralelismo entre hoteles/entradas distintas.
- `ignore_retry=True` mantiene la contención **fuera** de `max_retries` → ninguna credencial acaba en `failed` por perder la carrera (solo los errores reales del vendor → `failed`, como antes).
- El lock es **xact-scoped**: cubre toda la ida-y-vuelta al vendor y se libera solo al commit/rollback (sin fugas si el job revienta).
- `pg_try_advisory_xact_lock` es **no bloqueante** → imposible deadlock.

Se mantiene intacto el retry transitorio de 300s para gateway offline/lento real o concurrencia externa.

## Tests

Nueva clase `TestGatewaySerialization` en `test_lock_code_sync.py` (helper True/False reteniendo el lock desde una segunda conexión, contrato `ignore_retry`/`seconds`, e integraciones create/remove que verifican que con el gateway ocupado no se llama al vendor y el estado queda limpio).

Suite del módulo en local sobre BD limpia: **0 failed, 0 error(s)** (132 tests).