### PR TITLE
[FIX] pms_autoinvoice: apply the invoicing policy only to automatic invoices

### DIFF
--- a/pms_autoinvoice/models/pms_folio.py
+++ b/pms_autoinvoice/models/pms_folio.py
@@ -55,13 +55,22 @@ class PmsFolio(models.Model):
         return lines_to_invoice
 
     def _get_invoice_date(self, partner_invoice_id, lines_to_invoice, date=None):
+        invoice_date = super()._get_invoice_date(
+            partner_invoice_id, lines_to_invoice, date=date
+        )
+        # The invoicing policy only dates the invoices issued by the automatic
+        # invoicing cron. Manual invoicing (backend wizard, app) must keep the
+        # date asked for by the caller, which is usually none: the invoice then
+        # takes the date of the day it is posted. Dating a manual invoice on the
+        # checkout of the reservation books it in a past period -- often locked,
+        # or already closed -- and leaves a draft that cannot be posted, because
+        # the sequence of the current period does not match that date.
+        if not self.env.context.get("autoinvoice"):
+            return invoice_date
         partner_invoice = self.env["res.partner"].browse(partner_invoice_id)
         partner_invoice_policy = self.pms_property_id.default_invoicing_policy
         if partner_invoice and partner_invoice.invoicing_policy != "property":
             partner_invoice_policy = partner_invoice.invoicing_policy
-        invoice_date = super()._get_invoice_date(
-            partner_invoice_id, lines_to_invoice, date=date
-        )
         if partner_invoice_policy == "checkout":
             margin_days_autoinvoice = (
                 self.pms_property_id.margin_days_autoinvoice

--- a/pms_autoinvoice/tests/test_pms_folio_autoinvoice.py
+++ b/pms_autoinvoice/tests/test_pms_folio_autoinvoice.py
@@ -385,6 +385,115 @@ class TestPmsFolioInvoice(TestPms):
             "The invoice section must show the rooms of the reservation",
         )
 
+    def test_manual_invoice_ignores_checkout_invoicing_policy(self):
+        """
+        Test that manual invoicing does not date the invoice on the checkout
+        --------------------------------------
+        Set property default_invoicing_policy to checkout with 0 days of
+        margin, create a reservation checked out a week ago and invoice its
+        folio manually (no autoinvoice context, like the backend wizard and
+        the app do). The draft invoice must not take the checkout as its
+        date: it stays empty so that the invoice is dated the day it is
+        posted, instead of being booked in a past period.
+        """
+        # ARRANGE
+        self.property.default_invoicing_policy = "checkout"
+        self.property.margin_days_autoinvoice = 0
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.property.id,
+                "checkin": datetime.date.today() - datetime.timedelta(days=10),
+                "checkout": datetime.date.today() - datetime.timedelta(days=7),
+                "adults": 2,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_id.id,
+                "sale_channel_origin_id": self.sale_channel_direct1.id,
+            }
+        )
+
+        # ACT
+        invoices = reservation.folio_id._create_invoices()
+
+        # ASSERT
+        self.assertFalse(
+            invoices.invoice_date,
+            "A manually created invoice must not be dated on the checkout",
+        )
+        self.assertNotEqual(
+            invoices.invoice_date_due,
+            reservation.checkout,
+            "A manually created invoice must not be due on the checkout",
+        )
+
+    def test_manual_invoice_keeps_the_requested_date(self):
+        """
+        Test that manual invoicing honours the date asked for by the caller
+        --------------------------------------
+        Same property policy as above, but the caller (the app sends the date
+        chosen by the user) asks for an explicit invoice date: that date must
+        be the one used, not the checkout of the reservation.
+        """
+        # ARRANGE
+        self.property.default_invoicing_policy = "checkout"
+        self.property.margin_days_autoinvoice = 0
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.property.id,
+                "checkin": datetime.date.today() - datetime.timedelta(days=10),
+                "checkout": datetime.date.today() - datetime.timedelta(days=7),
+                "adults": 2,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_id.id,
+                "sale_channel_origin_id": self.sale_channel_direct1.id,
+            }
+        )
+        invoice_date = datetime.date.today() - datetime.timedelta(days=1)
+
+        # ACT
+        invoices = reservation.folio_id._create_invoices(date=invoice_date)
+
+        # ASSERT
+        self.assertEqual(
+            invoices.invoice_date,
+            invoice_date,
+            "The manually created invoice must keep the requested date",
+        )
+
+    def test_autoinvoice_dates_the_invoice_on_the_checkout(self):
+        """
+        Test that the automatic invoicing keeps applying the policy date
+        --------------------------------------
+        The invoicing policy of the property (checkout + margin days) is the
+        one that dates the invoices issued by the autoinvoicing cron, so that
+        every stay is invoiced in the period it was consumed.
+        """
+        # ARRANGE
+        self.property.default_invoicing_policy = "checkout"
+        self.property.margin_days_autoinvoice = 0
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.property.id,
+                "checkin": datetime.date.today() - datetime.timedelta(days=10),
+                "checkout": datetime.date.today() - datetime.timedelta(days=7),
+                "adults": 2,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_id.id,
+                "sale_channel_origin_id": self.sale_channel_direct1.id,
+            }
+        )
+
+        # ACT
+        invoices = reservation.folio_id.with_context(autoinvoice=True)._create_invoices(
+            grouped=True, final=False
+        )
+
+        # ASSERT
+        self.assertEqual(
+            invoices.invoice_date,
+            reservation.checkout,
+            "The automatic invoice must be dated on the checkout of the stay",
+        )
+
     def test_not_autoinvoice_unpaid_cancel_folio_partner_policy(self):
         """
         Test create and invoice the cron by partner preconfig automation


### PR DESCRIPTION
## Problem

`pms_autoinvoice` overrides `pms.folio._get_invoice_date()` to date the invoice according to the invoicing policy (`checkout` + margin days, or the configured month day). Unlike its sibling `_get_lines_to_invoice()`, that override did not check the `autoinvoice` context, so it applied to **every** invoice created from a folio: the backend wizard (`folio.make.invoice.advance`), `pms_api_rest` and `pms_fastapi`.

The override was dead code until #123 loaded `models/pms_folio.py`, so the regression only surfaced with that fix. Under the `checkout` policy, manual invoicing produces drafts dated on the last checkout of the stay:

- **Past checkout** -> `invoice_date` in a period that is already closed. The draft cannot be posted: `account.sequence.mixin._constrains_date_sequence` rejects it, because the sequence of the current period does not match that date. And if the date falls before `period_lock_date`, `_create_invoices()` raises the locked-period `UserError` and no invoice is created at all.
- **Future checkout** -> the date lands in `invoice_date_due` (see the `key_field` choice in `pms.folio._create_invoices`), and with no payment term `_compute_needed_terms` keeps it as the `date_maturity` of the receivable line even after posting.

Re-issuing the invoice of an old reservation after refunding it hit this every time.

## Fix

Gate the policy behind the `autoinvoice` context, the same way `_get_lines_to_invoice` already is. Automatic invoicing keeps dating the invoices on the checkout, so every stay is invoiced in the period it was consumed; manual invoicing keeps the date the caller asked for -- usually none, so the invoice takes the date of the day it is posted.

## Tests

- `test_manual_invoice_ignores_checkout_invoicing_policy` -- manual invoicing of a folio checked out a week ago leaves `invoice_date` empty. Fails without the fix: the invoice comes out dated on the checkout.
- `test_manual_invoice_keeps_the_requested_date` -- an explicit `date` from the caller still wins.
- `test_autoinvoice_dates_the_invoice_on_the_checkout` -- the cron path keeps applying the policy.