### PR TITLE
[FIX] pms_autoinvoice: load the pms.folio override and keep the reservation sections in automatic invoices

### DIFF
--- a/pms_autoinvoice/models/__init__.py
+++ b/pms_autoinvoice/models/__init__.py
@@ -1,5 +1,6 @@
 from . import account_payment
 from . import folio_sale_line
+from . import pms_folio
 from . import pms_property
 from . import res_partner
 from . import account_journal

--- a/pms_autoinvoice/models/pms_folio.py
+++ b/pms_autoinvoice/models/pms_folio.py
@@ -1,5 +1,7 @@
 import datetime
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import fields, models
 
 
@@ -51,26 +53,28 @@ class PmsFolio(models.Model):
                 if partner_invoice.margin_days_autoinvoice == 0
                 else partner_invoice.margin_days_autoinvoice
             )
-            invoice_date = max(
+            checkouts = (
                 self.env["pms.reservation"]
-                .search([("sale_line_ids", "in", lines_to_invoice.keys())])
+                .search([("sale_line_ids", "in", list(lines_to_invoice.keys()))])
                 .mapped("checkout")
-            ) + datetime.timedelta(days=margin_days_autoinvoice)
+            )
+            # Folios billing only services not bound to a reservation have no
+            # checkout to work with: keep the date computed by super() instead
+            # of blowing up on an empty max().
+            if checkouts:
+                invoice_date = max(checkouts) + datetime.timedelta(
+                    days=margin_days_autoinvoice
+                )
         if partner_invoice_policy == "month_day":
             month_day = (
                 self.pms_property_id.invoicing_month_day
                 if partner_invoice.invoicing_month_day == 0
                 else partner_invoice.invoicing_month_day
             )
-            invoice_date = datetime.date(
-                datetime.date.today().year,
-                datetime.date.today().month,
-                month_day,
-            )
-            if invoice_date < datetime.date.today():
-                invoice_date = datetime.date(
-                    datetime.date.today().year,
-                    datetime.date.today().month + 1,
-                    month_day,
-                )
+            today = fields.Date.today()
+            # relativedelta clamps the day to the end of the month, and rolls
+            # the year over in December (month + 1 would raise there).
+            invoice_date = today + relativedelta(day=month_day)
+            if invoice_date < today:
+                invoice_date = today + relativedelta(months=1, day=month_day)
         return invoice_date

--- a/pms_autoinvoice/models/pms_folio.py
+++ b/pms_autoinvoice/models/pms_folio.py
@@ -37,6 +37,21 @@ class PmsFolio(models.Model):
             ):
                 continue
             lines_to_invoice[line.id] = 0 if line.display_type else line.qty_to_invoice
+        # Add the reservation section header of every line being invoiced. The
+        # section name carries the room ("folio/reservation - room"), which is
+        # the reference corporate clients check the invoice against, and
+        # get_invoice_vals_list can only emit a section that is part of the
+        # lines to invoice (this is what manual invoicing does as well).
+        # Only sections billed to the same partner as the line are added, so a
+        # section can never end up alone in a group and create an empty invoice.
+        for line in self.env["folio.sale.line"].browse(list(lines_to_invoice)):
+            section = line.section_id
+            if (
+                section
+                and section.id not in lines_to_invoice
+                and section.default_invoice_to == line.default_invoice_to
+            ):
+                lines_to_invoice[section.id] = 0
         return lines_to_invoice
 
     def _get_invoice_date(self, partner_invoice_id, lines_to_invoice, date=None):

--- a/pms_autoinvoice/tests/test_pms_folio_autoinvoice.py
+++ b/pms_autoinvoice/tests/test_pms_folio_autoinvoice.py
@@ -340,6 +340,51 @@ class TestPmsFolioInvoice(TestPms):
             "Billed services and overnights invoicing wrong compute",
         )
 
+    def test_autoinvoice_folio_keeps_reservation_sections(self):
+        """
+        Test that the automatic invoice keeps the reservation sections
+        --------------------------------------
+        Set property default_invoicing_policy to checkout with 0 days of
+        margin, create a reservation already checked out and run the
+        autoinvoicing. The created invoice must include the section line of
+        the reservation, whose name carries the room that the client checks
+        the invoice against.
+        """
+        # ARRANGE
+        self.property.default_invoicing_policy = "checkout"
+        self.property.margin_days_autoinvoice = 0
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.property.id,
+                "checkin": datetime.date.today() - datetime.timedelta(days=3),
+                "checkout": datetime.date.today(),
+                "adults": 2,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_id.id,
+                "sale_channel_origin_id": self.sale_channel_direct1.id,
+            }
+        )
+
+        # ACT
+        self.property.autoinvoicing()
+
+        # ASSERT
+        invoice_sections = reservation.folio_id.move_ids.line_ids.filtered(
+            lambda line: line.display_type == "line_section"
+        )
+        self.assertEqual(
+            invoice_sections.folio_line_ids,
+            reservation.sale_line_ids.filtered(
+                lambda line: line.display_type == "line_section"
+            ),
+            "The automatic invoice must include the reservation section",
+        )
+        self.assertIn(
+            reservation.rooms,
+            invoice_sections.name,
+            "The invoice section must show the rooms of the reservation",
+        )
+
     def test_not_autoinvoice_unpaid_cancel_folio_partner_policy(self):
         """
         Test create and invoice the cron by partner preconfig automation


### PR DESCRIPTION
## Problem

`pms_autoinvoice/models/__init__.py` never imported `pms_folio`, so the `PmsFolio`
class of the module has been dead code since the module was added:
`_get_lines_to_invoice` and `_get_invoice_date` always resolved to `pms`.

Consequences of the dead import:

- No `autoinvoice_date` filter on the lines to invoice. The "leaked future line"
  safety net in `autoinvoice_folio` was working around precisely this.
- No guard against the 0€ invoices built out of orphan `line_note`s.
- No invoicing policy applied to the invoice date: it was just the day the cron ran.

On top of that, and this is the user-visible bug that surfaced it: automatic
invoices came out **without the reservation sections**. Every reservation of a
folio has a `line_section` sale line whose name, once invoiced, becomes
`folio/reservation - rooms`. It is the only place where the room appears on the
invoice, and corporate customers (public administrations, social entities) check
their invoices against it before paying. `get_invoice_vals_list` can only emit a
section that belongs to the lines to invoice, and manual invoicing adds them to
`lines_to_invoice` — the automatic one never did. So the very same folio invoiced
by the cron lost the room detail, and the customer refused the invoice.

## Fix

1. Import `pms_folio` and harden the two landmines in `_get_invoice_date` that
   had never been executed: `month + 1` raises every December, and `max()` over
   an empty list breaks folios that only bill services with no reservation
   behind them.
2. Add to `lines_to_invoice` the section of every line being invoiced, guarded
   to sections billed to the same partner as the line, so a section can never
   end up alone in a group and create an empty invoice.

## Test

New `test_autoinvoice_folio_keeps_reservation_sections`: a checked-out
reservation invoiced by `autoinvoicing()` must produce a move containing the
section line of the reservation, with its rooms in the name. Fails without the
fix (empty sections), passes with it. Full `pms_autoinvoice` suite green.

## Behaviour change to review

Activating the override changes the `invoice_date` of automatic invoices from
"day the cron ran" to the value of the invoicing policy (last checkout + margin
days, or the configured month day). For a `checkout` policy with 0 margin days
and a cron running the same night, both dates match; a recovery run on a later
day will now date the invoice on the checkout instead of the run date.
