### PR TITLE
[FIX] connector_pms_wubook: keep per-room occupancy on same-type multi-room Booking reservations

### DIFF
--- a/connector_pms_wubook/models/pms_folio/adapter.py
+++ b/connector_pms_wubook/models/pms_folio/adapter.py
@@ -272,20 +272,29 @@ class ChannelWubookPmsFolioAdapter(Component):
                 # TODO: move the following code to method and
                 #  remove boards_d
                 board = boards_d.get(room_id)
+                # Default per-room occupancy/children from the room_id-keyed
+                # dicts. NOTE: when a booking has several rooms of the SAME room
+                # type they share room_id, so these dicts collapse to a single
+                # entry and can no longer hold per-room guest counts. The
+                # Booking.com branch below overrides them with the authoritative
+                # per-room ancillary data.
+                occupancy = occupancies_d.get(room_id)
+                children = occupancies_d_children.get(room_id)
                 if id_channel == 2:  # Booking.com
                     # Board services can be included in the rate
                     # plan and detected by the WuBook API
                     detected_board = value.get("ancillary", {}).get("Detected Board")
                     board = detected_board != "nb" and detected_board or None
-                    # Guests can differ from the Wubook ones???
+                    # Booking.com sends the real per-room guest counts in each
+                    # booked_room's ancillary. Read them directly instead of the
+                    # room_id-keyed dict, which collapses rooms of the same type
+                    # (e.g. 2 rooms with 1 and 2 adults would both end up as 1).
                     guests_adults = room.get("ancillary", {}).get("guests_adults")
                     if guests_adults:
-                        occupancies_d[room_id] = min(
-                            occupancies_d[room_id], guests_adults
-                        )
+                        occupancy = guests_adults
                     guests_children = room.get("ancillary", {}).get("guests_children")
                     if guests_children:
-                        occupancies_d_children[room_id] = guests_children
+                        children = guests_children
                 if id_channel == 43:  # AirBnb
                     # Add commission in price
                     self.apply_gross_prices_airbnb(
@@ -316,8 +325,8 @@ class ChannelWubookPmsFolioAdapter(Component):
                             "day": days["day"],
                             "room_id": room_id,
                             "board": board,
-                            "occupancy": occupancies_d.get(room_id) or 1,
-                            "children": occupancies_d_children.get(room_id) or 0,
+                            "occupancy": occupancy or 1,
+                            "children": children or 0,
                             "board_included": id_channel != 0,
                             "vat_included": vat_included,
                             "agency_id": agency.id if agency else False,
@@ -331,8 +340,8 @@ class ChannelWubookPmsFolioAdapter(Component):
                         "arrival_hour": value["arrival_hour"],
                         "ota_reservation_code": value["channel_reservation_code"],
                         "board": board,
-                        "occupancy": occupancies_d.get(room_id) or 1,
-                        "children": occupancies_d_children.get(room_id) or 0,
+                        "occupancy": occupancy or 1,
+                        "children": children or 0,
                         "rate_id": room_rate_id,
                         "customer_notes": customer_notes,
                         "lines": lines,

--- a/connector_pms_wubook/tests/test_folio.py
+++ b/connector_pms_wubook/tests/test_folio.py
@@ -1,7 +1,10 @@
 # Copyright 2021 Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import datetime
 import json
 import logging
+
+from odoo.tests import tagged
 
 from . import common
 
@@ -588,3 +591,113 @@ class TestPmsFolio(common.TestWubookConnector):
 #             wubook_values,
 #             "The room type data on Odoo does not match the data on Wubook",
 #         )
+
+
+# post_install so the accounting set up by other modules (chart of accounts and
+# its payment method lines) is already in place when the backend is created.
+@tagged("post_install", "-at_install")
+class TestPmsFolioOccupancy(common.TestWubookConnector):
+    """Unit tests for ``_reorg_folio_data`` occupancy parsing."""
+
+    def _build_adapter(self):
+        p1 = self.browse_ref("pms.main_pms_property")
+        payment_method_line = self.env["account.payment.method.line"].search(
+            [("company_id", "=", p1.company_id.id)], limit=1
+        ) or self.env["account.payment.method.line"].search([], limit=1)
+        backend = self.env["channel.wubook.backend"].create(
+            {
+                "name": "Test backend",
+                "pms_property_id": p1.id,
+                "user_id": self.user1(p1).id,
+                "backend_type_id": self.backend_type1.parent_id.id,
+                "pricelist_external_id": 1,
+                "wubook_payment_method_line_id": payment_method_line.id,
+                **self.fake_credentials,
+            }
+        )
+        with backend.work_on("channel.wubook.pms.folio") as work:
+            return work.component(usage="backend.adapter")
+
+    def _booking_value(self):
+        """Booking.com (id_channel=2) reservation with TWO rooms of the SAME
+        room type (same room_id) but a different number of adults per room.
+
+        WuBook returns the per-room occupancy in ``rooms_occupancies`` keyed by a
+        non-unique room id, and the authoritative per-room guest counts in each
+        booked_room's ancillary (``guests_adults`` / ``guests_children``).
+        """
+        day = datetime.date(2026, 6, 27)
+        return {
+            "reservation_code": 1782427170,
+            "id_channel": 2,  # Booking.com
+            "men": 3,
+            "children": 0,
+            "arrival_hour": "14:00",
+            "channel_reservation_code": "6347634839-6347634840",
+            "channel_data": {},
+            "customer_notes": "",
+            "boards": {},
+            "ancillary": {"Detected Board": "nb"},
+            # both entries collapse on the same room id -> per-room data is lost
+            # unless we read it from each booked_room's ancillary
+            "rooms_occupancies": [
+                {"id": 100, "occupancy": 1},
+                {"id": 100, "occupancy": 2},
+            ],
+            "booked_rooms": [
+                {
+                    "room_id": 100,
+                    "ancillary": {"guests_adults": 1, "guests_children": 0},
+                    "roomdays": [
+                        {
+                            "rate_id": 1,
+                            "price": 75.4,
+                            "day": day,
+                            "ancillary": None,
+                        }
+                    ],
+                },
+                {
+                    "room_id": 100,
+                    "ancillary": {"guests_adults": 2, "guests_children": 1},
+                    "roomdays": [
+                        {
+                            "rate_id": 1,
+                            "price": 83.78,
+                            "day": day,
+                            "ancillary": None,
+                        }
+                    ],
+                },
+            ],
+        }
+
+    def test_reorg_multiroom_same_type_keeps_per_room_occupancy(self):
+        """
+        PRE:    - Booking reservation, 2 rooms of the same type, 1 and 2 adults
+        ACT:    - run _reorg_folio_data
+        POST:   - each reservation keeps its own occupancy (1 and 2), not the
+                  collapsed minimum (1 and 1)
+        """
+        adapter = self._build_adapter()
+        value = self._booking_value()
+
+        adapter._reorg_folio_data([value])
+
+        reservations = value["reservations"]
+        self.assertEqual(len(reservations), 2)
+        occupancies = sorted(r["occupancy"] for r in reservations)
+        self.assertEqual(
+            occupancies,
+            [1, 2],
+            "Per-room adults must be preserved for same-room-type Booking "
+            "reservations (regression: both collapsed to 1)",
+        )
+        # children are parsed per room from the booked_room ancillary too
+        children = sorted(r["children"] for r in reservations)
+        self.assertEqual(children, [0, 1])
+        # the reservation lines must carry the same per-room occupancy
+        for reservation in reservations:
+            for line in reservation["lines"]:
+                self.assertEqual(line["occupancy"], reservation["occupancy"])
+                self.assertEqual(line["children"], reservation["children"])


### PR DESCRIPTION
## Problem

A Booking.com reservation that books several rooms of the **same room type** was imported with the wrong number of guests: every room ended up with the lowest per-room guest count. For example, a booking of two rooms — one for 1 adult and one for 2 adults — was imported as 1 adult in both rooms.

## Root cause

In `_reorg_folio_data` (`connector_pms_wubook/models/pms_folio/adapter.py`) the per-room `occupancy`/`children` are stored in dicts keyed by `room_id`. When several `booked_rooms` share the same `room_id` (rooms of the same room type), those dicts collapse to a single entry and the per-room counts are lost. For Booking.com the code then ran `occupancies_d[room_id] = min(occupancies_d[room_id], guests_adults)` while iterating each room, so the single shared entry ended at the minimum across all rooms.

## Fix

Booking.com already returns the authoritative per-room guest counts in each `booked_room`'s `ancillary` (`guests_adults` / `guests_children`). Read them directly into per-room local variables instead of the `room_id`-keyed dict. The change is confined to the `id_channel == 2` (Booking.com) branch, so every other channel keeps the previous behaviour.

## Tests

Adds a regression test (`TestPmsFolioOccupancy.test_reorg_multiroom_same_type_keeps_per_room_occupancy`) covering a two-room, same-room-type Booking reservation with 1 and 2 adults, asserting each reservation (and its lines) keeps its own occupancy and children.

## Notes

The underlying `room_id`-keyed collapse can in principle affect any channel that books multiple rooms of the same type with different occupancy, but only Booking.com provides per-room data to reconstruct it; other channels are intentionally left unchanged.