### PR TITLE
[16.0][TEST] connector_pms_wubook: fix flaky availability import test

### DIFF
--- a/connector_pms_wubook/tests/test_master_sync.py
+++ b/connector_pms_wubook/tests/test_master_sync.py
@@ -1533,7 +1533,7 @@ class TestFolioImportAvailabilityExport(TransactionComponentCase):
         ``connector_no_export=True``, so no listener stages anything.
         """
         checkin = checkin or self.checkin
-        return (
+        reservation = (
             self.env["pms.reservation"]
             .with_context(connector_no_export=True)
             .create(
@@ -1547,6 +1547,16 @@ class TestFolioImportAvailabilityExport(TransactionComponentCase):
                 }
             )
         )
+        # ``pms.reservation.splitted`` is a stored compute that assigns
+        # ``preferred_room_id`` as a side effect, so it reaches the listeners
+        # through a public write. Being deferred, that recompute runs in
+        # whichever environment flushes first -- ``Transaction.flush()`` picks
+        # one out of a ``WeakSet``, i.e. by memory address -- while the guard
+        # only looks at ``record.env.context``. Flush here, in the importing
+        # environment, so the flag is where the listener looks for it instead
+        # of leaving it to chance.
+        reservation.env.flush_all()
+        return reservation
 
     def _folio_binding(self, folio, external_id=987654):
         return self.env["channel.wubook.pms.folio"].create(


### PR DESCRIPTION
`TestFolioImportAvailabilityExport` has been failing intermittently — 6 of 15 runs
(~40%) on a recent series of PRs — always the same way:

```
connector_pms_wubook/tests/test_master_sync.py
TestFolioImportAvailabilityExport.test_imported_reservation_stages_nothing_by_itself
AssertionError: 1 != 0
```

The staged job is exactly the one the test says must not appear:

```
channel.wubook.pms.property.availability . export_record
args = (channel.wubook.backend(N,), pms.property(M,))
identity_key = 'wubook_export_property_avail:N:M'
```

Re-running the job does not reliably clear it, and the suite of this module in
isolation never fails, which is what made it look like flakiness with no cause.

## Why it happens

The write that reaches the listener is not made by the test — it is made by a
**stored compute**, as a side effect:

```
pms/models/pms_reservation.py  _compute_splitted    (splitted: store=True)
   reservation.preferred_room_id = room_ids[0]
     -> public write() on pms.reservation
       -> component_event on_record_write
         -> connector_pms_wubook/models/pms_reservation/listener.py
           -> buffer_property_exports(...)      with the guard seeing no flag
```

`no_connector_export()` reads `record.env.context`, so the guard is **per
environment**. But this recompute is deferred, and a deferred recompute runs in
whichever environment happens to flush first:

```python
# odoo/api.py
class Transaction:
    self.envs = WeakSet()        # Environment.__hash__ is object.__hash__ -> id()

    def flush(self):
        for env in self.envs:    # iteration order = memory addresses
            ...
            break                # keeps the FIRST one
```

If that first environment is the importing one, the recompute carries
`connector_no_export=True` and the listener stays silent. If it is the plain
`setUpClass` environment, the flag is simply not there and the export gets
staged. Measured with a probe: 8 live environments, 5 with the flag and 3
without — 3/8 = 37.5%, which matches the observed rate. The WeakSet order
changes even between two calls inside the same process.

Something has to call `cr.flush()` mid-transaction for the recompute to happen
at all, and that is why the module's own suite never fails while a full
installation does: an active `on_write` notification rule on `pms.folio` (from
another module in the same installation) opens a savepoint during
`folio.action_confirm`, and `_FlushingSavepoint` calls `cr.flush()`:

```
action_confirm -> folio.action_confirm
  -> pms_notifications  write -> _pms_notification_create_event_log
    -> with self.env.cr.savepoint()
      -> _FlushingSavepoint -> cr.flush() -> Transaction.flush()  [recompute]
                                          -> precommit.run()      [job staged]
```

## The fix

Flush the reservation in the importing environment right after the create, so
nothing is left pending for another environment to recompute. It goes in the
shared helper rather than in the failing test because
`test_importer_stages_property_export` (which expects exactly one job) was
exposed to the same race.

## Verification

Clean install of `connector_pms_wubook`, all its tests in one process:

- A temporary test that **forces the losing side of the coin flip**
  (`Transaction.flush` patched to pick an environment without the flag) stages
  **0 jobs** with this change. The fix defeats the race, it does not just avoid
  triggering it.
- `0 failed, 0 error(s) of 158 tests`.

## Scope

**Tests only.** On a real import that extra job is a no-op: the importer
republishes availability itself (`_refresh_availability_export`) and
`identity_key` collapses the duplicate. No functional change.
