### PR TITLE
[FIX] pms_api_rest: apply board service price rules by consumption date

### DIFF
--- a/pms_api_rest/services/pms_price_service.py
+++ b/pms_api_rest/services/pms_price_service.py
@@ -152,6 +152,7 @@ class PmsPriceService(Component):
         product = product.with_context(
             board_service_line_id=board_service_line_id,
             property=pms_property_id,
+            consumption_date=consumption_date,
         )
         price = pricelist._get_product_price(
             product=product,
@@ -185,7 +186,6 @@ class PmsPriceService(Component):
             lines = (
                 self.env["pms.board.service.room.type.line"]
                 .sudo()
-                .browse()
                 .browse(board_service_line_id)
             )
         else:


### PR DESCRIPTION
## Problema

El endpoint `GET /prices` pasaba `consumption_date` a la pricelist solo como kwarg, que filtra items de tarifa por fechas de consumo pero nunca llega al contexto del producto. El precio base del régimen se resuelve vía `product.price_compute` → `board_price`, cuyo compute lee `consumption_date` del contexto del producto para aplicar las reglas dinámicas de precio de régimen (`pms.board.service.room.type.line.rule`, POC en el repo pms).

Sin ese contexto, `/prices` devolvía siempre el importe base de la línea de régimen, por lo que el booking engine del front mostraba y persistía precios de régimen sin regla (el front construye los `priceUnit` de las serviceLines a partir de `/prices`).

## Fix

- Añadir `consumption_date` al contexto del producto en `_get_product_price` para que las reglas de precio de régimen se apliquen por día. El cambio es inerte sin el POC: el compute base ignora ese contexto y `_compute_board_price` ya declara `@api.depends_context("consumption_date", ...)` en pms 16.0, así que la invalidación de caché por fecha ya está contemplada.
- Eliminar un `browse()` vacío duplicado en `_get_board_service_price`.

No requiere cambios en el front: el booking engine y la pestaña de servicios de reserva ya obtienen los precios por fecha de `/prices`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)