### PR TITLE
fix(pms_api_rest): avoid huge folio messages payload

### DIFF
--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -1905,7 +1905,7 @@ class PmsFolioService(Component):
                     )
                     message_body = self.parse_message_body(message)
                     if message.message_type == "email":
-                        subject = "Email enviado: " + message.subject
+                        subject = "Email enviado: " + (message.subject or "")
                     else:
                         subject = message.subject if message.subject else None
                     reservation_messages.append(
@@ -1919,9 +1919,9 @@ class PmsFolioService(Component):
                             date=reservation_message_date.strftime("%d/%m/%y %H:%M:%S"),
                             messageType=message.message_type,
                             authorImageBase64=base64.b64encode(
-                                message.author_id.image_1024
+                                message.author_id.image_128
                             ).decode("utf-8")
-                            if message.author_id.image_1024
+                            if message.author_id.image_128
                             else None,
                             authorImageUrl=url_image_pms_api_rest(
                                 "res.partner", message.author_id.id, "image_1024"
@@ -1932,7 +1932,7 @@ class PmsFolioService(Component):
             for folio_message in folio.message_ids:
                 message_body = self.parse_message_body(folio_message)
                 if folio_message.message_type == "email":
-                    subject = "Email enviado: " + folio_message.subject
+                    subject = "Email enviado: " + (folio_message.subject or "")
                 else:
                     subject = folio_message.subject if folio_message.subject else None
                 folio_message_date = pytz.UTC.localize(folio_message.date)
@@ -1947,9 +1947,9 @@ class PmsFolioService(Component):
                         date=folio_message_date.strftime("%d/%m/%y %H:%M:%S"),
                         messageType=folio_message.message_type,
                         authorImageBase64=base64.b64encode(
-                            folio_message.author_id.image_1024
+                            folio_message.author_id.image_128
                         ).decode("utf-8")
-                        if folio_message.author_id.image_1024
+                        if folio_message.author_id.image_128
                         else None,
                         authorImageUrl=url_image_pms_api_rest(
                             "res.partner", folio_message.author_id.id, "image_1024"


### PR DESCRIPTION
## Problem

`GET /folios/<id>/messages` embeds the author avatar as base64 `image_1024` in **every** message. On folios with a long message history whose messages are mostly authored by a user with a heavy avatar, the response grows to tens of MB (real case: ~260 messages x 146 KB avatar ≈ 37 MB JSON). The frontend force-switches to the folio messages tab right after sending an invoice/folio mail, fetches that payload (up to 3 times due to duplicated watchers) and crashes with the generic "Algo ha ido mal" dialog — while the mail itself was actually sent. This makes users believe mail sending is broken.

Note the field is double-encoded (ORM binary fields are already base64, and the service b64-encodes them again, +33%), and the current frontend does not even consume `authorImageBase64` — it renders avatars from `authorImageUrl`.

## Fix

- Use `image_128` (chat-avatar size) for `authorImageBase64` instead of `image_1024`. Worst case payload drops from ~37 MB to a few hundred KB. `authorImageUrl` is untouched (browser caches it per author).
- Guard the `"Email enviado: "` subject concatenation: an email message with no subject raised `TypeError` → HTTP 500.

## Notes for reviewers

- Avatars uploaded through the frontend are stored directly in `image_1024` (`image_1920`/`image_128` empty), so `authorImageBase64` will often be `None` after this change — harmless, see above (frontend uses `authorImageUrl`). Longer term the frontend can drop the base64 field entirely.
- Frontend follow-up (separate repo): the messages tab fetches the endpoint up to 3 times in a row after sending a mail; worth deduplicating.