### PR TITLE
[FIX] pms_api_rest: convert channel currency in batch price push

### DIFF
--- a/pms_api_rest/models/pms_property.py
+++ b/pms_api_rest/models/pms_property.py
@@ -626,6 +626,14 @@ class PmsProperty(models.Model):
                 ),
                 2,
             )
+            # HOTFIX TO CONVERT PRICE IN PROPERTY CHANNEL CURRENCY
+            if pms_property.channel_currency_id:
+                price = round(
+                    price
+                    * pms_property.channel_currency_id.rate
+                    / pms_property.company_id.currency_id.rate,
+                    2,
+                )
             if current_price is None:
                 current_price = price
                 current_date_from = date


### PR DESCRIPTION
## Problem

`generate_prices_json` (used by `pms_api_push_batch` and the availability-plan cron re-push) sent pricelist prices in the **company currency**, while the event-driven push (`get_payload_prices`) already converts them to the property **channel currency**.

On properties whose channel currency differs from the company currency (e.g. a DOP company pushing USD to Neobookings), this produced **unconverted prices in the channel** for any date range last touched by the batch path, while single days edited through the event path looked correct. Symptom seen in production: months that were only ever bulk-pushed showed raw local-currency amounts on the OTA extranet.

## Fix

Apply the same channel-currency conversion already present in `get_payload_prices` to the batch path:

```python
if pms_property.channel_currency_id:
    price = round(
        price
        * pms_property.channel_currency_id.rate
        / pms_property.company_id.currency_id.rate,
        2,
    )
```

Only affects properties with `channel_currency_id` set and different from the company currency; same-currency setups are unchanged.

## Verification

Applied as a hot-patch in production and re-pushed a full 365-day range: all months now export converted amounts (e.g. 35000 local → 598.78 channel), matching the event-driven path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)