### PR TITLE
[16.0][FIX] pms_notifications: ship notification rules inactive

### DIFF
--- a/pms_notifications/README.rst
+++ b/pms_notifications/README.rst
@@ -33,10 +33,29 @@ document numbers mapping
 Usage
 =====
 
-You can set the aeat documentation type in Contacts -> Configuration ->
-Partner ID Categories. When you add a new partner document,
-automatically set it in vat or aeat documents according to the
-configured mapping
+The module ships five ready-to-use notification rules (booking
+confirmation, pre-arrival information, digital check-in reminder,
+checkout reminder and thank you / review request), each one bound to its
+own email template.
+
+**All of them are created inactive.** They send messages to your guests,
+so nothing goes out until somebody reviews the wording and turns the
+rule on. To activate one:
+
+1. Go to *Property Management > Configuration > Notification Rules*.
+2. Open the rule, review its template (the default texts are generic)
+   and pick the properties it applies to. An empty *Properties* field
+   means every property in the database.
+3. Tick *Active*.
+
+Scheduled rules are triggered by the *PMS Notifications: Run Scheduled
+Rules* cron, and queued messages are delivered by *PMS Notifications:
+Send Pending Email Notifications*. Note that a scheduled rule fires for
+every reservation already inside its time window, so activating one on a
+live database may send a batch of messages straight away.
+
+Every attempt is recorded in *Notification Logs*, with its state and
+error, so you can check what was sent and to whom.
 
 Bug Tracker
 ===========

--- a/pms_notifications/data/pms_property_notification_rules.xml
+++ b/pms_notifications/data/pms_property_notification_rules.xml
@@ -8,7 +8,7 @@
       model="pms.property.notification.rule"
     >
         <field name="name">Confirmation Notification (Email)</field>
-        <field name="active">True</field>
+        <field name="active">False</field>
         <field
         name="template_id"
         ref="pms_notifications.pms_notification_template_folio_confirmation_email"
@@ -28,7 +28,7 @@
       model="pms.property.notification.rule"
     >
             <field name="name">Pre-arrival Information (Email)</field>
-            <field name="active">True</field>
+            <field name="active">False</field>
             <field name="pms_property_ids" eval="[(6, 0, [])]" />
             <field
         name="template_id"
@@ -55,7 +55,7 @@
       model="pms.property.notification.rule"
     >
             <field name="name">Digital Check-in Reminder (Email)</field>
-            <field name="active">True</field>
+            <field name="active">False</field>
             <field name="pms_property_ids" eval="[(6, 0, [])]" />
             <field
         name="template_id"
@@ -82,7 +82,7 @@
       model="pms.property.notification.rule"
     >
             <field name="name">Checkout Reminder (Email)</field>
-            <field name="active">True</field>
+            <field name="active">False</field>
             <field name="pms_property_ids" eval="[(6, 0, [])]" />
             <field
         name="template_id"
@@ -109,7 +109,7 @@
       model="pms.property.notification.rule"
     >
             <field name="name">Thank You Review Request (Email)</field>
-            <field name="active">True</field>
+            <field name="active">False</field>
             <field name="pms_property_ids" eval="[(6, 0, [])]" />
             <field
         name="template_id"

--- a/pms_notifications/readme/USAGE.md
+++ b/pms_notifications/readme/USAGE.md
@@ -1,3 +1,22 @@
-You can set the aeat documentation type in Contacts -\> Configuration -\> Partner ID
-Categories. When you add a new partner document, automatically set it in vat or aeat
-documents according to the configured mapping
+The module ships five ready-to-use notification rules (booking confirmation,
+pre-arrival information, digital check-in reminder, checkout reminder and thank
+you / review request), each one bound to its own email template.
+
+**All of them are created inactive.** They send messages to your guests, so
+nothing goes out until somebody reviews the wording and turns the rule on. To
+activate one:
+
+1. Go to *Property Management > Configuration > Notification Rules*.
+2. Open the rule, review its template (the default texts are generic) and pick
+   the properties it applies to. An empty *Properties* field means every
+   property in the database.
+3. Tick *Active*.
+
+Scheduled rules are triggered by the *PMS Notifications: Run Scheduled Rules*
+cron, and queued messages are delivered by *PMS Notifications: Send Pending
+Email Notifications*. Note that a scheduled rule fires for every reservation
+already inside its time window, so activating one on a live database may send a
+batch of messages straight away.
+
+Every attempt is recorded in *Notification Logs*, with its state and error, so
+you can check what was sent and to whom.

--- a/pms_notifications/static/description/index.html
+++ b/pms_notifications/static/description/index.html
@@ -387,10 +387,27 @@ document numbers mapping</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<p>You can set the aeat documentation type in Contacts -&gt; Configuration -&gt;
-Partner ID Categories. When you add a new partner document,
-automatically set it in vat or aeat documents according to the
-configured mapping</p>
+<p>The module ships five ready-to-use notification rules (booking
+confirmation, pre-arrival information, digital check-in reminder,
+checkout reminder and thank you / review request), each one bound to its
+own email template.</p>
+<p><strong>All of them are created inactive.</strong> They send messages to your guests,
+so nothing goes out until somebody reviews the wording and turns the
+rule on. To activate one:</p>
+<ol class="arabic simple">
+<li>Go to <em>Property Management &gt; Configuration &gt; Notification Rules</em>.</li>
+<li>Open the rule, review its template (the default texts are generic)
+and pick the properties it applies to. An empty <em>Properties</em> field
+means every property in the database.</li>
+<li>Tick <em>Active</em>.</li>
+</ol>
+<p>Scheduled rules are triggered by the <em>PMS Notifications: Run Scheduled
+Rules</em> cron, and queued messages are delivered by <em>PMS Notifications:
+Send Pending Email Notifications</em>. Note that a scheduled rule fires for
+every reservation already inside its time window, so activating one on a
+live database may send a batch of messages straight away.</p>
+<p>Every attempt is recorded in <em>Notification Logs</em>, with its state and
+error, so you can check what was sent and to whom.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>


### PR DESCRIPTION
## Problema

Las cinco reglas que el módulo instala en `data/pms_property_notification_rules.xml` se crean con `active=True`. Instalar el módulo enciende, sin que nadie lo decida, cinco correos automáticos al huésped con los textos genéricos por defecto:

| Regla | Cuándo dispara |
|---|---|
| Confirmation Notification | al confirmar el folio |
| Pre-arrival Information | 3 días antes del check-in |
| Digital Check-in Reminder | 1 día antes del check-in |
| Checkout Reminder | 1 día antes de la salida |
| Thank You Review Request | 1 día después de la salida |

Sus dos crons también nacen activos, así que en cuanto pasa la primera ejecución se recogen **todas** las reservas que ya están dentro de la ventana y sale una tanda de golpe.

Es lo que ocurrió en un alojamiento en producción: **19 correos de "recordatorio de check-in digital" llegaron a huéspedes reales de madrugada**, más uno de pre-llegada, mientras el hotel creía que el correo automático estaba desactivado. Los interruptores que ellos conocían (`pms.property.is_*_auto_mail`) pertenecen al mecanismo de `pms` y estaban todos a False: este módulo es una vía paralela.

Cuesta detectarlo porque las plantillas llevan `auto_delete`, así que el `mail.mail` desaparece tras enviarse y solo queda rastro en `mail.tracking.email` y en el log del módulo.

## Solución

Crear las reglas **inactivas**. El bloque es `noupdate="1"`, así que las bases de datos que ya las tengan activadas a propósito no se ven afectadas: solo cambian las instalaciones nuevas.

Se aprovecha para escribir el `USAGE.md`, que hasta ahora tenía un texto copiado de otro módulo (hablaba de categorías de documentos AEAT). Ahora explica cómo revisar la plantilla y activar una regla, y avisa de la tanda inicial al activarla sobre una base con reservas vivas.

## Prueba

Instalación nueva: las cinco reglas aparecen en *Notification Rules* como inactivas y no sale ningún correo hasta que se activa una. Actualización de módulo sobre una base existente: las reglas conservan su estado (bloque `noupdate`).