### PR TITLE
[FIX] pms_api_rest: allow module data loads to write on the various partner

### DIFF
--- a/pms_api_rest/models/res_partner.py
+++ b/pms_api_rest/models/res_partner.py
@@ -72,6 +72,12 @@ class ResPartner(models.Model):
         return {f for f in _PROTECTED_FIELDS if f in self._fields}
 
     def write(self, vals):
+        # Module data loads run with install_mode=True (see
+        # BaseModel._load_records); e.g. pms_l10n_es_sii sets
+        # aeat_anonymous_cash_customer on this partner from its data XML.
+        # The guard only targets runtime writes (REST API, UI).
+        if self.env.context.get("install_mode"):
+            return super().write(vals)
         various = self._get_various_partner()
         if various and various.id in self.ids:
             forbidden = self._get_various_partner_protected_fields().intersection(vals)

--- a/pms_api_rest/tests/test_various_partner_protection.py
+++ b/pms_api_rest/tests/test_various_partner_protection.py
@@ -35,6 +35,16 @@ class TestVariousPartnerProtection(TransactionCase):
         with self.assertRaises(UserError):
             self.various.sudo().write({"vat": "ES12345678Z"})
 
+    def test_write_protected_field_in_install_mode_passes(self):
+        # Module data loads (BaseModel._load_records) run with
+        # install_mode=True and must be able to touch protected fields:
+        # pms_l10n_es_sii sets aeat_anonymous_cash_customer on this
+        # partner from its data XML on a fresh install.
+        self.various.with_context(install_mode=True).write(
+            {"comment": "set by module data"}
+        )
+        self.assertEqual(self.various.comment, "set by module data")
+
     def test_write_unprotected_field_passes(self):
         # ``ref`` is not in the protected set; nothing prevents touching it.
         self.various.write({"ref": "VARIOUS-REF"})


### PR DESCRIPTION
## Problem

The various-partner write guard introduced in 1cc158f blocks **every** write on protected fields of `pms.various_pms_partner`, including writes performed by module XML data loading.

On a **fresh install** (new database with the full addon set), `pms_l10n_es_sii` sets `aeat_anonymous_cash_customer` on that partner from its `data/pms_data.xml`:

```
odoo.exceptions.UserError: The system contact 'Various Clients' is reserved for simplified invoices and cannot be modified. Blocked fields: aeat_anonymous_cash_customer. ...
odoo.tools.convert.ParseError: while parsing .../pms_l10n_es_sii/data/pms_data.xml:4
CRITICAL ... Failed to initialize database
```

The registry fails to load and the database cannot be initialized at all.

Existing databases never hit this because that record is `noupdate="1"` and was written before the guard existed — the bug only surfaces on new deployments (e.g. self-hosted installs reproducing our addons tree).

## Fix

Bypass the guard when `install_mode` is set in the context, which `BaseModel._load_records` only sets during module install/upgrade data loading. Runtime writes coming from the REST API or the UI remain blocked, which is what the guard was added for.

Includes a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)