### PR TITLE
[FIX] connector_pms_wubook: drop stale inconsistent-rules views on upgrade

### DIFF
--- a/connector_pms_wubook/migrations/16.0.1.3.0/pre-migration.py
+++ b/connector_pms_wubook/migrations/16.0.1.3.0/pre-migration.py
@@ -1,0 +1,19 @@
+from openupgradelib import openupgrade
+
+# Views removed from the source together with the inconsistent_rule_count
+# field they displayed. On databases that still hold the old records, the
+# combined-arch validation triggered while writing any sibling view during
+# the update hits them before obsolete records are garbage-collected, so
+# the whole upgrade crashes. Drop them up front.
+STALE_VIEWS = [
+    "connector_pms_wubook.availability_plan_rule_view_form",
+    "connector_pms_wubook.massive_changes_wizard",
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    for xmlid in STALE_VIEWS:
+        view = env.ref(xmlid, raise_if_not_found=False)
+        if view:
+            view.unlink()


### PR DESCRIPTION
## Problem

76afd8a (16.0.1.3.0) removed the `inconsistent_rule_count` field together with the two view records that displayed it (the rule-form warning badge and the massive-changes wizard extension), but did not add a migration. Databases upgraded from earlier versions still hold those records, and the module update crashes:

```
odoo.tools.convert.ParseError: while parsing connector_pms_wubook/views/pms_availability_plan_rule_views.xml
Field "inconsistent_rule_count" does not exist in model "pms.availability.plan.rule"
```

When `availability_plan_rule_wubook_connector_view_form` is written during the data load, `_check_xml` validates the combined arch — the root view plus **every** active inheriting view in the database — and hits the stale badge view that references the dropped field. Obsolete records are only garbage-collected at the end of a successful load (`_process_end`), so the update aborts before the cleanup can run and the database can never self-heal. Every subsequent update fails the same way.

## Fix

Add `migrations/16.0.1.3.0/pre-migration.py` that unlinks both stale view records before the module data loads. Idempotent: on databases installed directly on 16.0.1.3.0 (or where the views are already gone) it does nothing.