### PR TITLE
[IMP] pms_api_rest: structured code when folio PUT hits invoiced lines

### DIFF
--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -1,11 +1,12 @@
 import base64
+import json
 import logging
 from datetime import datetime, timedelta
 
 import pytz
 
 from odoo import _, fields
-from odoo.exceptions import AccessError, MissingError, ValidationError
+from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import get_lang
 
@@ -2093,6 +2094,35 @@ class PmsFolioService(Component):
 
     # TEMP
 
+    def _folio_has_locked_invoiced_lines(self, folio):
+        """Return True if the folio has posted (non-reversed) customer invoices
+        or any sale line with quantity already invoiced. Callers use this to
+        surface a specific API error code when a PUT fails because the folio
+        cannot be modified due to invoicing."""
+        if not folio or not folio.exists():
+            return False
+        has_posted_invoice = any(
+            move.state == "posted"
+            and move.move_type == "out_invoice"
+            and move.payment_state != "reversed"
+            for move in folio.move_ids
+        )
+        if has_posted_invoice:
+            return True
+        return any(line.qty_invoiced > 0 for line in folio.sale_line_ids)
+
+    def _raise_folio_invoiced_error(self, error):
+        """Re-raise a UserError as a structured API error so external clients
+        can react to the specific "folio has invoiced lines" case."""
+        raise ValidationError(
+            json.dumps(
+                {
+                    "code": "FOLIO_HAS_INVOICED_LINES",
+                    "message": str(error),
+                }
+            )
+        ) from error
+
     @restapi.method(
         [
             (
@@ -2114,6 +2144,7 @@ class PmsFolioService(Component):
         max_checkout_payload = max(
             pms_folio_info.reservations, key=lambda x: x.checkout
         ).checkout
+        folio = self.env["pms.folio"]
         try:
             folio = (
                 self.env["pms.folio"]
@@ -2178,6 +2209,10 @@ class PmsFolioService(Component):
                     "request_type": "folios",
                 }
             )
+            if isinstance(e, UserError) and self._folio_has_locked_invoiced_lines(
+                folio
+            ):
+                self._raise_folio_invoiced_error(e)
             if not external_app:
                 raise ValidationError(_("Error updating folio from API: %s") % e) from e
             else:
@@ -2204,6 +2239,7 @@ class PmsFolioService(Component):
         max_checkout_payload = max(
             pms_folio_info.reservations, key=lambda x: x.checkout
         ).checkout
+        folio = self.env["pms.folio"]
         try:
             folio = self.env["pms.folio"].sudo().browse(folio_id)
             if not folio:
@@ -2260,6 +2296,10 @@ class PmsFolioService(Component):
                     "request_type": "folios",
                 }
             )
+            if isinstance(e, UserError) and self._folio_has_locked_invoiced_lines(
+                folio
+            ):
+                self._raise_folio_invoiced_error(e)
             if not external_app:
                 raise ValidationError(_("Error updating folio from API: %s") % e) from e
             else:

--- a/pms_api_rest/tests/__init__.py
+++ b/pms_api_rest/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_folio_invoiced_error_code
 from . import test_pms_board_service_room_type
 from . import test_roomdoo_app_menu
 from . import test_various_partner_protection

--- a/pms_api_rest/tests/test_folio_invoiced_error_code.py
+++ b/pms_api_rest/tests/test_folio_invoiced_error_code.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Commit [Sun]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""External clients that hit the ``/folios`` PUT endpoints need a stable,
+machine-readable error when the target folio cannot be modified/cancelled
+because it has invoiced lines. Otherwise every backend ``UserError`` looks
+the same and callers cannot distinguish this specific business condition
+from any other validation failure.
+
+These tests cover the two API-side pieces that make the code
+``FOLIO_HAS_INVOICED_LINES`` reach the client:
+
+* ``_folio_has_locked_invoiced_lines`` — the guard used to decide whether
+  the current failure is caused by invoicing.
+* ``_raise_folio_invoiced_error`` — the wrapper that turns the underlying
+  ``UserError`` into a ``ValidationError`` whose message is a JSON payload
+  with the ``code`` field.
+* the ``update_put_folio`` end-to-end flow, forcing the update path to
+  raise a ``UserError`` on a folio that already has a posted invoice.
+"""
+import datetime
+import json
+from unittest.mock import patch
+
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.component.core import WorkContext
+from odoo.addons.pms.tests.common import TestPms
+
+
+@tagged("post_install", "-at_install")
+class TestFolioInvoicedErrorCode(TestPms, AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Use admin (uid=1) so record rules do not get in the way; the API
+        # endpoint itself sudo()es its lookups.
+        cls.env = cls.env(user=cls.env["res.users"].browse(1))
+
+        cls.simplified_journal = cls.env["account.journal"].create(
+            {
+                "name": "Simplified journal",
+                "code": "SMPT",
+                "type": "sale",
+                "company_id": cls.env.ref("base.main_company").id,
+            }
+        )
+        cls.property = cls.env["pms.property"].create(
+            {
+                "name": "Property for invoiced-error tests",
+                "company_id": cls.env.ref("base.main_company").id,
+                "default_pricelist_id": cls.pricelist1.id,
+                "journal_simplified_invoice_id": cls.simplified_journal.id,
+            }
+        )
+        cls.room_type = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.property.id],
+                "name": "Double Test",
+                "default_code": "DBL_ERR",
+                "class_id": cls.room_type_class1.id,
+                "list_price": 25,
+            }
+        )
+        cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.property.id,
+                "name": "Room 101",
+                "room_type_id": cls.room_type.id,
+                "capacity": 2,
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Guest",
+                "vat": "45224522J",
+                "country_id": cls.env.ref("base.es").id,
+                "city": "Madrid",
+                "zip": "28013",
+                "street": "Calle Falsa 1",
+            }
+        )
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Direct", "channel_type": "direct"}
+        )
+
+    def _make_folio(self):
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.property.id,
+                "checkin": datetime.datetime.now(),
+                "checkout": datetime.datetime.now() + datetime.timedelta(days=2),
+                "adults": 2,
+                "room_type_id": self.room_type.id,
+                "partner_id": self.partner.id,
+                "sale_channel_origin_id": self.sale_channel.id,
+            }
+        )
+        return reservation.folio_id
+
+    def _folio_service(self):
+        collection = _PseudoCollection("pms.services", self.env)
+        work = WorkContext(
+            model_name="rest.service.registration", collection=collection
+        )
+        return work.component(usage="folios")
+
+    # ---- helper ------------------------------------------------------------
+
+    def test_helper_false_when_folio_has_no_invoice(self):
+        folio = self._make_folio()
+        self.assertFalse(self._folio_service()._folio_has_locked_invoiced_lines(folio))
+
+    def test_helper_false_when_invoice_is_only_draft(self):
+        folio = self._make_folio()
+        folio._create_invoices()
+        # A draft move alone does not lock the folio: qty_invoiced is only
+        # incremented when the move is posted.
+        self.assertEqual(folio.move_ids.state, "draft")
+        self.assertFalse(self._folio_service()._folio_has_locked_invoiced_lines(folio))
+
+    def test_helper_true_when_invoice_is_posted(self):
+        folio = self._make_folio()
+        folio._create_invoices()
+        folio.move_ids.action_post()
+        self.assertTrue(self._folio_service()._folio_has_locked_invoiced_lines(folio))
+
+    def test_helper_false_for_empty_recordset(self):
+        empty = self.env["pms.folio"]
+        self.assertFalse(self._folio_service()._folio_has_locked_invoiced_lines(empty))
+
+    # ---- structured error --------------------------------------------------
+
+    def test_raise_folio_invoiced_error_shape(self):
+        service = self._folio_service()
+        with self.assertRaises(ValidationError) as cm:
+            service._raise_folio_invoiced_error(UserError("locked line"))
+        payload = json.loads(cm.exception.args[0])
+        self.assertEqual(payload["code"], "FOLIO_HAS_INVOICED_LINES")
+        self.assertEqual(payload["message"], "locked line")
+
+    # ---- endpoint ----------------------------------------------------------
+
+    def _build_put_payload(self, folio):
+        reservation = folio.reservation_ids[0]
+        ReservationInfo = self.env.datamodels["pms.reservation.info"]
+        reservation_info = ReservationInfo(partial=True)
+        reservation_info.id = reservation.id
+        reservation_info.checkin = reservation.checkin.strftime("%Y-%m-%d")
+        reservation_info.checkout = reservation.checkout.strftime("%Y-%m-%d")
+
+        FolioInfo = self.env.datamodels["pms.folio.info"]
+        folio_info = FolioInfo(partial=True)
+        folio_info.state = "cancel"
+        folio_info.pmsPropertyId = self.property.id
+        folio_info.reservations = [reservation_info]
+        return folio_info
+
+    def test_put_folio_returns_structured_code_when_invoiced(self):
+        folio = self._make_folio()
+        folio._create_invoices()
+        folio.move_ids.action_post()
+        service = self._folio_service()
+        payload = self._build_put_payload(folio)
+
+        # Force ``update_folio_values`` to raise a UserError, mimicking the
+        # real failure raised by ``folio.sale.line.write/unlink`` when a
+        # posted invoice blocks the change. The endpoint must catch it and
+        # re-raise a ValidationError whose body is the structured JSON.
+        with patch.object(
+            type(service),
+            "update_folio_values",
+            side_effect=UserError("cannot modify invoiced line"),
+        ):
+            with self.assertRaises(ValidationError) as cm:
+                service.update_put_folio(folio.id, payload)
+
+        body = json.loads(cm.exception.args[0])
+        self.assertEqual(body["code"], "FOLIO_HAS_INVOICED_LINES")
+        self.assertIn("cannot modify invoiced line", body["message"])
+
+    def test_put_folio_keeps_generic_error_when_not_invoiced(self):
+        # Same UserError, but the folio has no invoice: the endpoint must
+        # fall back to the generic wrapper so we do not mislabel unrelated
+        # failures as "invoiced".
+        folio = self._make_folio()
+        service = self._folio_service()
+        payload = self._build_put_payload(folio)
+
+        with patch.object(
+            type(service),
+            "update_folio_values",
+            side_effect=UserError("unrelated failure"),
+        ):
+            with self.assertRaises(ValidationError) as cm:
+                service.update_put_folio(folio.id, payload)
+
+        # Not a JSON code — falls back to the pre-existing wrapper message.
+        with self.assertRaises(ValueError):
+            json.loads(cm.exception.args[0])
+        self.assertIn("unrelated failure", cm.exception.args[0])


### PR DESCRIPTION
## Summary

External clients driving the `/folios` PUT endpoints (e.g. channel managers) currently receive a generic `ValidationError` whenever the folio has posted invoices. There is no way for the caller to distinguish that specific business case from any other backend failure without string-matching the message.

This PR surfaces a stable, machine-readable code for that situation:

- New helper `_folio_has_locked_invoiced_lines(folio)` decides whether the folio has any posted (non-reversed) customer invoice or lines with `qty_invoiced > 0`.
- New wrapper `_raise_folio_invoiced_error(error)` re-raises a `ValidationError` whose message is a JSON payload:

  ```json
  { "code": "FOLIO_HAS_INVOICED_LINES", "message": "<original UserError>" }
  ```

- Both `update_put_folio` and `update_put_external_folio` catch the underlying `UserError` from `folio.sale.line.write/unlink`, and — only when the guard says the failure was caused by invoicing — re-raise the structured error. Unrelated `UserError`s keep falling back to the previous generic wrapper.

Behavior is opt-in for callers: consumers that already tolerate the generic error keep working; new integrations can parse `code` to react programmatically.

## Test plan

- [ ] `docker-compose run --rm -l traefik.enable=false odoo odoo --test-tags /pms_api_rest --stop-after-init -d test --no-http -u pms_api_rest` passes the new `TestFolioInvoicedErrorCode` cases:
  - helper returns False without invoice / with draft invoice / on empty recordset; True with posted invoice
  - `_raise_folio_invoiced_error` produces a JSON payload with `code == "FOLIO_HAS_INVOICED_LINES"`
  - `update_put_folio` on a folio with a posted invoice + a `UserError` from the update path returns the structured payload
  - `update_put_folio` on a folio without invoice keeps the generic wrapper
- [ ] Manual smoke on `predev.roomdoo.com` against a folio with a posted simplified invoice, PUT `/api/folios/<id>` with `state: cancel` → response body parses as JSON with the code