### PR TITLE
[16.0][ADD] pms_api_rest: unaccompanied minors declaration

### DIFF
--- a/pms_api_rest/__manifest__.py
+++ b/pms_api_rest/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",
     "category": "Generic Modules/Property Management System",
-    "version": "16.0.1.4.3",
+    "version": "16.0.1.5.0",
     "license": "AGPL-3",
     "depends": [
         "pms",

--- a/pms_api_rest/datamodels/pms_checkin_partner.py
+++ b/pms_api_rest/datamodels/pms_checkin_partner.py
@@ -17,6 +17,12 @@ class PmsCheckinPartnerInfo(Datamodel):
     documentLegalRepresentative = fields.String(required=False, allow_none=True)
     relationship = fields.String(required=False, allow_none=True)
     responsibleCheckinPartnerId = fields.Integer(required=False, allow_none=True)
+    # The minors travel on their own with the authorization of their legal
+    # guardian, so no relationship with an accompanying guest is required. It
+    # is a single declaration for the whole booking: it is exchanged on every
+    # guest, and all the guests of the booking report the same value. Omitting
+    # it leaves it as it was, sending false withdraws it.
+    unaccompaniedMinors = fields.Boolean(required=False, allow_none=True)
     documentType = fields.Integer(required=False, allow_none=True)
     documentNumber = fields.String(required=False, allow_none=True)
     documentExpeditionDate = fields.String(required=False, allow_none=True)
@@ -36,3 +42,22 @@ class PmsCheckinPartnerInfo(Datamodel):
     originInputData = fields.String(required=False, allow_none=True)
     signature = fields.String(required=False, allow_none=True)
     isAlreadyInReservation = fields.Boolean(required=False, allow_none=True)
+
+
+class PmsCheckinPartnerInfoOutput(Datamodel):
+    """The guest as it is reported, with the data that is never written back.
+
+    A single datamodel is used as the request and the response of the guest
+    endpoints, and base_rest builds the same schema for both, so read only data
+    would show up as writable. It lives here instead.
+    """
+
+    _name = "pms.checkin.partner.info.output"
+    _inherit = "pms.checkin.partner.info"
+
+    # Read only. Every guest of the booking whose birthdate is known is under
+    # the age of majority, which is when the declaration above is meaningful.
+    allGuestsMinors = fields.Boolean(required=False, allow_none=True)
+    # Read only. Name of the stored guardian authorization, null when there is
+    # none. The document itself is exchanged through its own endpoints.
+    minorsAuthorizationFilename = fields.String(required=False, allow_none=True)

--- a/pms_api_rest/services/pms_reservation_service.py
+++ b/pms_api_rest/services/pms_reservation_service.py
@@ -7,7 +7,8 @@ from datetime import datetime, timedelta
 import pytz
 
 from odoo import SUPERUSER_ID, _, fields
-from odoo.exceptions import AccessError, MissingError
+from odoo.exceptions import AccessError, MissingError, ValidationError
+from odoo.http import content_disposition, request
 from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval
 
@@ -21,6 +22,10 @@ from ..pms_api_rest_utils import (
     precheckin_share_url,
     url_image_pms_api_rest,
 )
+
+# Cap for the guardian authorization upload. Generous for a scanned document,
+# small enough that a mistaken upload does not fill the filestore.
+MAX_MINORS_AUTHORIZATION_SIZE = 10 * 1024 * 1024
 
 
 def is_adult(birthdate):
@@ -704,7 +709,7 @@ class PmsReservationService(Component):
                 "GET",
             )
         ],
-        output_param=Datamodel("pms.checkin.partner.info", is_list=True),
+        output_param=Datamodel("pms.checkin.partner.info.output", is_list=True),
         auth="jwt_api_pms",
     )
     def get_checkin_partners(self, reservation_id):
@@ -713,7 +718,7 @@ class PmsReservationService(Component):
             raise MissingError(_("Reservation not found"))
         pms_api_check_access(user=self.env.user, records=reservation)
         checkin_partners = []
-        PmsCheckinPartnerInfo = self.env.datamodels["pms.checkin.partner.info"]
+        PmsCheckinPartnerInfo = self.env.datamodels["pms.checkin.partner.info.output"]
         if not reservation.exists():
             pass
         else:
@@ -801,6 +806,21 @@ class PmsReservationService(Component):
                         responsibleCheckinPartnerId=checkin_partner.ses_related_checkin_partner_id.id
                         if checkin_partner.ses_related_checkin_partner_id
                         else None,
+                        # The unaccompanied minors declaration and its
+                        # authorization belong to the folio, not to the guest:
+                        # the guardians may be booked in one reservation and the
+                        # minors in another one of the same folio. Every guest
+                        # reports the same value.
+                        unaccompaniedMinors=(
+                            checkin_partner.folio_id.ses_unaccompanied_minors
+                        ),
+                        allGuestsMinors=(
+                            checkin_partner.folio_id.ses_all_guests_minors
+                        ),
+                        minorsAuthorizationFilename=(
+                            checkin_partner.folio_id.ses_minors_authorization_filename
+                            or None
+                        ),
                     )
                 )
         return checkin_partners
@@ -833,6 +853,13 @@ class PmsReservationService(Component):
         if not checkin_partner:
             raise MissingError(_("Checkin partner not found"))
         pms_api_check_access(user=self.env.user, records=checkin_partner)
+        # Stored before the boarding branch below, which returns early: a
+        # request that declares the unaccompanied minors and boards the guest at
+        # once would otherwise lose the declaration and then be rejected for
+        # missing the relationship the declaration waives.
+        self._write_unaccompanied_minors(
+            checkin_partner, pms_checkin_partner_info.unaccompaniedMinors
+        )
         if (
             pms_checkin_partner_info.actionOnBoard
             and pms_checkin_partner_info.actionOnBoard is not None
@@ -1107,6 +1134,9 @@ class PmsReservationService(Component):
                     else False,
                 )
             )
+            self._write_unaccompanied_minors(
+                checkin_partner_last, pms_checkin_partner_info.unaccompaniedMinors
+            )
             return checkin_partner_last.id
         else:
             raise MissingError(
@@ -1211,6 +1241,160 @@ class PmsReservationService(Component):
                 }
             )
         return vals
+
+    def _write_unaccompanied_minors(self, checkin_partner, unaccompanied_minors):
+        """Store the unaccompanied minors declaration, which lives on the folio.
+
+        ``None`` means the field was not sent, and the declaration is left as it
+        was. This is not the usual mapping behaviour, where an absent field is
+        written as empty, and it cannot be: the declaration is folio wide, so
+        that would silently withdraw a declaration made through another guest on
+        every request that writes any other guest of the folio.
+        """
+        if unaccompanied_minors is None:
+            return
+        checkin_partner.folio_id.ses_unaccompanied_minors = unaccompanied_minors
+
+    def _get_reservation_checkin_partner(self, reservation_id, checkin_partner_id):
+        checkin_partner = (
+            self.env["pms.checkin.partner"]
+            .sudo()
+            .search(
+                [
+                    ("id", "=", checkin_partner_id),
+                    ("reservation_id", "=", reservation_id),
+                ]
+            )
+        )
+        if not checkin_partner:
+            raise MissingError(_("Checkin partner not found"))
+        pms_api_check_access(user=self.env.user, records=checkin_partner)
+        return checkin_partner
+
+    def _store_minors_authorization(self, checkin_partner, content, filename):
+        if not content:
+            raise ValidationError(_("The uploaded authorization is empty"))
+        if len(content) > MAX_MINORS_AUTHORIZATION_SIZE:
+            raise ValidationError(
+                _("The uploaded authorization is larger than %s MB")
+                % (MAX_MINORS_AUTHORIZATION_SIZE // (1024 * 1024))
+            )
+        checkin_partner.folio_id.write(
+            {
+                "ses_minors_authorization": base64.b64encode(content),
+                "ses_minors_authorization_filename": filename,
+            }
+        )
+
+    def _read_minors_authorization(self, checkin_partner):
+        folio = checkin_partner.folio_id
+        if not folio.ses_minors_authorization:
+            raise MissingError(_("There is no authorization stored"))
+        return (
+            base64.b64decode(folio.ses_minors_authorization),
+            folio.ses_minors_authorization_filename or "authorization",
+        )
+
+    # The upload has a path of its own, unlike the download and the removal
+    # below, because a cors preflight only advertises the methods of the single
+    # route it matches, and every http method is a route of its own here. On a
+    # shared path the browser would be told that only DELETE is allowed and
+    # would block the upload. GET needs no such permission, being safelisted.
+    @restapi.method(
+        [
+            (
+                [
+                    "/p/<int:reservation_id>/checkin-partners/"
+                    "<int:checkin_partner_id>/minors-authorization",
+                ],
+                "PUT",
+            )
+        ],
+        auth="jwt_api_pms",
+    )
+    def upload_minors_authorization(self, reservation_id, checkin_partner_id):
+        """Store the guardian authorization of the unaccompanied minors.
+
+        The document is uploaded as ``multipart/form-data`` under the ``file``
+        part, so a scanned document does not pay the base64 overhead of the
+        datamodel fields. It is read straight from the request because
+        ``restapi.MultipartFormData`` cannot be used: the base_rest dispatcher
+        leaves the uploaded files out of ``request.params``, so declaring the
+        parts would never reach them.
+
+        There is a single authorization per folio, whichever of its guests it is
+        uploaded through.
+        """
+        checkin_partner = self._get_reservation_checkin_partner(
+            reservation_id, checkin_partner_id
+        )
+        upload = request.httprequest.files.get("file")
+        if not upload:
+            raise ValidationError(
+                _("The authorization must be uploaded in the 'file' part")
+            )
+        self._store_minors_authorization(
+            checkin_partner, upload.read(), upload.filename
+        )
+        return checkin_partner.id
+
+    @restapi.method(
+        [
+            (
+                [
+                    "/<int:reservation_id>/checkin-partners/"
+                    "<int:checkin_partner_id>/minors-authorization",
+                ],
+                "GET",
+            )
+        ],
+        auth="jwt_api_pms",
+        output_param=restapi.BinaryData(),
+    )
+    def download_minors_authorization(self, reservation_id, checkin_partner_id):
+        """Download the stored guardian authorization of the unaccompanied minors."""
+        checkin_partner = self._get_reservation_checkin_partner(
+            reservation_id, checkin_partner_id
+        )
+        content, filename = self._read_minors_authorization(checkin_partner)
+        return request.make_response(
+            content,
+            headers=[
+                # Served as an opaque download and never inline: the file comes
+                # from whatever the establishment scanned, and letting the
+                # browser render it would turn an HTML or SVG upload into a
+                # script running on the API origin.
+                ("Content-Type", "application/octet-stream"),
+                ("X-Content-Type-Options", "nosniff"),
+                ("Content-Disposition", content_disposition(filename)),
+                ("Content-Length", len(content)),
+            ],
+        )
+
+    @restapi.method(
+        [
+            (
+                [
+                    "/<int:reservation_id>/checkin-partners/"
+                    "<int:checkin_partner_id>/minors-authorization",
+                ],
+                "DELETE",
+            )
+        ],
+        auth="jwt_api_pms",
+    )
+    def delete_minors_authorization(self, reservation_id, checkin_partner_id):
+        """Remove the stored guardian authorization of the unaccompanied minors."""
+        checkin_partner = self._get_reservation_checkin_partner(
+            reservation_id, checkin_partner_id
+        )
+        checkin_partner.folio_id.write(
+            {
+                "ses_minors_authorization": False,
+                "ses_minors_authorization_filename": False,
+            }
+        )
+        return checkin_partner.id
 
     @restapi.method(
         [

--- a/pms_api_rest/tests/__init__.py
+++ b/pms_api_rest/tests/__init__.py
@@ -2,4 +2,5 @@ from . import test_external_folio_guest_name
 from . import test_folio_invoiced_error_code
 from . import test_pms_board_service_room_type
 from . import test_roomdoo_app_menu
+from . import test_ses_unaccompanied_minors
 from . import test_various_partner_protection

--- a/pms_api_rest/tests/test_ses_unaccompanied_minors.py
+++ b/pms_api_rest/tests/test_ses_unaccompanied_minors.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Commit [Sun]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""Minors travelling on their own with the authorization of their legal guardian
+are declared through the guest resource, but the declaration and its
+authorization document belong to the folio: the guardians may be booked in one
+reservation and the minors in another one of the same folio.
+
+These tests cover the API side of that mapping:
+
+* the declaration is reported on and written through any guest of the folio,
+* an omitted ``unaccompaniedMinors`` leaves the declaration alone, which is what
+  keeps a request writing one guest from withdrawing a declaration made through
+  another one,
+* the declaration is stored even when the same request boards the guest, whose
+  checkin data is only complete thanks to the declaration,
+* the guardian authorization is a single document per folio, size capped.
+"""
+import base64
+import datetime
+import io
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from werkzeug.datastructures import FileStorage
+
+from odoo.exceptions import MissingError, ValidationError
+from odoo.tests import tagged
+
+from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.component.core import WorkContext
+from odoo.addons.pms.tests.common import TestPms
+
+from ..services.pms_reservation_service import MAX_MINORS_AUTHORIZATION_SIZE
+
+
+@tagged("post_install", "-at_install")
+class TestSesUnaccompaniedMinors(TestPms):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Use admin (uid=1) so record rules do not get in the way; the endpoints
+        # themselves sudo() their lookups. They do check the property of the
+        # records against the caller's own properties, so the caller gets the
+        # test property assigned, like a receptionist working on their hotel.
+        cls.env = cls.env(user=cls.env["res.users"].browse(1))
+        cls.env.user.write(
+            {
+                "company_ids": [(4, cls.company1.id)],
+                "pms_property_ids": [(4, cls.pms_property1.id)],
+            }
+        )
+        cls.room_type = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Double Minors",
+                "default_code": "DBL_MIN",
+                "class_id": cls.room_type_class1.id,
+                "list_price": 30,
+            }
+        )
+        for number in (101, 102):
+            cls.env["pms.room"].create(
+                {
+                    "pms_property_id": cls.pms_property1.id,
+                    "name": "Room %s" % number,
+                    "room_type_id": cls.room_type.id,
+                    "capacity": 2,
+                }
+            )
+        cls.partner = cls.env["res.partner"].create({"name": "Booker"})
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Direct minors", "channel_type": "direct"}
+        )
+
+    # ---- fixtures ----------------------------------------------------------
+
+    def _service(self):
+        collection = _PseudoCollection("pms.services", self.env)
+        work = WorkContext(
+            model_name="rest.service.registration", collection=collection
+        )
+        return work.component(usage="reservations")
+
+    def _checkin_partner_info(self, **values):
+        return self.env.datamodels["pms.checkin.partner.info"](**values)
+
+    def _create_reservation(self, adults=1, folio=None):
+        values = {
+            "pms_property_id": self.pms_property1.id,
+            "checkin": datetime.date.today(),
+            "checkout": datetime.date.today() + datetime.timedelta(days=2),
+            "adults": adults,
+            "room_type_id": self.room_type.id,
+            "partner_id": self.partner.id,
+            "sale_channel_origin_id": self.sale_channel.id,
+        }
+        if folio:
+            values["folio_id"] = folio.id
+        return self.env["pms.reservation"].create(values)
+
+    def _fill_minor(self, checkin_partner):
+        """Complete every checkin datum a minor needs but the relationship.
+
+        A guest born 10 years ago needs no identity document, and the country is
+        not Spain so no state is required either. What is left missing is the
+        relationship with an accompanying guest, which is exactly what the
+        declaration waives.
+        """
+        checkin_partner.write(
+            {
+                "firstname": "Lone",
+                "lastname": "Minor",
+                "birthdate_date": datetime.date.today()
+                - datetime.timedelta(days=365 * 10),
+                "gender": "female",
+                "nationality_id": self.env.ref("base.fr").id,
+                "country_id": self.env.ref("base.fr").id,
+                "street": "Rue de la Paix 1",
+                "city": "Paris",
+                "zip": "75002",
+            }
+        )
+        return checkin_partner
+
+    def _upload(self, reservation, checkin_partner, files):
+        """Call the upload endpoint with the given multipart parts.
+
+        The request is faked because the uploaded parts do not travel in the
+        datamodel: base_rest keeps them out of ``request.params``, so the
+        endpoint reads them from the request itself.
+        """
+        # ``new`` is given so mock does not inspect the original: ``request`` is
+        # a proxy that raises as soon as it is touched with no request bound.
+        with patch(
+            "odoo.addons.pms_api_rest.services.pms_reservation_service.request",
+            new=SimpleNamespace(httprequest=SimpleNamespace(files=files)),
+        ):
+            return self._service().upload_minors_authorization(
+                reservation.id, checkin_partner.id
+            )
+
+    # ---- the declaration ---------------------------------------------------
+
+    def test_declaration_is_reported_on_every_guest_of_the_folio(self):
+        reservation = self._create_reservation()
+        sibling = self._create_reservation(folio=reservation.folio_id)
+        reservation.folio_id.ses_unaccompanied_minors = True
+
+        for booked in (reservation, sibling):
+            guests = self._service().get_checkin_partners(booked.id)
+            self.assertTrue(guests)
+            for guest in guests:
+                self.assertTrue(guest.unaccompaniedMinors)
+
+    def test_all_guests_minors_is_reported_when_every_guest_is_a_minor(self):
+        reservation = self._create_reservation()
+        self._fill_minor(reservation.checkin_partner_ids[0])
+
+        guests = self._service().get_checkin_partners(reservation.id)
+        self.assertTrue(guests[0].allGuestsMinors)
+
+    def test_all_guests_minors_is_not_reported_when_a_guest_is_of_age(self):
+        reservation = self._create_reservation()
+        sibling = self._create_reservation(folio=reservation.folio_id)
+        self._fill_minor(reservation.checkin_partner_ids[0])
+        sibling.checkin_partner_ids[0].birthdate_date = (
+            datetime.date.today() - datetime.timedelta(days=365 * 30)
+        )
+
+        # A guardian booked in another reservation of the same folio is what
+        # makes the declaration meaningless, so it is not reported as available.
+        guests = self._service().get_checkin_partners(reservation.id)
+        self.assertFalse(guests[0].allGuestsMinors)
+
+    def test_declaration_written_through_a_guest_lands_on_the_folio(self):
+        reservation = self._create_reservation()
+        checkin_partner = reservation.checkin_partner_ids[0]
+
+        self._service().write_reservation_checkin_partner(
+            reservation.id,
+            checkin_partner.id,
+            self._checkin_partner_info(
+                firstname="Lone", lastname="Minor", unaccompaniedMinors=True
+            ),
+        )
+
+        self.assertTrue(reservation.folio_id.ses_unaccompanied_minors)
+
+    def test_omitted_declaration_is_left_untouched(self):
+        reservation = self._create_reservation()
+        sibling = self._create_reservation(folio=reservation.folio_id)
+        reservation.folio_id.ses_unaccompanied_minors = True
+
+        # A request that writes another guest of the folio and says nothing
+        # about the declaration must not withdraw it.
+        self._service().write_reservation_checkin_partner(
+            sibling.id,
+            sibling.checkin_partner_ids[0].id,
+            self._checkin_partner_info(firstname="Other", lastname="Guest"),
+        )
+
+        self.assertTrue(reservation.folio_id.ses_unaccompanied_minors)
+
+    def test_declaration_sent_as_false_is_withdrawn(self):
+        reservation = self._create_reservation()
+        reservation.folio_id.ses_unaccompanied_minors = True
+
+        self._service().write_reservation_checkin_partner(
+            reservation.id,
+            reservation.checkin_partner_ids[0].id,
+            self._checkin_partner_info(
+                firstname="Lone", lastname="Minor", unaccompaniedMinors=False
+            ),
+        )
+
+        self.assertFalse(reservation.folio_id.ses_unaccompanied_minors)
+
+    def test_declaration_is_stored_before_boarding_the_guest(self):
+        reservation = self._create_reservation()
+        checkin_partner = self._fill_minor(reservation.checkin_partner_ids[0])
+
+        # Declaring and boarding in a single request: the guest has no
+        # relationship with an accompanying guest, so boarding only succeeds if
+        # the declaration was stored first.
+        self._service().write_reservation_checkin_partner(
+            reservation.id,
+            checkin_partner.id,
+            self._checkin_partner_info(unaccompaniedMinors=True, actionOnBoard=True),
+        )
+
+        self.assertTrue(reservation.folio_id.ses_unaccompanied_minors)
+        self.assertEqual(checkin_partner.state, "onboard")
+
+    def test_declaration_written_when_completing_a_guest_slot(self):
+        reservation = self._create_reservation(adults=2)
+
+        self._service().create_reservation_checkin_partner(
+            reservation.id,
+            self._checkin_partner_info(
+                firstname="Lone", lastname="Minor", unaccompaniedMinors=True
+            ),
+        )
+
+        self.assertTrue(reservation.folio_id.ses_unaccompanied_minors)
+
+    def test_read_only_data_is_not_part_of_the_write_contract(self):
+        """The guest endpoints share a datamodel, and base_rest builds the same
+        schema for the request and the response, so what is only reported must
+        stay out of the one the write endpoints declare.
+        """
+        written = self.env.datamodels["pms.checkin.partner.info"].get_schema()
+        reported = self.env.datamodels["pms.checkin.partner.info.output"].get_schema()
+
+        for name in ("allGuestsMinors", "minorsAuthorizationFilename"):
+            self.assertNotIn(name, written.fields)
+            self.assertIn(name, reported.fields)
+        self.assertIn("unaccompaniedMinors", written.fields)
+
+    # ---- the guardian authorization ----------------------------------------
+
+    def test_authorization_is_shared_by_the_guests_of_the_folio(self):
+        reservation = self._create_reservation()
+        sibling = self._create_reservation(folio=reservation.folio_id)
+        service = self._service()
+
+        service._store_minors_authorization(
+            reservation.checkin_partner_ids[0], b"scanned pdf", "authorization.pdf"
+        )
+
+        # Uploaded through a guest of one reservation, readable through a guest
+        # of the other one: there is a single document per folio.
+        content, filename = service._read_minors_authorization(
+            sibling.checkin_partner_ids[0]
+        )
+        self.assertEqual(content, b"scanned pdf")
+        self.assertEqual(filename, "authorization.pdf")
+        self.assertEqual(
+            base64.b64decode(reservation.folio_id.ses_minors_authorization),
+            b"scanned pdf",
+        )
+
+    def test_authorization_filename_is_reported_on_the_guest(self):
+        reservation = self._create_reservation()
+        checkin_partner = reservation.checkin_partner_ids[0]
+        service = self._service()
+
+        self.assertIsNone(
+            service.get_checkin_partners(reservation.id)[0].minorsAuthorizationFilename
+        )
+
+        service._store_minors_authorization(
+            checkin_partner, b"scanned pdf", "authorization.pdf"
+        )
+
+        self.assertEqual(
+            service.get_checkin_partners(reservation.id)[0].minorsAuthorizationFilename,
+            "authorization.pdf",
+        )
+
+    def test_authorization_is_uploaded_as_a_multipart_file(self):
+        reservation = self._create_reservation()
+        upload = FileStorage(
+            stream=io.BytesIO(b"scanned pdf"), filename="authorization.pdf"
+        )
+
+        self._upload(reservation, reservation.checkin_partner_ids[0], {"file": upload})
+
+        self.assertEqual(
+            base64.b64decode(reservation.folio_id.ses_minors_authorization),
+            b"scanned pdf",
+        )
+        self.assertEqual(
+            reservation.folio_id.ses_minors_authorization_filename,
+            "authorization.pdf",
+        )
+
+    def test_upload_without_the_file_part_is_rejected(self):
+        reservation = self._create_reservation()
+        with self.assertRaisesRegex(ValidationError, "file"):
+            self._upload(reservation, reservation.checkin_partner_ids[0], {})
+
+    def test_a_guest_of_another_reservation_is_not_found(self):
+        reservation = self._create_reservation()
+        other = self._create_reservation()
+        with self.assertRaises(MissingError):
+            self._service().delete_minors_authorization(
+                reservation.id, other.checkin_partner_ids[0].id
+            )
+
+    def test_empty_authorization_is_rejected(self):
+        reservation = self._create_reservation()
+        with self.assertRaisesRegex(ValidationError, "empty"):
+            self._service()._store_minors_authorization(
+                reservation.checkin_partner_ids[0], b"", "authorization.pdf"
+            )
+
+    def test_oversized_authorization_is_rejected(self):
+        reservation = self._create_reservation()
+        with self.assertRaisesRegex(ValidationError, "larger"):
+            self._service()._store_minors_authorization(
+                reservation.checkin_partner_ids[0],
+                b"x" * (MAX_MINORS_AUTHORIZATION_SIZE + 1),
+                "authorization.pdf",
+            )
+
+    def test_reading_a_missing_authorization_is_not_found(self):
+        reservation = self._create_reservation()
+        with self.assertRaises(MissingError):
+            self._service()._read_minors_authorization(
+                reservation.checkin_partner_ids[0]
+            )
+
+    def test_deleting_the_authorization_clears_name_and_content(self):
+        reservation = self._create_reservation()
+        checkin_partner = reservation.checkin_partner_ids[0]
+        service = self._service()
+        service._store_minors_authorization(
+            checkin_partner, b"scanned pdf", "authorization.pdf"
+        )
+
+        service.delete_minors_authorization(reservation.id, checkin_partner.id)
+
+        self.assertFalse(reservation.folio_id.ses_minors_authorization)
+        self.assertFalse(reservation.folio_id.ses_minors_authorization_filename)


### PR DESCRIPTION
API side of https://github.com/OCA/pms/pull/435, and it depends on it: the fields exposed here live in
`pms_l10n_es`.

The declaration and the guardian authorization are exchanged on the guest
resource, and Odoo maps them to the folio, so a single declaration covers
guardians and minors booked in different reservations. Every guest of the folio
reports the same value.

### Contract

On the guest:

- `unaccompaniedMinors` — read/write.
- `allGuestsMinors` — read only, the signal of when the declaration applies.
- `minorsAuthorizationFilename` — read only, `null` when there is no document.

The document, `multipart/form-data` under the `file` part, 10 MB cap:

    PUT    /api/reservations/{rid}/checkin-partners/{cid}/minors-authorization
    GET    /api/reservations/{rid}/checkin-partners/{cid}/minors-authorization
    DELETE /api/reservations/{rid}/checkin-partners/{cid}/minors-authorization

### An omitted declaration is left alone

Unlike the rest of the mapping, an absent `unaccompaniedMinors` does not write
an empty value. The declaration is folio wide, so that would withdraw it on
every request that writes any other guest of the folio. Sending `false`
withdraws it.

### `restapi.MultipartFormData` is not usable

The base_rest dispatcher sets `request.params` to the path arguments and adds
nothing for multipart, so the declared parts never reach the service method.
The file is read from `request.httprequest.files` instead.

### The declaration is written before boarding

`actionOnBoard` returns early, so a request that declared and boarded in one go
dropped the declaration and was then rejected for the missing relationship the
declaration waives.

### Not in the public precheckin

The staff makes the declaration, so it is not exposed on the guest-facing
precheckin endpoint.

Nothing added to `pms_fastapi`, which has no checkin endpoints yet.

The tests cover the mapping and the storage. The multipart read itself needs a
real request, so it is not covered. The `ruff` hook is already red on
`pms_reservation_service.py` in `16.0` (35 E501 + 2 E741), so this commit
skipped it; nothing new was added.
