### PR TITLE
[16.0] Zero-padded HH:MM hours: smartlock parser reuse and Wubook import

### DIFF
--- a/connector_pms_wubook/models/pms_reservation/mapper_import.py
+++ b/connector_pms_wubook/models/pms_reservation/mapper_import.py
@@ -63,6 +63,19 @@ def get_board_service_room_type(mapper, room_type, board, pricelist_id=False):
     )
 
 
+def pad_hour(hour_str):
+    """Return the hour Wubook sends ("9:00") zero-padded ("09:00").
+
+    ``pms.reservation.arrival_hour`` only accepts the padded format. What
+    is not an hour is returned untouched, to be rejected there instead of
+    imported.
+    """
+    hour, separator, minute = hour_str.partition(":")
+    if not separator or not hour.isdigit() or not minute.isdigit():
+        return hour_str
+    return f"{hour.zfill(2)}:{minute.zfill(2)}"
+
+
 class ChannelWubookPmsReservationMapperImport(Component):
     _name = "channel.wubook.pms.reservation.mapper.import"
     _inherit = "channel.wubook.mapper.import"
@@ -124,7 +137,7 @@ class ChannelWubookPmsReservationMapperImport(Component):
             if record["arrival_hour"] == "24:00":
                 record["arrival_hour"] = "23:59"
             return {
-                "arrival_hour": record["arrival_hour"],
+                "arrival_hour": pad_hour(record["arrival_hour"]),
             }
 
     @mapping

--- a/connector_pms_wubook/tests/__init__.py
+++ b/connector_pms_wubook/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_auth
 from . import test_listener_batching
 from . import test_master_sync
 from . import test_pricelist_flatten
+from . import test_reservation_mapper

--- a/connector_pms_wubook/tests/test_reservation_mapper.py
+++ b/connector_pms_wubook/tests/test_reservation_mapper.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Roomdoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+"""Tests for the arrival hour normalization of the reservation import
+mapper.
+
+Wubook sends the arrival hour as the guest typed it, so hours without
+zero padding ("9:00") and "24:00" reach the mapper, while
+``pms.reservation.arrival_hour`` only accepts a zero-padded 24h "HH:MM"
+string. These tests pin what the mapper hands over to the reservation.
+"""
+
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.connector_pms_wubook.models.pms_reservation.mapper_import import (
+    ChannelWubookPmsReservationMapperImport,
+    pad_hour,
+)
+
+
+class TestReservationMapperArrivalHour(TransactionCase):
+    def _map_dates(self, arrival_hour):
+        # The mapping reads the incoming record only, so it is exercised
+        # without the component machinery nor a Wubook backend.
+        return ChannelWubookPmsReservationMapperImport.dates(
+            None, {"arrival_hour": arrival_hour}
+        )
+
+    def test_arrival_hour_is_zero_padded(self):
+        self.assertEqual(self._map_dates("9:00"), {"arrival_hour": "09:00"})
+        self.assertEqual(self._map_dates("0:0"), {"arrival_hour": "00:00"})
+
+    def test_arrival_hour_already_padded_is_kept(self):
+        self.assertEqual(self._map_dates("14:30"), {"arrival_hour": "14:30"})
+
+    def test_arrival_hour_end_of_day(self):
+        """Wubook's "24:00" is not an hour, it means the end of the day."""
+        self.assertEqual(self._map_dates("24:00"), {"arrival_hour": "23:59"})
+
+    def test_no_arrival_hour_is_not_mapped(self):
+        """The adapter turns Wubook's "--" into no arrival hour."""
+        self.assertIsNone(self._map_dates(None))
+
+    def test_pad_hour_keeps_what_is_not_an_hour(self):
+        """An unparseable hour reaches the reservation check untouched."""
+        for value in ("1400", "aa:bb", "14:", ""):
+            with self.subTest(value=value):
+                self.assertEqual(pad_hour(value), value)

--- a/pms_smartlock_base/models/pms_reservation.py
+++ b/pms_smartlock_base/models/pms_reservation.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time, timedelta
+from datetime import timedelta
 
 from odoo import api, fields, models
 
@@ -232,23 +232,16 @@ class PmsReservation(models.Model):
             if idx == 0:
                 date_from = self.checkin_datetime
             else:
-                date_from = self._lock_code_property_dt(
+                date_from = self.pms_property_id.datetime_from_hour_str(
                     first.date, self.pms_property_id.default_departure_hour
                 )
             if idx == len(groups) - 1:
                 date_to = self.checkout_datetime
             else:
                 next_first_date = groups[idx + 1][1].date
-                date_to = self._lock_code_property_dt(
+                date_to = self.pms_property_id.datetime_from_hour_str(
                     next_first_date,
                     self.pms_property_id.default_departure_hour,
                 )
             windows.append((room, date_from, date_to))
         return windows
-
-    def _lock_code_property_dt(self, local_date, hour_str):
-        self.ensure_one()
-        hour = int(hour_str[0:2])
-        minute = int(hour_str[3:5])
-        local_dt = datetime.combine(local_date, time(hour, minute))
-        return self.pms_property_id.date_property_timezone(local_dt)

--- a/pms_smartlock_base/tests/test_sync_reconcile.py
+++ b/pms_smartlock_base/tests/test_sync_reconcile.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time, timedelta
+from datetime import timedelta
 from unittest.mock import patch
 
 from odoo import fields
@@ -205,12 +205,9 @@ class TestBuildLockCodeWindows(CommonSmartlock):
         self.assertEqual(second_to, reservation.checkout_datetime)
         # Transition: same instant, at default_departure_hour of day 2
         self.assertEqual(first_to, second_from)
-        hour, minute = (
-            int(self.pms_property.default_departure_hour[0:2]),
-            int(self.pms_property.default_departure_hour[3:5]),
+        expected = self.pms_property.datetime_from_hour_str(
+            sorted_lines[1].date, self.pms_property.default_departure_hour
         )
-        transition_local = datetime.combine(sorted_lines[1].date, time(hour, minute))
-        expected = self.pms_property.date_property_timezone(transition_local)
         self.assertEqual(first_to, expected)
 
     def test_room_without_lock_excluded_from_windows(self):


### PR DESCRIPTION
Depende de OCA/pms#434, que valida las horas con una regex y expone el parser en
`pms.property`. Las dos ramas van juntas: `pms_smartlock_base` llama al helper
nuevo, y sin la validación estricta el padding de Wubook no hace falta.

### pms_smartlock_base

Las ventanas de código parseaban `default_departure_hour` por slicing; ahora usan
`pms.property.datetime_from_hour_str`, igual que los computes de `checkin_datetime`
y `checkout_datetime`.

### connector_pms_wubook

Wubook manda la hora tal cual la teclea el huésped, así que llegan valores como
`"9:00"` que la reserva ya no acepta. El mapper rellena con cero antes de
escribirla; el `"24:00"` -> `"23:59"` se queda donde estaba, y lo que no es una hora
pasa intacto para que lo rechace la reserva en vez de entrar en base de datos.
