### PR TITLE
[16.0][TEST] connector_pms_wubook: pin the export guard, not the coin flip

### DIFF
--- a/connector_pms_wubook/tests/test_master_sync.py
+++ b/connector_pms_wubook/tests/test_master_sync.py
@@ -1561,11 +1561,30 @@ class TestFolioImportAvailabilityExport(TransactionComponentCase):
         with self.backend.work_on("channel.wubook.pms.folio") as work:
             return work.component_by_name("channel.wubook.pms.folio.importer")
 
-    def test_imported_reservation_stages_nothing_by_itself(self):
-        """The cause of the bug, pinned: with the flag on, the listeners
-        stay silent even though the reservation just ate a room."""
+    def test_import_flag_silences_the_reservation_listener(self):
+        """The cause of the bug, pinned: the importer works under
+        ``connector_no_export=True`` and while that flag is on the listeners
+        stage nothing, so publishing availability is the importer's job.
+
+        The write is made here explicitly instead of being left to the
+        create: ``pms.reservation.splitted`` is a stored compute that
+        assigns ``preferred_room_id`` as a side effect, and a deferred
+        recompute runs in whichever environment flushes first
+        (``Transaction.flush()`` takes one out of a ``WeakSet``, i.e. by
+        memory address) while the guard only reads ``record.env.context``.
+        Asserting on the create was therefore a coin toss -- the flag was
+        simply not in the environment the guard looked at. What the guard
+        does promise is what is pinned here.
+        """
+        reservation = self._import_reservation()
+        # Settle every deferred recompute the create left pending and drain
+        # whatever they staged, so the only thing the trap below can see is
+        # the write this test makes.
+        self.env.cr.flush()
         with trap_jobs() as trap:
-            self._import_reservation()
+            reservation.with_context(connector_no_export=True).write(
+                {"preferred_room_id": self.room.id}
+            )
             self.env.cr.precommit.run()
         trap.assert_jobs_count(0)
 

--- a/connector_pms_wubook/tests/test_master_sync.py
+++ b/connector_pms_wubook/tests/test_master_sync.py
@@ -1533,7 +1533,7 @@ class TestFolioImportAvailabilityExport(TransactionComponentCase):
         ``connector_no_export=True``, so no listener stages anything.
         """
         checkin = checkin or self.checkin
-        reservation = (
+        return (
             self.env["pms.reservation"]
             .with_context(connector_no_export=True)
             .create(
@@ -1547,16 +1547,6 @@ class TestFolioImportAvailabilityExport(TransactionComponentCase):
                 }
             )
         )
-        # ``pms.reservation.splitted`` is a stored compute that assigns
-        # ``preferred_room_id`` as a side effect, so it reaches the listeners
-        # through a public write. Being deferred, that recompute runs in
-        # whichever environment flushes first -- ``Transaction.flush()`` picks
-        # one out of a ``WeakSet``, i.e. by memory address -- while the guard
-        # only looks at ``record.env.context``. Flush here, in the importing
-        # environment, so the flag is where the listener looks for it instead
-        # of leaving it to chance.
-        reservation.env.flush_all()
-        return reservation
 
     def _folio_binding(self, folio, external_id=987654):
         return self.env["channel.wubook.pms.folio"].create(


### PR DESCRIPTION
Follow-up to #137, which did **not** fix the flakiness: 5 of the 7 stacked PRs
failed on the first run after it was merged, on the same test and with the same
`1 != 0`. This reverts it and pins the guard in a way that cannot depend on
chance.

## Why #137 did not work

It flushed the reservation in the importing environment right after the
`create`. Too late: with a 30-frame probe the recompute is already done by the
time the helper returns.

```
create -> action_confirm -> folio.action_confirm
  -> pms_notifications  write -> _pms_notification_create_event_log
    -> with self.env.cr.savepoint()
      -> _FlushingSavepoint -> cr.flush() -> Transaction.flush()
        -> env_to_flush.flush_all()          <- the environment of the lottery
          -> _compute_splitted -> preferred_room_id = ... -> public write
            -> pms.reservation listener -> availability export staged
```

Right after the `create` the probe reported no fields left to compute, so there
was nothing for that flush to do. The change was inert — neither better nor
worse.

## Why the old assertion cannot hold

`pms.reservation.splitted` is a stored compute that assigns
`preferred_room_id` as a side effect, so it reaches the listeners through a
public write. A deferred recompute runs in whichever environment flushes
first:

```python
# odoo/api.py
class Transaction:
    self.envs = WeakSet()        # Environment.__hash__ is object.__hash__ -> id()

    def flush(self):
        for env in self.envs:    # iteration order = memory addresses
            ...
            break                # keeps the FIRST one
```

`no_connector_export()` reads `record.env.context`, so whenever the environment
picked is not the importing one the flag is simply not there. Measured: 8 live
environments, 5 with the flag and 3 without — 3/8, matching the observed rate.
No flushing discipline on our side can control that choice, which is why the
end-to-end form of the assertion is not testable.

`preferred_room_id` cannot be dropped from the listener either: it is watched on
purpose, because moving a reservation from its header only recomputes
`pms.reservation.line.room_id` through `_write()`, which `component_event` does
not hook.

## What this PR asserts instead

What the guard does promise: **a write made under the flag stages nothing.** The
write is explicit and in a known environment, and the `create` is settled with
`cr.flush()` before the trap opens, so no pending recompute can leak into it.
The end-to-end side is still covered by `test_importer_stages_property_export`,
which checks that the importer publishes availability itself.

## Verification

All on a full installation of the repo running this module's tests — the setup
where the old test fails, unlike the module's suite in isolation.

| run | code | result |
| --- | --- | --- |
| control | old test | **1 failed** — the flaky test, as expected |
| 1-4 | new test | 0 failed of 158 |
| 5-8 | new test + `cr.flush()` hardening | 0 failed of 158 |
| mutation (temporary, in all 8) | same write **without** the flag | staged exactly 1 job |

The mutation run is what gives the assertion teeth: without the flag the very
same write does reach the listener, so the zero above comes from the guard and
not from an event that never fired.

## Scope

Tests only, as in #137. On a real import the extra job is a no-op: the importer
republishes availability itself and `identity_key` collapses the duplicate.
