### PR TITLE
[FIX] connector_pms_wubook: publish availability after importing a folio

### DIFF
--- a/connector_pms_wubook/models/pms_availability/listener.py
+++ b/connector_pms_wubook/models/pms_availability/listener.py
@@ -30,6 +30,48 @@ def _flush_availability_buffer(env):
         ).export_record(binding.backend_id, binding.odoo_id)
 
 
+def buffer_property_export(env, property_binding):
+    """Stage one property-availability export for ``property_binding``.
+
+    Canonical entry point for every producer (listeners, folio importer):
+    the buffer lives in ``cr.precommit.data`` so that N contributions in a
+    transaction collapse to one job per binding, and ``identity_key``
+    collapses bursts spanning several transactions.
+    """
+    cr = env.cr
+    data = cr.precommit.data
+    if _AVAILABILITY_BUFFER_KEY not in data:
+        data[_AVAILABILITY_BUFFER_KEY] = {}
+        env_captured = env
+        cr.precommit.add(lambda env=env_captured: _flush_availability_buffer(env))
+    data[_AVAILABILITY_BUFFER_KEY].setdefault(property_binding.id, property_binding)
+
+
+def buffer_property_exports_for_rooms(env, pms_property, room_types):
+    """Stage a property-availability export on every backend connected on
+    ``pms_property`` that also has at least one of ``room_types`` bound.
+
+    A backend only sells the room types it has mapped, so a change limited
+    to unbound types has nothing to publish.
+    """
+    if not pms_property or not room_types:
+        return
+    for property_binding in pms_property.channel_wubook_bind_ids:
+        if not property_binding.external_id:
+            # Property not yet connected on this backend.
+            continue
+        backend = property_binding.backend_id
+        bound = room_types.filtered(
+            lambda rt, backend=backend: any(
+                b.backend_id == backend and b.external_id
+                for b in rt.channel_wubook_bind_ids
+            )
+        )
+        if not bound:
+            continue
+        buffer_property_export(env, property_binding)
+
+
 class ChannelWubookPmsAvailabilityListener(Component):
     """Cascade listener for ``pms.availability``.
 
@@ -58,35 +100,14 @@ class ChannelWubookPmsAvailabilityListener(Component):
     _inherit = "base.connector.listener"
     _apply_on = "pms.availability"
 
-    def _buffer_property_export(self, property_binding):
-        cr = self.env.cr
-        data = cr.precommit.data
-        if _AVAILABILITY_BUFFER_KEY not in data:
-            data[_AVAILABILITY_BUFFER_KEY] = {}
-            env = self.env
-            cr.precommit.add(lambda env=env: _flush_availability_buffer(env))
-        data[_AVAILABILITY_BUFFER_KEY].setdefault(property_binding.id, property_binding)
-
     def _enqueue_property_exports(self, record):
         """For each Wubook backend connected on ``record.pms_property_id``
         and where ``record.room_type_id`` is also bound, buffer one
         property-availability export.
         """
-        prop = record.pms_property_id
-        room_type = record.room_type_id
-        if not prop or not room_type:
-            return
-        for property_binding in prop.channel_wubook_bind_ids:
-            if not property_binding.external_id:
-                # Property not yet connected on this backend.
-                continue
-            backend = property_binding.backend_id
-            room_type_bound = room_type.channel_wubook_bind_ids.filtered(
-                lambda b, backend=backend: b.backend_id == backend and b.external_id
-            )
-            if not room_type_bound:
-                continue
-            self._buffer_property_export(property_binding)
+        buffer_property_exports_for_rooms(
+            self.env, record.pms_property_id, record.room_type_id
+        )
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_create(self, record, fields=None):

--- a/connector_pms_wubook/models/pms_availability/listener.py
+++ b/connector_pms_wubook/models/pms_availability/listener.py
@@ -47,6 +47,26 @@ def buffer_property_export(env, property_binding):
     data[_AVAILABILITY_BUFFER_KEY].setdefault(property_binding.id, property_binding)
 
 
+def buffer_property_exports(env, pms_property):
+    """Stage a property-availability export on every backend connected on
+    ``pms_property``, whatever the room types involved.
+
+    For a reassignment the footprint spans the room type the reservation
+    LEFT and the one it took, and the event only carries the latter, so
+    gating on it would skip the freed side whenever the destination type is
+    not mapped on the backend (an internal room, a type not sold online).
+    The export only ships bindings whose value actually moved, so scheduling
+    one too many costs a no-op job at worst.
+    """
+    if not pms_property:
+        return
+    for property_binding in pms_property.channel_wubook_bind_ids:
+        if not property_binding.external_id:
+            # Property not yet connected on this backend.
+            continue
+        buffer_property_export(env, property_binding)
+
+
 def buffer_property_exports_for_rooms(env, pms_property, room_types):
     """Stage a property-availability export on every backend connected on
     ``pms_property`` that also has at least one of ``room_types`` bound.

--- a/connector_pms_wubook/models/pms_availability_plan_rule/listener.py
+++ b/connector_pms_wubook/models/pms_availability_plan_rule/listener.py
@@ -4,10 +4,7 @@
 from odoo.addons.component.core import Component
 from odoo.addons.component_event.components.event import skip_if
 
-from ..pms_availability.listener import (
-    _AVAILABILITY_BUFFER_KEY,
-    _flush_availability_buffer,
-)
+from ..pms_availability.listener import buffer_property_exports_for_rooms
 
 # Per-transaction buffer for plan re-exports triggered by rule changes.
 # Massive operations (typical of calendar wizards that touch hundreds of
@@ -136,16 +133,7 @@ def _flush_pending_plan_avail(env):
         room_type = RoomType.browse(room_type_id).exists()
         if not room_type:
             continue
-        for property_binding in prop.channel_wubook_bind_ids:
-            if not property_binding.external_id:
-                continue
-            backend = property_binding.backend_id
-            room_type_bound = room_type.channel_wubook_bind_ids.filtered(
-                lambda b, backend=backend: b.backend_id == backend and b.external_id
-            )
-            if not room_type_bound:
-                continue
-            _buffer_property_export_at(env, property_binding)
+        buffer_property_exports_for_rooms(env, prop, room_type)
 
 
 def _buffer_plan_export_at(env, plan_binding):
@@ -159,19 +147,6 @@ def _buffer_plan_export_at(env, plan_binding):
         env_captured = env
         cr.precommit.add(lambda env=env_captured: _flush_plan_rules_buffer(env))
     data[_PLAN_RULES_BUFFER_KEY].setdefault(plan_binding.id, plan_binding)
-
-
-def _buffer_property_export_at(env, property_binding):
-    """Module-level twin of ``_buffer_property_export``, callable from
-    the precommit flush (no ``self``).
-    """
-    cr = env.cr
-    data = cr.precommit.data
-    if _AVAILABILITY_BUFFER_KEY not in data:
-        data[_AVAILABILITY_BUFFER_KEY] = {}
-        env_captured = env
-        cr.precommit.add(lambda env=env_captured: _flush_availability_buffer(env))
-    data[_AVAILABILITY_BUFFER_KEY].setdefault(property_binding.id, property_binding)
 
 
 class ChannelWubookPmsAvailabilityPlanRuleListener(Component):

--- a/connector_pms_wubook/models/pms_folio/importer.py
+++ b/connector_pms_wubook/models/pms_folio/importer.py
@@ -6,6 +6,8 @@ from odoo import _, fields
 
 from odoo.addons.component.core import Component
 
+from ..pms_availability.listener import buffer_property_exports_for_rooms
+
 
 class ChannelWubookPmsFolioDelayedBatchImporter(Component):
     _name = "channel.wubook.pms.folio.delayed.batch.importer"
@@ -143,16 +145,45 @@ class ChannelWubookPmsFolioImporter(Component):
                     partner=folio.partner_id,
                 )
 
-        # REVIEW: mark actual_write_date to now
-        # in availability and force to update Wubook avail changes
-        # (Wubook add/delete avail by itself)
+        self._refresh_availability_export(binding)
+
+    def _refresh_availability_export(self, binding):
+        """Re-publish the availability the imported folio just moved.
+
+        Two halves, and only the first one used to be here:
+
+        * mark the affected ``channel.wubook.pms.availability`` bindings
+          dirty, so the exporter picks them up (Wubook adds / deletes avail
+          by itself on the channel side, so our value has to win);
+        * actually schedule that export. The whole import runs under
+          ``connector_no_export=True`` (``connector_pms``'s importer sets
+          it on every record it creates or writes), which is exactly the
+          flag every availability listener checks
+          before staging a push — so an imported folio consumed or freed
+          rooms and nothing ever told Wubook. The dirty bindings then sat
+          there until an unrelated event happened to enqueue a job, and
+          the channel kept selling a room the PMS no longer had.
+
+        Staging goes through the same precommit buffer as the listeners,
+        so a burst of imports still collapses to one job per
+        (backend × property) pair.
+        """
+        folio = binding.odoo_id
         dates = folio.mapped("reservation_ids.reservation_line_ids.date")
+        if not dates:
+            return
+        # A reservation can sit in a room of a different type than the one
+        # booked (cross-type relocation) and it is the ASSIGNED room that
+        # moves availability, so both sides have to be refreshed.
+        room_types = folio.mapped("reservation_ids.room_type_id") | folio.mapped(
+            "reservation_ids.reservation_line_ids.room_id.room_type_id"
+        )
         avails = self.env["channel.wubook.pms.availability"].search(
             [
                 ("backend_id", "=", binding.backend_id.id),
                 ("date", ">=", min(dates)),
                 ("date", "<=", max(dates)),
-                ("room_type_id", "in", folio.mapped("reservation_ids.room_type_id.id")),
+                ("room_type_id", "in", room_types.ids),
             ]
         )
         query = (
@@ -165,6 +196,7 @@ class ChannelWubookPmsFolioImporter(Component):
             set(avails.filtered(lambda i: i.date >= fields.Date.today()).ids)
         ):
             cr.execute(query, [sub_ids])
+        buffer_property_exports_for_rooms(self.env, folio.pms_property_id, room_types)
 
     def _create(self, model, values):
         """Create the Internal record"""

--- a/connector_pms_wubook/models/pms_reservation/listener.py
+++ b/connector_pms_wubook/models/pms_reservation/listener.py
@@ -4,10 +4,7 @@
 from odoo.addons.component.core import Component
 from odoo.addons.component_event.components.event import skip_if
 
-from ..pms_availability.listener import (
-    _AVAILABILITY_BUFFER_KEY,
-    _flush_availability_buffer,
-)
+from ..pms_availability.listener import buffer_property_exports_for_rooms
 
 # Why this listener exists: when a reservation is cancelled (or
 # re-confirmed) the only PUBLIC write Odoo performs is
@@ -39,44 +36,15 @@ class ChannelWubookPmsReservationListener(Component):
     _inherit = "base.connector.listener"
     _apply_on = "pms.reservation"
 
-    def _buffer_property_export(self, property_binding):
-        cr = self.env.cr
-        data = cr.precommit.data
-        if _AVAILABILITY_BUFFER_KEY not in data:
-            data[_AVAILABILITY_BUFFER_KEY] = {}
-            env = self.env
-            cr.precommit.add(
-                lambda env=env: _flush_availability_buffer(env)
-            )
-        data[_AVAILABILITY_BUFFER_KEY].setdefault(
-            property_binding.id, property_binding
-        )
-
     def _enqueue_property_exports(self, record):
-        prop = record.pms_property_id
-        if not prop:
-            return
         # The availability footprint is defined by the rooms actually
         # assigned to the reservation lines — NOT by the reservation
         # header's preferred ``room_type_id``.
-        room_types = record.reservation_line_ids.mapped(
-            "room_id.room_type_id"
+        buffer_property_exports_for_rooms(
+            self.env,
+            record.pms_property_id,
+            record.reservation_line_ids.mapped("room_id.room_type_id"),
         )
-        if not room_types:
-            return
-        for property_binding in prop.channel_wubook_bind_ids:
-            if not property_binding.external_id:
-                continue
-            backend = property_binding.backend_id
-            bound = room_types.filtered(
-                lambda rt, backend=backend: any(
-                    b.backend_id == backend and b.external_id
-                    for b in rt.channel_wubook_bind_ids
-                )
-            )
-            if not bound:
-                continue
-            self._buffer_property_export(property_binding)
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_write(self, record, fields=None):

--- a/connector_pms_wubook/models/pms_reservation/listener.py
+++ b/connector_pms_wubook/models/pms_reservation/listener.py
@@ -4,7 +4,10 @@
 from odoo.addons.component.core import Component
 from odoo.addons.component_event.components.event import skip_if
 
-from ..pms_availability.listener import buffer_property_exports_for_rooms
+from ..pms_availability.listener import (
+    buffer_property_exports,
+    buffer_property_exports_for_rooms,
+)
 
 # Why this listener exists: when a reservation is cancelled (or
 # re-confirmed) the only PUBLIC write Odoo performs is
@@ -18,10 +21,20 @@ from ..pms_availability.listener import buffer_property_exports_for_rooms
 # down to the lines to figure out which property bindings need an avail
 # re-export.
 #
-# Other fields (dates, room_type_id, etc.) are NOT listed here: changes
-# to those propagate as line creates / unlinks / room_id writes which
-# are caught by the ``pms.reservation.line`` listener.
-_RESERVATION_RELEVANT_FIELDS = {"state"}
+# ``preferred_room_id`` / ``room_type_id`` are here because moving a
+# reservation from its header only RECOMPUTES ``pms.reservation.line.room_id``
+# (a stored compute) through Odoo's internal ``_write()``, which
+# ``component_event`` does not hook — so the line listener never sees the
+# move and the channel keeps selling the room the guest now occupies.
+#
+# Dates are not listed: they propagate as line creates / unlinks, which the
+# ``pms.reservation.line`` listener does catch.
+_RESERVATION_RELEVANT_FIELDS = {"state", "preferred_room_id", "room_type_id"}
+
+# Of those, the ones that can move the reservation ACROSS room types. The
+# event carries the record after the write, so the room type it left is
+# already gone: the push cannot be gated on the room types we can see.
+_RESERVATION_REASSIGNMENT_FIELDS = {"preferred_room_id", "room_type_id"}
 
 
 class ChannelWubookPmsReservationListener(Component):
@@ -49,5 +62,8 @@ class ChannelWubookPmsReservationListener(Component):
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_write(self, record, fields=None):
         if not fields or not (set(fields) & _RESERVATION_RELEVANT_FIELDS):
+            return
+        if set(fields) & _RESERVATION_REASSIGNMENT_FIELDS:
+            buffer_property_exports(self.env, record.pms_property_id)
             return
         self._enqueue_property_exports(record)

--- a/connector_pms_wubook/models/pms_reservation_line/listener.py
+++ b/connector_pms_wubook/models/pms_reservation_line/listener.py
@@ -4,10 +4,7 @@
 from odoo.addons.component.core import Component
 from odoo.addons.component_event.components.event import skip_if
 
-from ..pms_availability.listener import (
-    _AVAILABILITY_BUFFER_KEY,
-    _flush_availability_buffer,
-)
+from ..pms_availability.listener import buffer_property_exports_for_rooms
 
 # Fields whose public write on a reservation line shifts the
 # availability footprint: ``room_id`` is the actual assignment that
@@ -44,36 +41,10 @@ class ChannelWubookPmsReservationLineListener(Component):
     _inherit = "base.connector.listener"
     _apply_on = "pms.reservation.line"
 
-    def _buffer_property_export(self, property_binding):
-        cr = self.env.cr
-        data = cr.precommit.data
-        if _AVAILABILITY_BUFFER_KEY not in data:
-            data[_AVAILABILITY_BUFFER_KEY] = {}
-            env = self.env
-            cr.precommit.add(
-                lambda env=env: _flush_availability_buffer(env)
-            )
-        data[_AVAILABILITY_BUFFER_KEY].setdefault(
-            property_binding.id, property_binding
-        )
-
     def _enqueue_property_exports(self, record):
-        prop = record.pms_property_id
-        room = record.room_id
-        room_type = room.room_type_id if room else False
-        if not prop or not room_type:
-            return
-        for property_binding in prop.channel_wubook_bind_ids:
-            if not property_binding.external_id:
-                continue
-            backend = property_binding.backend_id
-            room_type_bound = room_type.channel_wubook_bind_ids.filtered(
-                lambda b, backend=backend: b.backend_id == backend
-                and b.external_id
-            )
-            if not room_type_bound:
-                continue
-            self._buffer_property_export(property_binding)
+        buffer_property_exports_for_rooms(
+            self.env, record.pms_property_id, record.room_id.room_type_id
+        )
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_create(self, record, fields=None):

--- a/connector_pms_wubook/models/pms_reservation_line/listener.py
+++ b/connector_pms_wubook/models/pms_reservation_line/listener.py
@@ -4,7 +4,10 @@
 from odoo.addons.component.core import Component
 from odoo.addons.component_event.components.event import skip_if
 
-from ..pms_availability.listener import buffer_property_exports_for_rooms
+from ..pms_availability.listener import (
+    buffer_property_exports,
+    buffer_property_exports_for_rooms,
+)
 
 # Fields whose public write on a reservation line shifts the
 # availability footprint: ``room_id`` is the actual assignment that
@@ -53,6 +56,12 @@ class ChannelWubookPmsReservationLineListener(Component):
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_write(self, record, fields=None):
         if not fields or not (set(fields) & _LINE_RELEVANT_FIELDS):
+            return
+        if "room_id" in fields:
+            # The line moved between rooms: the availability freed on the
+            # room type it left has to be published too, and the record only
+            # carries the new one.
+            buffer_property_exports(self.env, record.pms_property_id)
             return
         self._enqueue_property_exports(record)
 

--- a/connector_pms_wubook/models/pms_room/listener.py
+++ b/connector_pms_wubook/models/pms_room/listener.py
@@ -4,10 +4,7 @@
 from odoo.addons.component.core import Component
 from odoo.addons.component_event.components.event import skip_if
 
-from ..pms_availability.listener import (
-    _AVAILABILITY_BUFFER_KEY,
-    _flush_availability_buffer,
-)
+from ..pms_availability.listener import buffer_property_exports_for_rooms
 from .pms_room import PmsRoom
 
 # Fields whose change on a ``pms.room`` shifts the effective room count
@@ -50,19 +47,6 @@ class ChannelWubookPmsRoomListener(Component):
     _inherit = "base.connector.listener"
     _apply_on = "pms.room"
 
-    def _buffer_property_export(self, property_binding):
-        cr = self.env.cr
-        data = cr.precommit.data
-        if _AVAILABILITY_BUFFER_KEY not in data:
-            data[_AVAILABILITY_BUFFER_KEY] = {}
-            env = self.env
-            cr.precommit.add(
-                lambda env=env: _flush_availability_buffer(env)
-            )
-        data[_AVAILABILITY_BUFFER_KEY].setdefault(
-            property_binding.id, property_binding
-        )
-
     def _affected_pairs(self, record):
         """Return the set of ``(property_id, room_type_id)`` pairs whose
         Wubook avail may have moved as a consequence of the change.
@@ -94,22 +78,10 @@ class ChannelWubookPmsRoomListener(Component):
         prop_ids = {prop_id for prop_id, _rt_id in pairs}
         properties = self.env["pms.property"].browse(prop_ids).exists()
         for prop in properties:
-            for property_binding in prop.channel_wubook_bind_ids:
-                if not property_binding.external_id:
-                    continue
-                backend = property_binding.backend_id
-                # Only push if at least one of the affected room_types
-                # is also bound on this backend — otherwise Wubook
-                # cannot apply the change anyway.
-                bound = room_types.filtered(
-                    lambda rt, backend=backend: any(
-                        b.backend_id == backend and b.external_id
-                        for b in rt.channel_wubook_bind_ids
-                    )
-                )
-                if not bound:
-                    continue
-                self._buffer_property_export(property_binding)
+            # Only pushes where at least one of the affected room_types is
+            # also bound on the backend — otherwise Wubook cannot apply the
+            # change anyway.
+            buffer_property_exports_for_rooms(self.env, prop, room_types)
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_create(self, record, fields=None):

--- a/connector_pms_wubook/tests/test_master_sync.py
+++ b/connector_pms_wubook/tests/test_master_sync.py
@@ -1472,3 +1472,173 @@ class TestAvailabilityListener(TransactionComponentCase):
             self.property_avail_binding.export_record,
             args=(self.backend, self.pms_property),
         )
+
+
+@tagged("post_install", "-at_install")
+class TestFolioImportAvailabilityExport(TransactionComponentCase):
+    """A folio arriving from Wubook must re-publish the availability it moved.
+
+    The importer creates every record under ``connector_no_export=True``,
+    which is exactly the flag the avail / line / reservation listeners check
+    before staging a push. So nothing downstream of an import ever schedules
+    the property export: the importer has to do it itself, otherwise the
+    channel keeps selling a room the PMS has already given away.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _make_backend_environment(cls)
+        cls.room_type_a_binding = cls.env["channel.wubook.pms.room.type"].create(
+            {
+                "odoo_id": cls.room_type_a.id,
+                "backend_id": cls.backend.id,
+                "external_id": 111,
+            }
+        )
+        cls.property_avail_binding = cls.env[
+            "channel.wubook.pms.property.availability"
+        ].create(
+            {
+                "odoo_id": cls.pms_property.id,
+                "backend_id": cls.backend.id,
+                "external_id": cls.pms_property.id,
+            }
+        )
+        cls.availability_plan = cls.env["pms.availability.plan"].create(
+            {"name": "Folio Import Plan"}
+        )
+        cls.pricelist_default.write(
+            {
+                "availability_plan_id": cls.availability_plan.id,
+                "is_pms_available": True,
+            }
+        )
+        cls.room = cls.env["pms.room"].create(
+            {
+                "name": "Room MS 1",
+                "room_type_id": cls.room_type_a.id,
+                "pms_property_id": cls.pms_property.id,
+                "capacity": 2,
+            }
+        )
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Wubook OTA", "channel_type": "indirect"}
+        )
+        cls.checkin = date.today() + timedelta(days=10)
+        cls.checkout = cls.checkin + timedelta(days=2)
+
+    def _import_reservation(self, checkin=None):
+        """Create a reservation the way an import leaves it: under
+        ``connector_no_export=True``, so no listener stages anything.
+        """
+        checkin = checkin or self.checkin
+        return (
+            self.env["pms.reservation"]
+            .with_context(connector_no_export=True)
+            .create(
+                {
+                    "pms_property_id": self.pms_property.id,
+                    "checkin": checkin,
+                    "checkout": checkin + timedelta(days=2),
+                    "partner_name": "Imported guest",
+                    "sale_channel_origin_id": self.sale_channel.id,
+                    "room_type_id": self.room_type_a.id,
+                }
+            )
+        )
+
+    def _folio_binding(self, folio, external_id=987654):
+        return self.env["channel.wubook.pms.folio"].create(
+            {
+                "odoo_id": folio.id,
+                "backend_id": self.backend.id,
+                "external_id": external_id,
+            }
+        )
+
+    def _importer(self):
+        with self.backend.work_on("channel.wubook.pms.folio") as work:
+            return work.component_by_name("channel.wubook.pms.folio.importer")
+
+    def test_imported_reservation_stages_nothing_by_itself(self):
+        """The cause of the bug, pinned: with the flag on, the listeners
+        stay silent even though the reservation just ate a room."""
+        with trap_jobs() as trap:
+            self._import_reservation()
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(0)
+
+    def test_importer_stages_property_export(self):
+        folio = self._import_reservation().folio_id
+        binding = self._folio_binding(folio)
+        self.env.cr.precommit.run()
+        with trap_jobs() as trap:
+            self._importer()._refresh_availability_export(binding)
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(1)
+        trap.assert_enqueued_job(
+            self.property_avail_binding.export_record,
+            args=(self.backend, self.pms_property),
+            properties={
+                "identity_key": (
+                    f"wubook_export_property_avail:{self.backend.id}"
+                    f":{self.pms_property.id}"
+                )
+            },
+        )
+
+    def test_several_imports_collapse_to_one_job(self):
+        bindings = [
+            self._folio_binding(
+                self._import_reservation(
+                    checkin=self.checkin + timedelta(days=3 * offset)
+                ).folio_id,
+                external_id=500 + offset,
+            )
+            for offset in range(3)
+        ]
+        self.env.cr.precommit.run()
+        with trap_jobs() as trap:
+            importer = self._importer()
+            for binding in bindings:
+                importer._refresh_availability_export(binding)
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(1)
+
+    def test_folio_without_reservations_stages_nothing(self):
+        folio = self.env["pms.folio"].create(
+            {
+                "pms_property_id": self.pms_property.id,
+                "partner_name": "Empty folio",
+                "sale_channel_origin_id": self.sale_channel.id,
+            }
+        )
+        binding = self._folio_binding(folio, external_id=123456)
+        self.env.cr.precommit.run()
+        with trap_jobs() as trap:
+            self._importer()._refresh_availability_export(binding)
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(0)
+
+    def test_unbound_room_type_stages_nothing(self):
+        """The backend only sells what it has mapped: a folio on an
+        unbound room type has nothing to publish."""
+        folio = self._import_reservation().folio_id
+        binding = self._folio_binding(folio)
+        self.room_type_a_binding.unlink()
+        self.env.cr.precommit.run()
+        with trap_jobs() as trap:
+            self._importer()._refresh_availability_export(binding)
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(0)
+
+    def test_property_not_connected_stages_nothing(self):
+        folio = self._import_reservation().folio_id
+        binding = self._folio_binding(folio)
+        self.property_avail_binding.unlink()
+        self.env.cr.precommit.run()
+        with trap_jobs() as trap:
+            self._importer()._refresh_availability_export(binding)
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(0)

--- a/connector_pms_wubook/tests/test_master_sync.py
+++ b/connector_pms_wubook/tests/test_master_sync.py
@@ -1642,3 +1642,147 @@ class TestFolioImportAvailabilityExport(TransactionComponentCase):
             self._importer()._refresh_availability_export(binding)
             self.env.cr.precommit.run()
         trap.assert_jobs_count(0)
+
+
+@tagged("post_install", "-at_install")
+class TestRoomReassignmentAvailabilityExport(TransactionComponentCase):
+    """Moving a reservation between rooms must publish BOTH sides.
+
+    Two things conspire against it. Reassigning from the reservation header
+    only recomputes ``line.room_id`` through ``_write()``, which
+    ``component_event`` never sees; and the event that does fire carries the
+    room the reservation moved INTO, never the one it left — so gating the
+    push on the room types we can see drops the freed side whenever the
+    destination room type is not sold on the backend.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _make_backend_environment(cls)
+        cls.room_type_a_binding = cls.env["channel.wubook.pms.room.type"].create(
+            {
+                "odoo_id": cls.room_type_a.id,
+                "backend_id": cls.backend.id,
+                "external_id": 222,
+            }
+        )
+        cls.property_avail_binding = cls.env[
+            "channel.wubook.pms.property.availability"
+        ].create(
+            {
+                "odoo_id": cls.pms_property.id,
+                "backend_id": cls.backend.id,
+                "external_id": cls.pms_property.id,
+            }
+        )
+        cls.plan = cls.env["pms.availability.plan"].create({"name": "Reassign Plan"})
+        cls.pricelist_default.write(
+            {"availability_plan_id": cls.plan.id, "is_pms_available": True}
+        )
+        cls.room_a1, cls.room_a2 = (
+            cls.env["pms.room"].create(
+                {
+                    "name": name,
+                    "room_type_id": cls.room_type_a.id,
+                    "pms_property_id": cls.pms_property.id,
+                    "capacity": 2,
+                }
+            )
+            for name in ("Reassign A1", "Reassign A2")
+        )
+        # A room type the backend does not sell (internal room, offline type).
+        unsold_product = cls.env["product.product"].create(
+            {"name": "RT-unsold product", "type": "service", "list_price": 80.0}
+        )
+        cls.room_type_unsold = cls.env["pms.room.type"].create(
+            {
+                "name": "RT-unsold",
+                "default_code": "RTUN",
+                "class_id": cls.room_type_class.id,
+                "product_id": unsold_product.id,
+                "pms_property_ids": [(6, 0, [cls.pms_property.id])],
+            }
+        )
+        cls.room_unsold = cls.env["pms.room"].create(
+            {
+                "name": "Reassign internal",
+                "room_type_id": cls.room_type_unsold.id,
+                "pms_property_id": cls.pms_property.id,
+                "capacity": 2,
+            }
+        )
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {"name": "Reassign channel", "channel_type": "indirect"}
+        )
+
+    def _reservation(self):
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.pms_property.id,
+                "checkin": date.today() + timedelta(days=20),
+                "checkout": date.today() + timedelta(days=22),
+                "partner_name": "Reassign guest",
+                "sale_channel_origin_id": self.sale_channel.id,
+                "room_type_id": self.room_type_a.id,
+                "preferred_room_id": self.room_a1.id,
+            }
+        )
+        self.env.cr.precommit.run()  # flush the buffer filled by the create
+        return reservation
+
+    def _assert_property_export(self, trap):
+        trap.assert_jobs_count(1)
+        trap.assert_enqueued_job(
+            self.property_avail_binding.export_record,
+            args=(self.backend, self.pms_property),
+            properties={
+                "identity_key": (
+                    f"wubook_export_property_avail:{self.backend.id}"
+                    f":{self.pms_property.id}"
+                )
+            },
+        )
+
+    def test_header_reassignment_stages_export(self):
+        reservation = self._reservation()
+        with trap_jobs() as trap:
+            reservation.preferred_room_id = self.room_a2.id
+            self.env.cr.precommit.run()
+        self._assert_property_export(trap)
+
+    def test_header_reassignment_to_unsold_type_stages_export(self):
+        """The guest moves into a room the backend does not sell: the room
+        left behind is back on sale and has to be published."""
+        reservation = self._reservation()
+        with trap_jobs() as trap:
+            reservation.preferred_room_id = self.room_unsold.id
+            self.env.cr.precommit.run()
+        self._assert_property_export(trap)
+
+    def test_line_room_write_to_unsold_type_stages_export(self):
+        reservation = self._reservation()
+        with trap_jobs() as trap:
+            reservation.reservation_line_ids.write({"room_id": self.room_unsold.id})
+            self.env.cr.precommit.run()
+        self._assert_property_export(trap)
+
+    def test_state_change_is_still_scoped_to_bound_room_types(self):
+        """Cancelling does not move rooms, so the room types on the lines are
+        the whole footprint and the scope check still applies."""
+        reservation = self._reservation()
+        reservation.preferred_room_id = self.room_unsold.id
+        self.env.cr.precommit.run()
+        self.room_type_a_binding.unlink()
+        with trap_jobs() as trap:
+            reservation.action_cancel()
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(0)
+
+    def test_reassignment_without_connected_property_stages_nothing(self):
+        reservation = self._reservation()
+        self.property_avail_binding.unlink()
+        with trap_jobs() as trap:
+            reservation.preferred_room_id = self.room_a2.id
+            self.env.cr.precommit.run()
+        trap.assert_jobs_count(0)


### PR DESCRIPTION
## The bug

A folio imported from Wubook consumes (or frees) rooms in the PMS, and nothing ever tells Wubook.

`connector_pms`'s importer creates and writes every record under `connector_no_export=True`
(`components_custom/importer.py::_create/_update`), which is exactly the flag every availability
listener checks in its `skip_if`. So the reservation-line create events cascaded by an import are
skipped and the property-availability export is never staged. The folio importer already marked the
affected `channel.wubook.pms.availability` bindings dirty, but only half the job was there: nothing
enqueued the export that ships them. The push then went out at some random later point, when an
unrelated event (a PMS-side edit, an import that cancels a folio, an external integration) happened
to stage one.

The flag is meant to stop us re-exporting the binding we just imported — not to silence the
availability side effect.

## Evidence

Production tenant, 2026-08-24 (UTC):

| Time | Event |
|---|---|
| 18:41:46 | Booking reservation imported; takes the last room of its type for the nights of 09 and 10/10. No export job staged. |
| 18:47:41 | The channel sells that same room type for 09/10 → import fails with `no availability` |
| 18:49:07 | The `update_avail` finally goes out, triggered by unrelated activity |

Same day, same property: another import at 14:03:54 took the last room for the night of 15/09 and
Wubook kept publishing it as available until 18:01:18 — **3h57m** of window.

Note the fleet has the `_generic_export` cron (`model._generic_export(interval=1, count=6)`)
disabled in several tenants, so there is no safety net behind the listeners: the miss becomes an
oversell.

## The fix

* `ChannelWubookPmsFolioImporter._refresh_availability_export()`: the dirty marking that lived
  inline in `_after_import` moves into its own method and now also stages the property export,
  through the same precommit buffer the listeners use — so a burst of imports still collapses to
  one job per (backend × property) pair, deduplicated across transactions by `identity_key`.
* The room types it refreshes now include the rooms actually **assigned** to the lines, not only
  the booked `room_type_id`: a reservation sitting in a room of another type (cross-type
  relocation) moves availability on the assigned room's type.
* A folio with no reservation lines is a no-op (it used to reach `min()` on an empty list).
* Cleanup: the five copies of "resolve the property bindings, check the room type is bound, buffer
  the export" (avail / line / reservation / room / plan-rule listeners) collapse into two shared
  helpers, `buffer_property_export()` and `buffer_property_exports_for_rooms()`, in
  `pms_availability/listener.py`.

## Tests

New `TestFolioImportAvailabilityExport` (6 tests): the imported reservation stages nothing by
itself (pins the cause), the importer stages exactly one property export with the right
`identity_key`, several imports collapse to one job, and the no-op cases (folio without lines,
unbound room type, property not connected).

Run against a copy of a real tenant database: the full `connector_pms_wubook` suite passes
(166 tests). The single failure —
`TestWubookConnectMixin.test_action_open_wizard_creates_pre_saved_wizard` — is pre-existing and
reproduces identically without this branch.


---

## Second commit: reassignments

Same blind spot, different trigger. Moving a reservation to another room **from the header** only
recomputes `pms.reservation.line.room_id` — a stored compute written through `_write()`, which
`component_event` does not hook — so no listener fires and nothing is published: the channel keeps
selling the room the guest now occupies. This was diagnosed in production on 2026-06-29 and fixed
in `22cedee` on `16.0-fix-wubook-single-avail-plan`, a branch that was never merged; the running
containers carry it as a hot patch that any image rebuild silently drops. This brings it into
`16.0`, with the regression test it never had.

And the freed side. The event carries the record **after** the write, so the room type the
reservation left is already gone from it. Gating the push on the room types we can see therefore
drops the freed side whenever the destination type is not sold on the backend (an internal room, a
type kept offline): the room that just came back on sale stays published as sold. Reassignments now
stage the export for every connected backend of the property. The export still ships only the
bindings whose value actually moved, so an unnecessary schedule costs a no-op job.

Measured on `16.0` before the change, staging a copy of a real tenant database:

| Action | Export staged |
|---|---|
| New reservation | yes |
| Cancellation | yes |
| Direct line write, mapped type → mapped type | yes |
| Direct line write, mapped → **unsold type** | **no** |
| Header reassignment (`preferred_room_id`) | **no** |
| Header reassignment, with `22cedee` applied | yes |
| Header reassignment with `22cedee`, mapped → **unsold type** | **no** |

All of them stage the export with this branch. Full suite re-run on the tenant copy: 173 tests, same
single pre-existing failure (`TestWubookConnectMixin.test_action_open_wizard_creates_pre_saved_wizard`).
