### PR TITLE
[IMP] pms_api_rest: expose excludePaymentReminders in agencies GET

### DIFF
--- a/pms_api_rest/__manifest__.py
+++ b/pms_api_rest/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",
     "category": "Generic Modules/Property Management System",
-    "version": "16.0.1.4.2",
+    "version": "16.0.1.4.3",
     "license": "AGPL-3",
     "depends": [
         "pms",

--- a/pms_api_rest/datamodels/pms_agency.py
+++ b/pms_api_rest/datamodels/pms_agency.py
@@ -15,3 +15,4 @@ class PmsAgencyInfo(Datamodel):
     name = fields.String(required=True, allow_none=False)
     imageUrl = fields.String(required=False, allow_none=True)
     saleChannelId = fields.Integer(required=False, allow_none=True)
+    excludePaymentReminders = fields.Boolean(required=False, allow_none=True)

--- a/pms_api_rest/services/pms_agency_service.py
+++ b/pms_api_rest/services/pms_agency_service.py
@@ -38,6 +38,10 @@ class PmsAgencyService(Component):
         agencies = self.env["res.partner"].sudo().search(domain)
         pms_api_check_access(user=self.env.user, records=agencies)
         for agency in agencies:
+            # field defined in pms_bookai (optional module)
+            exclude_payment_reminders = bool(
+                getattr(agency, "bookai_exclude_payment_reminders", False)
+            )
             result_agencies.append(
                 PmsAgencyInfo(
                     id=agency.id,
@@ -46,6 +50,7 @@ class PmsAgencyService(Component):
                         "res.partner", agency.id, "image_128"
                     ),
                     saleChannelId=agency.sale_channel_id.id,
+                    excludePaymentReminders=exclude_payment_reminders,
                 )
             )
         return result_agencies
@@ -76,11 +81,16 @@ class PmsAgencyService(Component):
         if agency:
             pms_api_check_access(user=self.env.user, records=agency)
             PmsAgencieInfo = self.env.datamodels["pms.agency.info"]
+            # field defined in pms_bookai (optional module)
+            exclude_payment_reminders = bool(
+                getattr(agency, "bookai_exclude_payment_reminders", False)
+            )
             return PmsAgencieInfo(
                 id=agency.id,
                 name=agency.name if agency.name else None,
                 imageUrl=url_image_pms_api_rest("res.partner", agency.id, "image_128"),
                 saleChannelId=agency.sale_channel_id.id,
+                excludePaymentReminders=exclude_payment_reminders,
             )
         else:
             raise MissingError(_("Agency not found"))


### PR DESCRIPTION
Adds `excludePaymentReminders` (boolean) to the `pms.agency.info` datamodel so `GET /api/agencies` and `GET /api/agencies/<id>` expose whether an agency is excluded from payment reminder notifications.

The backend field is defined in `pms_bookai` (optional module), so the service reads it defensively with `getattr` and exposes it under a generic, integration-neutral name.

Hot-deployed in production as a hotfix; this PR makes it durable for the next image build.