### PR TITLE
[16.0][FIX] pms_api_rest: kinship relationship round-trip in checkin partners API

### DIFF
--- a/pms_api_rest/services/pms_reservation_service.py
+++ b/pms_api_rest/services/pms_reservation_service.py
@@ -34,17 +34,20 @@ def is_adult(birthdate):
 def find_opposite_relationship(relationship_code):
     inverse_relationships = {
         "PM": "HJ",  # Padre o Madre -> Hijo
+        "HJ": "PM",  # Hijo -> Padre o Madre
         "TU": "OT",  # Tutor -> Otro (sin inverso claro)
         "TI": "SB",  # Tío -> Sobrino
         "HR": "HR",  # Hermano -> Hermano
         "AB": "NI",  # Abuelo -> Nieto
+        "NI": "AB",  # Nieto -> Abuelo
         "BA": "BN",  # Bisabuelo -> Bisnieto
+        "BN": "BA",  # Bisnieto -> Bisabuelo
         "CD": "CD",  # Cuñado -> Cuñado
         "CY": "CY",  # Cónyuge -> Cónyuge
         "SB": "TI",  # Sobrino -> Tío
         "SG": "YN",  # Suegro -> Yerno o Nuera
         "YN": "SG",  # Yerno o Nuera -> Suegro
-        "OT": "OT",  # Otro -> Tutor (arbitrario)
+        "OT": "OT",  # Otro -> Otro
     }
     # Buscar la relación inversa
     related_code = inverse_relationships.get(
@@ -782,7 +785,13 @@ class PmsReservationService(Component):
                         signature=checkin_partner.signature
                         if checkin_partner.signature
                         else None,
-                        relationship=checkin_partner.ses_partners_relationship
+                        # ses_partners_relationship is stored from the guest's
+                        # own perspective (e.g. "HJ"), but the API contract
+                        # exchanges the responsible adult's perspective
+                        # (e.g. "PM"), so it is inverted back here
+                        relationship=find_opposite_relationship(
+                            checkin_partner.ses_partners_relationship
+                        )
                         if checkin_partner.ses_partners_relationship
                         else "",
                         responsibleCheckinPartnerId=checkin_partner.ses_related_checkin_partner_id.id
@@ -842,7 +851,10 @@ class PmsReservationService(Component):
                     [("id", "=", pms_checkin_partner_info.responsibleCheckinPartnerId)]
                 )
             )
-            if responsible_checkin_partner_record:
+            if (
+                responsible_checkin_partner_record
+                and pms_checkin_partner_info.relationship
+            ):
                 responsible_checkin_partner_record.ses_partners_relationship = (
                     pms_checkin_partner_info.relationship
                 )
@@ -1180,7 +1192,7 @@ class PmsReservationService(Component):
             vals.update({"signature": base64.b64encode(signature_image)})
         else:
             vals.update({"signature": False})
-        if pms_checkin_partner_info.relationship != "":
+        if pms_checkin_partner_info.relationship:
             vals.update(
                 {
                     "ses_partners_relationship": find_opposite_relationship(


### PR DESCRIPTION
## Problem

Hotels report that the kinship ("Relacion de parentesco") of minors is not recorded: after saving a minor with a responsible adult and kinship, the field shows up empty when the form is reloaded, both after front-desk check-in and after guests complete the pre-check-in. Several support tickets have been opened about this.

The data was actually being stored correctly on first save. The real defects are in the API round-trip:

1. **Asymmetric contract.** The PATCH endpoints receive the relationship code from the responsible adult's perspective (e.g. `PM` = parent) and store the inverse on the minor's `ses_partners_relationship` (e.g. `HJ` = child, which is what the SES traveller report expects). But the GET `/reservations/<id>/checkin-partners` returned the stored (minor-perspective) code as-is. The frontend select only contains adult-perspective codes, so `HJ` matched nothing and rendered empty — making users think nothing was saved.
2. **Data degradation on re-save.** Saving the form again echoed the minor-perspective code (`HJ`) back to the PATCH. `HJ`/`NI`/`BN` were missing from the inverse map, so they collapsed to `OT` ("Other"), silently degrading correct data. The responsible adult's own code was also overwritten with the echoed value (adults ended up stored as `HJ`), and production data confirms both effects.

## Fix

- Return the inverse (adult-perspective) code in the checkin partners GET, restoring a symmetric contract with the existing frontend.
- Complete the inverse relationship map with the missing minor-perspective keys (`HJ`, `NI`, `BN`) so the mapping is an involution (`TU` -> `OT` remains lossy: the SES catalogue has no inverse for guardian).
- Only overwrite the responsible adult's relationship when a non-empty one is sent.
- Guard against `None` relationship in `mapping_checkin_partner_values` (previously `None != ""` passed the check and stored `OT`).

## Round-trip after the fix

Save `PM` -> minor stores `HJ`, adult stores `PM` -> GET returns `PM` -> select shows "Padre o Madre" -> re-save is idempotent.

Existing rows degraded to `OT` will display as "Other"; re-selecting the correct kinship now sticks. No frontend changes required.