### PR TITLE
[FIX] pms_bookai: re-render the WhatsApp payload at send time

### DIFF
--- a/pms_bookai/models/pms_notification_log.py
+++ b/pms_bookai/models/pms_notification_log.py
@@ -622,13 +622,21 @@ class PmsNotificationLog(models.Model):
                     log.write({"state": state, "error_message": msg})
                     continue
 
-                # Fallback: if legacy logs miss payload data, prepare it now.
-                if (
-                    not log.whatsapp_phone
-                    or not log.whatsapp_country
-                    or not log.bookai_origin_folio_id
-                ):
-                    log._bookai_prepare_payload_fields()
+                # Re-render the payload at send time: parameters, preview and
+                # recipient data must reflect the CURRENT record state (amounts,
+                # phone or language may have changed since the log was created).
+                frozen_params = log.whatsapp_template_parameters
+                log._bookai_prepare_payload_fields()
+                if log.state in ("error", "skipped"):
+                    # Re-preparation failed or property mode changed:
+                    # never send a stale payload.
+                    continue
+                if frozen_params and frozen_params != log.whatsapp_template_parameters:
+                    _logger.info(
+                        "Log %s payload re-rendered at send time; params were: %s",
+                        log.id,
+                        frozen_params,
+                    )
 
                 if not log.whatsapp_phone or not log.whatsapp_country:
                     raise ValidationError(

--- a/pms_bookai/tests/test_bookai_notification_log.py
+++ b/pms_bookai/tests/test_bookai_notification_log.py
@@ -386,3 +386,63 @@ class TestBookaiNotificationLog(TestBookaiCommon):
         ) as mock_post:
             log.action_send_bookai_whatsapp()
         mock_post.assert_not_called()
+
+    # ---------------------------------------------------------------
+    # Payload re-render at send time
+    # ---------------------------------------------------------------
+    def _make_param_follow_partner_name(self):
+        """Turn the template param into one that depends on the record."""
+        self.bookai_template.bookai_param_ids.filtered(
+            lambda p: p.key == "guest_name"
+        ).write(
+            {
+                "value_type": "inline",
+                "value_literal": False,
+                "value_inline_tmpl": "{{ object.partner_name or '' }}",
+            }
+        )
+
+    def test_action_send_rerenders_payload(self):
+        """The payload must reflect the record state at send time, not at create."""
+        self._make_param_follow_partner_name()
+        log = self._create_log()
+        self.assertIn("Test Guest", log.whatsapp_template_parameters)
+
+        # The guest is renamed after the log was created.
+        self.folio.write({"partner_name": "Renamed Guest"})
+
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_resp.content = b'{"message_id": "wamid.test"}'
+        mock_resp.text = '{"message_id": "wamid.test"}'
+        mock_resp.json.return_value = {"message_id": "wamid.test", "status": "ok"}
+        mock_resp.raise_for_status = MagicMock()
+        with patch(
+            "odoo.addons.pms_bookai.models." "pms_notification_log.requests.post",
+            return_value=mock_resp,
+        ) as mock_post:
+            log.action_send_bookai_whatsapp()
+
+        mock_post.assert_called_once()
+        self.assertEqual(log.state, "sent")
+        self.assertIn("Renamed Guest", log.whatsapp_template_parameters)
+        self.assertNotIn("Test Guest", log.whatsapp_template_parameters)
+        self.assertIn("Renamed Guest", log.bookai_last_request_payload)
+
+    @mute_logger(PREPARE_LOGGER)
+    def test_action_send_aborts_when_reprepare_fails(self):
+        """A failed re-render must abort the send instead of shipping stale data."""
+        log = self._create_log()
+        self.assertTrue(log.whatsapp_template_parameters)
+
+        # Break the template so that re-preparing the payload fails.
+        self.bookai_template.write({"bookai_template_code": False})
+
+        with patch(
+            "odoo.addons.pms_bookai.models." "pms_notification_log.requests.post"
+        ) as mock_post:
+            log.action_send_bookai_whatsapp()
+
+        mock_post.assert_not_called()
+        self.assertIn(log.state, ("error", "skipped"))


### PR DESCRIPTION
The payload was rendered when the log was created, and the sender only re-prepared it when basic recipient data was missing (a fallback for legacy logs). Anything that changed on the record between creation and delivery — pending amount, phone, language — was sent stale.

`_bookai_prepare_payload_fields()` is now called unconditionally before building the request, and the previous parameters are logged when they differ.

### Two behaviours that come with it, on purpose

- **A failed re-render aborts the send.** If re-preparing leaves the log in `error` or `skipped` (broken template, missing token, property mode changed), we `continue` instead of shipping the frozen payload. Before, such a log was delivered with the old data. Not sending is preferable to sending something that is no longer true, but it is a change of behaviour worth reviewing.
- `_bookai_check_property_mode` is evaluated twice per log, once in the sender loop and once inside `_bookai_prepare_payload_fields`. Negligible cost, noted for completeness.

### Tests

Two new cases in `TestBookaiNotificationLog`:

- `test_action_send_rerenders_payload`: the template param is switched to an inline expression over `partner_name`, the folio is renamed *after* the log is created, and the request must carry the new value (`state == "sent"`, new value in `whatsapp_template_parameters` and in `bookai_last_request_payload`). Fails on `16.0`, where the conditional fallback does not re-render.
- `test_action_send_aborts_when_reprepare_fails`: the template code is cleared after the log is created, so re-preparation fails; `requests.post` must not be called and the log ends in `error`.

### Context

The fix has been running as a hot-patch in a production container with no durable branch, so it would be lost on the next image rebuild.