### PR TITLE
[16.0][FIX] pms_api_rest, pms_fastapi: make cash session close idempotent

### DIFF
--- a/pms_api_rest/__manifest__.py
+++ b/pms_api_rest/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",
     "category": "Generic Modules/Property Management System",
-    "version": "16.0.1.4.2",
+    "version": "16.0.1.4.3",
     "license": "AGPL-3",
     "depends": [
         "pms",

--- a/pms_api_rest/services/pms_transaction_service.py
+++ b/pms_api_rest/services/pms_transaction_service.py
@@ -460,7 +460,7 @@ class PmsTransactionService(Component):
                 balance=0,
                 dateTime=fields.Datetime.now().isoformat(),
             )
-        isOpen = True if not statement.is_complete else False
+        isOpen = self._is_cash_session_open(statement)
         timezone = pytz.timezone(self.env.context.get("tz") or "UTC")
         create_date_utc = pytz.UTC.localize(statement.create_date)
         create_date = create_date_utc.astimezone(timezone)
@@ -528,7 +528,7 @@ class PmsTransactionService(Component):
         # If a cash session is already open, do not create a duplicate one: a
         # second open statement would steal the day's payments and lead to a
         # double count of those payments when closing. Just reuse the open one.
-        if last_statement and not last_statement.is_complete:
+        if last_statement and self._is_cash_session_open(last_statement):
             return {"result": True, "diff": 0}
         compute_end_balance = (
             round(last_statement.balance_end_real, 2) if last_statement else 0
@@ -568,6 +568,23 @@ class PmsTransactionService(Component):
             journal_id=journal_id,
             pms_property_id=pms_property_id,
         )
+        if not statement:
+            return {"result": True, "diff": 0}
+        # Serialize concurrent close requests on the same session (e.g. a
+        # double click on the front close button): the second request waits
+        # on the row lock until the first one commits, and then sees the
+        # session already closed instead of pouring the payments again.
+        self.env.cr.execute(
+            "SELECT id FROM account_bank_statement WHERE id = %s FOR UPDATE",
+            (statement.id,),
+        )
+        statement.invalidate_recordset()
+        # Only the explicit flag here: the is_complete fallback of
+        # _is_cash_session_open would misread a force-opened session (whose
+        # difference line makes it compute complete) as closed and skip
+        # pouring its payments.
+        if "cash_session_closed" in statement._fields and statement.cash_session_closed:
+            return {"result": True, "diff": 0}
         session_payments = (
             self.env["account.payment"]
             .sudo()
@@ -580,6 +597,13 @@ class PmsTransactionService(Component):
                 ]
             )
         )
+        # A payment already matched against a statement line was poured by a
+        # previous close request: pouring it again would duplicate the line.
+        session_payments = session_payments.filtered(lambda p: not p.is_matched)
+        if statement.line_ids and not session_payments:
+            # Repeated close request: the session lines were already created.
+            self._mark_cash_session_closed(statement)
+            return {"result": True, "diff": 0}
         session_payments_amount = sum(
             session_payments.filtered(lambda x: x.payment_type == "inbound").mapped(
                 "amount"
@@ -747,6 +771,16 @@ class PmsTransactionService(Component):
                     statement_move_line.account_id = payment_move_line.account_id
                     lines_to_reconcile = payment_move_line + statement_move_line
                     lines_to_reconcile.reconcile()
+
+    def _is_cash_session_open(self, statement):
+        """Whether the session is open, keyed off cash_session_closed when
+        pms_fastapi is installed (see _mark_cash_session_closed). The
+        is_complete fallback misreads force-opened sessions (their difference
+        line makes them compute complete), so it is only a fallback.
+        """
+        if "cash_session_closed" in statement._fields:
+            return not statement.cash_session_closed
+        return not statement.is_complete
 
     def _mark_cash_session_closed(self, statement):
         """TEMPORARY bridge to the FastAPI cash-session state. REMOVE WITH THIS MODULE.

--- a/pms_fastapi/__manifest__.py
+++ b/pms_fastapi/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "PMS FastAPI",
-    "version": "16.0.1.5.0",
+    "version": "16.0.1.5.1",
     "development_status": "Beta",
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",

--- a/pms_fastapi/models/account_bank_statement.py
+++ b/pms_fastapi/models/account_bank_statement.py
@@ -151,9 +151,25 @@ class AccountBankStatement(models.Model):
         when the session is actually closed and False when it is discarded.
         """
         self.ensure_one()
+        # Serialize concurrent close requests on the same session (e.g. a
+        # double click on the close button): the second request waits on the
+        # row lock until the first one commits, and the recheck below then
+        # sees the session already closed instead of pouring the payments
+        # again. The router's 409 guard alone cannot see an uncommitted close.
+        self.env.cr.execute(
+            "SELECT id FROM account_bank_statement WHERE id = %s FOR UPDATE",
+            (self.id,),
+        )
+        self.invalidate_recordset()
+        if self.cash_session_closed:
+            return True
         breakdown = self._pms_cash_session_breakdown()
         difference = round(counted_cash - breakdown["expected"], 2)
-        session_payments = self._pms_cash_session_payments()
+        # A payment already matched against a statement line was poured by a
+        # previous close, so pouring it again would duplicate the line.
+        session_payments = self._pms_cash_session_payments().filtered(
+            lambda p: not p.is_matched
+        )
         if not session_payments and not difference:
             self.unlink()
             return False


### PR DESCRIPTION
## Problem

A repeated close request on the same cash session (e.g. a **double click on the front close button**, producing two overlapping HTTP requests) re-created every statement line of the session.

The close flow pours the session payments into `account.bank.statement.line` records, but nothing marks them as already poured: the second request finds the same payments again (searched by `create_date >= statement.create_date`), the balance check matches again, and all the lines get duplicated. The second batch cannot be reconciled (the payments were already reconciled by the first one), the session end balance is inflated by the day's takings, and the phantom mismatch cascades into the next opens (false loss lines, duplicate open sessions).

Neither API was protected:
- Legacy `/transactions/cash-register` had no idempotency guard at all.
- FastAPI `/cash-sessions/{id}/closing` has a 409 already-closed guard, but it cannot see an uncommitted concurrent close (read-committed race).

## Fix

- **Legacy close**: row lock (`SELECT ... FOR UPDATE`) on the statement to serialize concurrent closes + early return when the session is already stamped `cash_session_closed` + skip payments already matched against a statement line (`is_matched`), so a repeated request is a no-op (`result: true, diff: 0`) instead of pouring the lines twice. No front change needed.
- **Legacy open/GET**: key the open/closed state off `cash_session_closed` when available instead of `is_complete`, which misreads a force-opened session (its difference line makes it compute complete) as closed — this is what allowed two open sessions to coexist after a forced open.
- **FastAPI close**: same row lock + recheck after acquiring it, plus the same `is_matched` safety net.

The `is_complete` fallback is kept only where it replicates the previous behaviour (installs without `pms_fastapi`); the close guard uses exclusively the explicit flag to avoid skipping the pour on force-opened sessions.