### PR TITLE
[IMP] pms_fastapi: guard free-text searches with min length (RFC 9457)

### DIFF
--- a/.claude/skills/roomdoo-fastapi-conventions/SKILL.md
+++ b/.claude/skills/roomdoo-fastapi-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roomdoo-fastapi-conventions
-description: "Conventions and patterns for developing FastAPI endpoints and Pydantic schemas in the Roomdoo project (roomdoo-modules). Use when creating or modifying FastAPI routers, Pydantic schemas, or extending pms_fastapi modules. Covers endpoint naming, helper patterns, data model conventions, CurrencyAmount usage, and module organization."
+description: "Conventions and patterns for developing FastAPI endpoints and Pydantic schemas in the Roomdoo project (roomdoo-modules). Use when creating or modifying FastAPI routers, Pydantic schemas, error responses, or search filters, or extending pms_fastapi modules. Covers endpoint naming, helper patterns, RFC 9457 problem+json errors, free-text search guards, data model conventions, CurrencyAmount usage, and module organization."
 globs:
   - "**/roomdoo-modules/**/routers/**"
   - "**/roomdoo-modules/**/schemas/**"
@@ -42,7 +42,12 @@ Endpoints delegate ALL logic to a **helper** (Odoo `AbstractModel`), making it i
 
 ```python
 @pms_api_router.get("/invoices", response_model=PagedCollection[InvoiceSummary])
-async def list_invoices(env, filters, paging, orderBy):
+async def list_invoices(
+    env: AuthenticatedEnv,
+    filters: Annotated[InvoiceSearch, Depends()],
+    paging: Annotated[Paging, Depends(paging)],
+    orderBy: Annotated[str, Depends(ContactOrderDependency)],
+):
     count, invoices = env["pms_api_invoice.invoice_router.helper"].new()._search(paging, filters, orderBy)
     return PagedCollection[InvoiceSummary](
         count=count,
@@ -72,9 +77,56 @@ class PmsApiInvoiceRouterHelper(models.AbstractModel):
 
 Helpers are inherited via `_inherit`: `_inherit = "pms_api_contact.contact_router.helper"`
 
+### Error Responses (RFC 9457)
+
+Client/business errors are returned as **RFC 9457 problem+json**, by **returning** a
+`JSONResponse` (NOT by raising). Raised exceptions go through the rest-framework handler
+(`convert_exception_to_status_body`), which wraps them as plain `{"detail": ...}` with
+`application/json` and no machine-readable code — too generic for the front to branch on.
+So for any error the front must distinguish, RETURN a problem+json:
+
+```python
+from fastapi.responses import JSONResponse
+
+return JSONResponse(
+    status_code=400,
+    media_type="application/problem+json",
+    content={
+        "type": "/errors/record-limit-exceeded",   # relative URI, kebab-case
+        "title": "Record limit exceeded",
+        "status": 400,                              # mirror status_code
+        "detail": f"The export requested {count} records, max is {max_records}.",
+        "requestedCount": count,                    # extension members: extra context
+        "maxAllowed": max_records,
+    },
+)
+```
+
+Rules:
+- An endpoint typed `-> SomeModel` may still `return` a `JSONResponse` for the error path
+  (FastAPI honours it). Keep the happy path returning the model.
+- `type` is a relative URI `/errors/<kebab-case>`; `title` is short and stable per `type`;
+  `status` mirrors `status_code`; `detail` is human-readable; add extension members for
+  machine-usable context (ids, counts, limits, offending `field`).
+- Don't leak Odoo internals (model/field/state names) in `detail`/members.
+- There's no shared problem+json builder yet; most are inline. Reuse one if present for
+  your error `type` (e.g. the search-text guard builder in
+  `pms_fastapi/models/fastapi_endpoint.py`).
+
 ## Data Models (Pydantic Schemas)
 
 All schemas inherit from `PmsBaseModel` (`odoo.addons.pms_fastapi.schemas.base`).
+
+### Reglas Pydantic (capa schema, no runtime)
+
+- Campos required: solo la anotación de tipo, **nunca** `...` (`name: str`, no
+  `name: str = Field(...)`).
+- **No usar `RootModel`**. Para listas, anotar el tipo de retorno
+  (`-> list[ServiceProduct]`) o `Annotated[list[X], Body()]` en el endpoint.
+- Preferir **anotación de tipo de retorno** para el filtrado/serialización; reservar
+  `response_model=` para cuando el tipo interno difiere del público (alinea con
+  "no exponer internos de Odoo"). Hoy conviven ambos estilos en el código — sin
+  obligación de unificar los endpoints existentes.
 
 ### Naming
 
@@ -121,3 +173,33 @@ class InvoiceSearch(BaseSearch):
             domain = expression.AND([domain, [("name", "ilike", self.name)]])
         return domain
 ```
+
+#### Free-text minimum-length guard
+
+Type every **free-text** (`ilike`) query param with `SearchText` (from `schemas.base`)
+instead of `str | None`. A value that is non-empty but shorter than
+`MIN_SEARCH_TEXT_LENGTH` (3) is rejected automatically with a problem+json
+(`type="/errors/search-text-too-short"`, `field`, `minLength`) **before** the endpoint
+runs — done by `PmsApiRouter`, which wraps any endpoint with a `BaseSearch` param. No
+per-field `if`, no per-endpoint code, and new search endpoints are covered automatically.
+
+```python
+from .base import BaseSearch, SearchText
+
+class ContactSearch(BaseSearch):
+    def __init__(
+        self,
+        # default-style: Query() as the default value
+        name: SearchText = Query(default=None, description="..."),
+        # Annotated-style also works:
+        # foo: Annotated[SearchText, Query(description="...")] = None,
+        types: list[ContactType] | None = Query(default=None),  # NOT marked
+    ):
+        ...
+```
+
+- Mark only scalar free-text fields. Do NOT mark lists, enums, ids, dates or booleans.
+- Don't use `Query(min_length=...)`: it yields a generic 422, not the structured
+  problem+json the front branches on.
+- Empty/whitespace means "no filter" (not an error). The attribute name must match the
+  `__init__` param name (the guard reads `getattr(self, param_name)`).

--- a/pms_fastapi/models/fastapi_endpoint.py
+++ b/pms_fastapi/models/fastapi_endpoint.py
@@ -1,11 +1,16 @@
+import functools
 import os
 import time
 from pathlib import Path
+from typing import Annotated, get_args, get_origin, get_type_hints
 
 from fastapi import APIRouter, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from odoo import api, fields, models
+
+from ..schemas.base import MIN_SEARCH_TEXT_LENGTH, BaseSearch
 
 APP_NAME = "pms_api"
 
@@ -131,4 +136,65 @@ class FastapiEndpoint(models.Model):
         return params
 
 
-pms_api_router = APIRouter()
+def _search_text_too_short_problem(field: str) -> JSONResponse:
+    """RFC 9457 problem+json for a free-text search value below the minimum length."""
+    return JSONResponse(
+        status_code=400,
+        media_type="application/problem+json",
+        content={
+            "type": "/errors/search-text-too-short",
+            "title": "Search text too short",
+            "status": 400,
+            "detail": (
+                f"Search text must be at least {MIN_SEARCH_TEXT_LENGTH} characters."
+            ),
+            "field": field,
+            "minLength": MIN_SEARCH_TEXT_LENGTH,
+        },
+    )
+
+
+def _endpoint_search_param(endpoint) -> str | None:
+    """Name of the endpoint param typed as a BaseSearch subclass, if any."""
+    for name, hint in get_type_hints(endpoint, include_extras=True).items():
+        annotated = get_args(hint)[0] if get_origin(hint) is Annotated else hint
+        if isinstance(annotated, type) and issubclass(annotated, BaseSearch):
+            return name
+    return None
+
+
+def _guard_search_text(endpoint):
+    """Wrap an endpoint so its BaseSearch filter is checked for too-short text.
+
+    Returns the endpoint unchanged when it has no BaseSearch param. The wrapper
+    keeps the original signature (functools.wraps) so FastAPI still introspects
+    the real params.
+    """
+    search_param = _endpoint_search_param(endpoint)
+    if search_param is None:
+        return endpoint
+
+    @functools.wraps(endpoint)
+    async def wrapper(*args, **kwargs):
+        filters = kwargs.get(search_param)
+        if filters is not None:
+            field = filters.first_short_search_text()
+            if field is not None:
+                return _search_text_too_short_problem(field)
+        return await endpoint(*args, **kwargs)
+
+    return wrapper
+
+
+class PmsApiRouter(APIRouter):
+    """APIRouter that auto-applies the free-text search length guard.
+
+    Any endpoint with a BaseSearch param is wrapped at registration time, so the
+    guard needs no per-endpoint code and covers future search endpoints too.
+    """
+
+    def add_api_route(self, path, endpoint, **kwargs):
+        return super().add_api_route(path, _guard_search_text(endpoint), **kwargs)
+
+
+pms_api_router = PmsApiRouter()

--- a/pms_fastapi/schemas/agency.py
+++ b/pms_fastapi/schemas/agency.py
@@ -6,7 +6,7 @@ from fastapi import Query
 from odoo import api
 from odoo.osv import expression
 
-from odoo.addons.pms_fastapi.schemas.base import BaseSearch
+from odoo.addons.pms_fastapi.schemas.base import BaseSearch, SearchText
 from odoo.addons.pms_fastapi.schemas.contact import ContactBase, ContactIdImage
 
 
@@ -44,26 +44,33 @@ class AgencySummary(ContactBase):
 class AgencySearch(BaseSearch):
     def __init__(
         self,
-        globalSearch: str | None = Query(
-            default=None,
-            description="Search across name, email, phone and VAT fields"
-            "this value (case-insensitive).",
-        ),
-        name: str | None = Query(
-            default=None,
-            description="Search for contacts whose name contains "
-            "this value (case-insensitive).",
-        ),
-        phone: str | None = Query(
-            default=None,
-            min_length=3,
-            description="Search for contacts whose phones contains " "this value.",
-        ),
-        email: str | None = Query(
-            default=None,
-            description="Search for contacts whose email contains this "
-            "value (case-insensitive).",
-        ),
+        globalSearch: Annotated[
+            SearchText,
+            Query(
+                description="Search across name, email, phone and VAT fields"
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        name: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose name contains "
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        phone: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose phones contains " "this value.",
+            ),
+        ] = None,
+        email: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose email contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
         countries: Annotated[
             list[str] | None,
             Query(
@@ -89,9 +96,8 @@ class AgencySearch(BaseSearch):
                 ("email", "ilike", self.globalSearch),
                 ("vat", "ilike", self.globalSearch),
             ]
-            if len(self.globalSearch) >= 3:
-                phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
-                domain = expression.OR([domain, phone_domain])
+            phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
+            domain = expression.OR([domain, phone_domain])
         if self.name:
             domain.append(("display_name", "ilike", self.name))
         if self.phone:

--- a/pms_fastapi/schemas/base.py
+++ b/pms_fastapi/schemas/base.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, get_args, get_type_hints
 
 from extendable_pydantic import StrictExtendableBaseModel
 from pydantic import ConfigDict, model_validator
@@ -13,6 +13,22 @@ class _CurrencyMarker:
 
 
 CurrencyAmount = Annotated[float, _CurrencyMarker()]
+
+
+# Minimum length a free-text search value must have before it is used to filter.
+# Shorter (but non-empty) values are rejected; empty/whitespace means "no filter".
+MIN_SEARCH_TEXT_LENGTH = 3
+
+
+class _SearchTextMarker:
+    pass
+
+
+# Type alias to declaratively mark a search query param as a guarded free-text field.
+# Annotate a *Search __init__ param with ``SearchText`` and the length guard applies
+# automatically (see PmsApiRouter in models/fastapi_endpoint.py). The marker is inert
+# for FastAPI, which only consumes FieldInfo/Query metadata.
+SearchText = Annotated[str | None, _SearchTextMarker()]
 
 
 class PmsBaseModel(StrictExtendableBaseModel):
@@ -134,9 +150,54 @@ class PmsBaseModel(StrictExtendableBaseModel):
         return data
 
 
+_search_text_fields_cache: dict[type, tuple[str, ...]] = {}
+
+
+def _has_search_text_marker(annotation) -> bool:
+    """Whether ``annotation`` carries the SearchText marker, anywhere inside.
+
+    Recurses through Union/Optional and nested Annotated because get_type_hints
+    wraps params defaulting to ``None`` in ``Optional[...]``, which hides the
+    marker from the top-level ``__metadata__``.
+    """
+    if any(
+        isinstance(meta, _SearchTextMarker)
+        for meta in getattr(annotation, "__metadata__", ())
+    ):
+        return True
+    return any(_has_search_text_marker(arg) for arg in get_args(annotation))
+
+
 class BaseSearch:
     def to_odoo_domain(self, env: api.Environment) -> list:
         return []
 
     def to_odoo_context(self, env: api.Environment) -> dict:
         return {}
+
+    @classmethod
+    def _search_text_field_names(cls) -> tuple[str, ...]:
+        """Names of the __init__ params marked as guarded free-text (``SearchText``)."""
+        cached = _search_text_fields_cache.get(cls)
+        if cached is None:
+            hints = get_type_hints(cls.__init__, include_extras=True)
+            cached = tuple(
+                name for name, hint in hints.items() if _has_search_text_marker(hint)
+            )
+            _search_text_fields_cache[cls] = cached
+        return cached
+
+    def first_short_search_text(self) -> str | None:
+        """First guarded text field whose value is non-empty but too short.
+
+        Returns the offending param name, or None when every guarded field is
+        empty/whitespace (no filter) or long enough.
+        """
+        for name in self._search_text_field_names():
+            value = getattr(self, name, None)
+            if value is None:
+                continue
+            stripped = value.strip()
+            if stripped and len(stripped) < MIN_SEARCH_TEXT_LENGTH:
+                return name
+        return None

--- a/pms_fastapi/schemas/contact.py
+++ b/pms_fastapi/schemas/contact.py
@@ -8,7 +8,7 @@ from pydantic import AnyHttpUrl, Field
 from odoo import api
 from odoo.osv import expression
 
-from .base import BaseSearch, PmsBaseModel
+from .base import BaseSearch, PmsBaseModel, SearchText
 from .contact_id_number import ContactIdNumberId
 from .contact_tag import ContactTagId
 from .country import CountryId, CountrySummary
@@ -301,26 +301,33 @@ class ContactUpdate(ContactInsert):
 class ContactSearch(BaseSearch):
     def __init__(
         self,
-        globalSearch: str | None = Query(
-            default=None,
-            description="Search across name, email, phone and VAT fields"
-            "this value (case-insensitive).",
-        ),
-        name: str | None = Query(
-            default=None,
-            description="Search for contacts whose name contains "
-            "this value (case-insensitive).",
-        ),
-        phone: str | None = Query(
-            default=None,
-            min_length=3,
-            description="Search for contacts whose phones contains " "this value.",
-        ),
-        email: str | None = Query(
-            default=None,
-            description="Search for contacts whose email contains this "
-            "value (case-insensitive).",
-        ),
+        globalSearch: Annotated[
+            SearchText,
+            Query(
+                description="Search across name, email, phone and VAT fields"
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        name: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose name contains "
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        phone: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose phones contains " "this value.",
+            ),
+        ] = None,
+        email: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose email contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
         types: Annotated[
             list[ContactType] | None,
             Query(
@@ -356,9 +363,8 @@ class ContactSearch(BaseSearch):
                 ("vat", "ilike", self.globalSearch),
                 ("identification_number", "ilike", self.globalSearch),
             ]
-            if len(self.globalSearch) >= 3:
-                phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
-                domain = expression.OR([domain, phone_domain])
+            phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
+            domain = expression.OR([domain, phone_domain])
         if self.name:
             domain.append(("display_name", "ilike", self.name))
         if self.phone:

--- a/pms_fastapi/schemas/customer.py
+++ b/pms_fastapi/schemas/customer.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from odoo import api
 from odoo.osv import expression
 
-from odoo.addons.pms_fastapi.schemas.base import BaseSearch
+from odoo.addons.pms_fastapi.schemas.base import BaseSearch, SearchText
 from odoo.addons.pms_fastapi.schemas.contact import ContactBase
 
 from .base import CurrencyAmount
@@ -51,31 +51,40 @@ class CustomerSearch(BaseSearch):
             default=None,
             description="Filter totalInvoiced by property.",
         ),
-        globalSearch: str | None = Query(
-            default=None,
-            description="Search across name, email, phone and VAT fields"
-            "this value (case-insensitive).",
-        ),
-        vat: str | None = Query(
-            default=None,
-            description="Search for contacts whose VAT contains this "
-            "value (case-insensitive).",
-        ),
-        name: str | None = Query(
-            default=None,
-            description="Search for contacts whose name contains "
-            "this value (case-insensitive).",
-        ),
-        phone: str | None = Query(
-            default=None,
-            min_length=3,
-            description="Search for contacts whose phones contains " "this value.",
-        ),
-        email: str | None = Query(
-            default=None,
-            description="Search for contacts whose email contains this "
-            "value (case-insensitive).",
-        ),
+        globalSearch: Annotated[
+            SearchText,
+            Query(
+                description="Search across name, email, phone and VAT fields"
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        vat: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose VAT contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
+        name: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose name contains "
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        phone: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose phones contains " "this value.",
+            ),
+        ] = None,
+        email: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose email contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
         countries: Annotated[
             list[str] | None,
             Query(
@@ -106,9 +115,8 @@ class CustomerSearch(BaseSearch):
                 ("email", "ilike", self.globalSearch),
                 ("vat", "ilike", self.globalSearch),
             ]
-            if len(self.globalSearch) >= 3:
-                phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
-                domain = expression.OR([domain, phone_domain])
+            phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
+            domain = expression.OR([domain, phone_domain])
         if self.vat:
             domain.append(("vat", "ilike", self.vat))
         if self.name:

--- a/pms_fastapi/schemas/guest.py
+++ b/pms_fastapi/schemas/guest.py
@@ -8,7 +8,7 @@ from fastapi.params import Query as QueryType
 from odoo import api
 from odoo.osv import expression
 
-from odoo.addons.pms_fastapi.schemas.base import BaseSearch
+from odoo.addons.pms_fastapi.schemas.base import BaseSearch, SearchText
 from odoo.addons.pms_fastapi.schemas.contact import ContactBase
 from odoo.addons.pms_fastapi.schemas.id_document import IdDocument
 
@@ -50,35 +50,44 @@ class GuestSearch(BaseSearch):
             default=None,
             description="Filter guests of the given property.",
         ),
-        globalSearch: str | None = Query(
-            default=None,
-            description="Search across name, email, phone and VAT fields"
-            "this value (case-insensitive).",
-        ),
-        vat: str | None = Query(
-            default=None,
-            description="Search for contacts whose VAT contains this "
-            "value (case-insensitive).",
-        ),
+        globalSearch: Annotated[
+            SearchText,
+            Query(
+                description="Search across name, email, phone and VAT fields"
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        vat: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose VAT contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
         inHouse: bool | None = Query(
             default=False,
             description="Search for contacts in house. Boolean value ",
         ),
-        name: str | None = Query(
-            default=None,
-            description="Search for contacts whose name contains "
-            "this value (case-insensitive).",
-        ),
-        phone: str | None = Query(
-            default=None,
-            min_length=3,
-            description="Search for contacts whose phones contains " "this value.",
-        ),
-        email: str | None = Query(
-            default=None,
-            description="Search for contacts whose email contains this "
-            "value (case-insensitive).",
-        ),
+        name: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose name contains "
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        phone: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose phones contains " "this value.",
+            ),
+        ] = None,
+        email: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose email contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
         countries: Annotated[
             list[str] | None,
             Query(
@@ -175,9 +184,8 @@ class GuestSearch(BaseSearch):
                 ("vat", "ilike", self.globalSearch),
                 ("identification_number", "ilike", self.globalSearch),
             ]
-            if len(self.globalSearch) >= 3:
-                phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
-                domain = expression.OR([domain, phone_domain])
+            phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
+            domain = expression.OR([domain, phone_domain])
         if self.vat:
             id_numbers = (
                 env["res.partner.id_number"]

--- a/pms_fastapi/schemas/invoice.py
+++ b/pms_fastapi/schemas/invoice.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from odoo import api
 from odoo.osv import expression
 
-from .base import BaseSearch, CurrencyAmount, PmsBaseModel
+from .base import BaseSearch, CurrencyAmount, PmsBaseModel, SearchText
 from .contact import ContactId
 from .currency import CurrencySummary
 from .journal import JournalSummary
@@ -192,25 +192,31 @@ class InvoiceSearch(BaseSearch):
             default=None,
             description="Filter guests of the given property.",
         ),
-        globalSearch: str | None = Query(
-            default=None,
-            description="Search across number, origin, reference, "
-            "payment reference, contact(email, vat, name).",
-        ),
+        globalSearch: Annotated[
+            SearchText,
+            Query(
+                description="Search across number, origin, reference, "
+                "payment reference, contact(email, vat, name).",
+            ),
+        ] = None,
         invoiceType: Annotated[
             InvoiceTypeEnum | None,
             Query(
                 description="Filter by invoice type.",
             ),
         ] = None,
-        name: str | None = Query(
-            default=None,
-            description="Filter by invoice number.",
-        ),
-        reference: str | None = Query(
-            default=None,
-            description="Filter by invoice reference.",
-        ),
+        name: Annotated[
+            SearchText,
+            Query(
+                description="Filter by invoice number.",
+            ),
+        ] = None,
+        reference: Annotated[
+            SearchText,
+            Query(
+                description="Filter by invoice reference.",
+            ),
+        ] = None,
         totalAmountGt: Annotated[
             float | None,
             Query(
@@ -274,10 +280,12 @@ class InvoiceSearch(BaseSearch):
                 "parameters, e.g., ?paymentMethod=1&paymentMethod=2",
             ),
         ] = None,
-        partner: str | None = Query(
-            default=None,
-            description="Filter by partner name.",
-        ),
+        partner: Annotated[
+            SearchText,
+            Query(
+                description="Filter by partner name.",
+            ),
+        ] = None,
     ):
         self.pmsProperty = pmsPropertyId
         self.globalSearch = globalSearch

--- a/pms_fastapi/schemas/pms_folio.py
+++ b/pms_fastapi/schemas/pms_folio.py
@@ -10,7 +10,7 @@ from odoo import api
 from odoo.osv import expression
 
 from .agency import AgencyIdImage
-from .base import BaseSearch, CurrencyAmount, PmsBaseModel
+from .base import BaseSearch, CurrencyAmount, PmsBaseModel, SearchText
 from .contact import ContactIdImage
 from .country import CountrySummary
 from .currency import CurrencySummary
@@ -261,14 +261,14 @@ class FolioSearch(BaseSearch):
             ),
         ] = None,
         globalSearch: Annotated[
-            str | None,
+            SearchText,
             Query(
                 description="Search across folio name, external reference, "
                 "and customer name.",
             ),
         ] = None,
         name: Annotated[
-            str | None,
+            SearchText,
             Query(
                 description="Search for folios whose name contains "
                 "this value (case-insensitive).",
@@ -287,7 +287,7 @@ class FolioSearch(BaseSearch):
             ),
         ] = None,
         room: Annotated[
-            str | None,
+            SearchText,
             Query(
                 description="Search for folios whose room is " "this value.",
             ),
@@ -311,13 +311,13 @@ class FolioSearch(BaseSearch):
             ),
         ] = None,
         saleChannel: Annotated[
-            str | None,
+            SearchText,
             Query(
                 description="Search for folios whose sale channel is " "this value.",
             ),
         ] = None,
         agency: Annotated[
-            str | None,
+            SearchText,
             Query(
                 description="Search for folios whose agency is " "this value.",
             ),
@@ -344,7 +344,7 @@ class FolioSearch(BaseSearch):
             ),
         ] = None,
         origin: Annotated[
-            str | None,
+            SearchText,
             Query(
                 description="Combined search of channel and agency.",
             ),

--- a/pms_fastapi/schemas/supplier.py
+++ b/pms_fastapi/schemas/supplier.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from odoo import api
 from odoo.osv import expression
 
-from odoo.addons.pms_fastapi.schemas.base import BaseSearch
+from odoo.addons.pms_fastapi.schemas.base import BaseSearch, SearchText
 from odoo.addons.pms_fastapi.schemas.contact import ContactBase
 
 from .base import CurrencyAmount
@@ -53,31 +53,40 @@ class SupplierSearch(BaseSearch):
             default=None,
             description="Filter totalInvoiced by property.",
         ),
-        globalSearch: str | None = Query(
-            default=None,
-            description="Search across name, email, phone and VAT fields"
-            "this value (case-insensitive).",
-        ),
-        vat: str | None = Query(
-            default=None,
-            description="Search for contacts whose VAT contains this "
-            "value (case-insensitive).",
-        ),
-        name: str | None = Query(
-            default=None,
-            description="Search for contacts whose name contains "
-            "this value (case-insensitive).",
-        ),
-        phone: str | None = Query(
-            default=None,
-            min_length=3,
-            description="Search for contacts whose phones contains " "this value.",
-        ),
-        email: str | None = Query(
-            default=None,
-            description="Search for contacts whose email contains this "
-            "value (case-insensitive).",
-        ),
+        globalSearch: Annotated[
+            SearchText,
+            Query(
+                description="Search across name, email, phone and VAT fields"
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        vat: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose VAT contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
+        name: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose name contains "
+                "this value (case-insensitive).",
+            ),
+        ] = None,
+        phone: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose phones contains " "this value.",
+            ),
+        ] = None,
+        email: Annotated[
+            SearchText,
+            Query(
+                description="Search for contacts whose email contains this "
+                "value (case-insensitive).",
+            ),
+        ] = None,
         countries: Annotated[
             list[str] | None,
             Query(
@@ -108,9 +117,8 @@ class SupplierSearch(BaseSearch):
                 ("email", "ilike", self.globalSearch),
                 ("vat", "ilike", self.globalSearch),
             ]
-            if len(self.globalSearch) >= 3:
-                phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
-                domain = expression.OR([domain, phone_domain])
+            phone_domain = [("phone_mobile_search", "ilike", self.globalSearch)]
+            domain = expression.OR([domain, phone_domain])
         if self.vat:
             domain.append(("vat", "ilike", self.vat))
         if self.name:

--- a/pms_fastapi/tests/__init__.py
+++ b/pms_fastapi/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_agencies
 from . import test_customers
 from . import test_guests
 from . import test_suppliers
+from . import test_search_text_guard

--- a/pms_fastapi/tests/test_search_text_guard.py
+++ b/pms_fastapi/tests/test_search_text_guard.py
@@ -1,0 +1,61 @@
+from fastapi import status
+
+from odoo.addons.pms_fastapi.tests.common import CommonTestPmsApi
+
+
+class TestSearchTextGuard(CommonTestPmsApi):
+    """Free-text search length guard (PmsApiRouter + SearchText marker).
+
+    These exercise the behaviour the module adds on top of FastAPI: marked
+    free-text params shorter than the minimum are rejected with an RFC 9457
+    problem+json, while empty/long values and unmarked params pass through.
+    """
+
+    def _assert_too_short(self, response, field):
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.text
+        )
+        self.assertEqual(response.headers["content-type"], "application/problem+json")
+        body = response.json()
+        self.assertEqual(body["type"], "/errors/search-text-too-short")
+        self.assertEqual(body["status"], 400)
+        self.assertEqual(body["field"], field)
+        self.assertEqual(body["minLength"], 3)
+
+    def test_short_text_is_rejected(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/agencies", params={"name": "ab"})
+            self._assert_too_short(response, "name")
+
+    def test_short_global_search_is_rejected(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/agencies", params={"globalSearch": "ab"})
+            self._assert_too_short(response, "globalSearch")
+
+    def test_long_enough_text_passes(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/agencies", params={"name": "abc"})
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+
+    def test_empty_text_is_no_filter(self):
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/agencies", params={"name": ""})
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+
+    def test_unmarked_param_is_not_guarded(self):
+        # `countries` is a list filter, not marked as free-text search.
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/agencies", params={"countries": "ES"})
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.text)
+
+    def test_guard_covers_annotated_style_schema(self):
+        # FolioSearch marks fields with Annotated[SearchText, Query(...)].
+        with self._create_test_client() as test_client:
+            self._login(test_client)
+            response = test_client.get("/folios", params={"room": "ab"})
+            self._assert_too_short(response, "room")


### PR DESCRIPTION
## Qué

Guarda escalable de **longitud mínima** para las búsquedas por texto de la API
(`pms_fastapi`), con error en formato **RFC 9457 problem+json** para que el front pueda
distinguir el caso "texto demasiado corto".

Antes solo `phone` tenía `Query(min_length=3)` y `globalSearch` un `if len >= 3` suelto:
no escalaba a todos los campos y devolvía un 422 genérico de Pydantic.

## Cómo

- Nuevo tipo marcador `SearchText` (`schemas/base.py`): se anota el parámetro de texto
  libre con `SearchText` en lugar de `str | None`.
- `PmsApiRouter` (`models/fastapi_endpoint.py`) envuelve automáticamente cualquier
  endpoint con un parámetro `BaseSearch`: si un campo marcado trae un valor no vacío de
  longitud `< MIN_SEARCH_TEXT_LENGTH` (3), **devuelve** un problem+json **antes** de
  ejecutar el endpoint. Sin `if` por campo, sin código por endpoint, y los endpoints de
  búsqueda futuros quedan cubiertos solos.
- Campos marcados en: contact, agency, customer, guest, supplier, invoice y folio
  (params de texto migrados al estilo `Annotated[...]`). Vacío/whitespace = sin filtro
  (no error).

## Respuesta de error (ejemplo exacto)

`GET /contacts?name=ab` →

```
HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
```
```json
{
  "type": "/errors/search-text-too-short",
  "title": "Search text too short",
  "status": 400,
  "detail": "Search text must be at least 3 characters.",
  "field": "name",
  "minLength": 3
}
```

`field` es el nombre del query param ofensor (p. ej. `name`, `globalSearch`, `room`).
Para el front, la señal a detectar es `type == "/errors/search-text-too-short"`.

## Tests

- `tests/test_search_text_guard.py` (end-to-end vía `FastAPITransactionCase`): casos 400
  (ambos estilos de anotación), 200, vacío, y param no marcado.
- Suite completa de `pms_fastapi` en verde: 0 failed, 0 error(s) of 56 tests.

## Convención documentada

Se actualiza la skill `roomdoo-fastapi-conventions` con la sección de errores RFC 9457 y
la guarda de búsqueda.

---

## ⚠️ Antes de mergear: cohesionar con otras PR de la API

Esta PR toca los **schemas de búsqueda** (`*Search`) de `pms_fastapi` y migra sus
parámetros de texto al estilo `Annotated[...]`. Hay otras PR abiertas que también
modifican endpoints/schemas de la API y que podrían:

- añadir nuevos campos de búsqueda de texto (habrá que marcarlos con `SearchText`),
- modificar las firmas de los mismos `*Search` (posibles conflictos de merge en
  contact/agency/customer/guest/supplier/invoice/folio),
- introducir errores que deberían adoptar el mismo formato RFC 9457.

**Acción requerida antes del merge:** revisar las PR de la API que estén en vuelo,
resolver conflictos y asegurar que los campos de texto nuevos quedan marcados con
`SearchText` y que los errores siguen la convención problem+json. Se mantiene en
**DRAFT** hasta esa reconciliación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
