### PR TITLE
[FIX] pms_api_rest: no availability rules when there are no rooms or dates

### DIFF
--- a/pms_api_rest/services/pms_availability_plan_service.py
+++ b/pms_api_rest/services/pms_availability_plan_service.py
@@ -30,7 +30,6 @@ class PmsAvailabilityPlanService(Component):
         auth="jwt_api_pms",
     )
     def get_availability_plans(self, pms_search_param, **args):
-
         availability_plans_all_properties = (
             self.env["pms.availability.plan"]
             .sudo()
@@ -120,6 +119,12 @@ class PmsAvailabilityPlanService(Component):
         )
         pms_api_check_access(user=self.env.user, records=rooms)
         room_type_ids = rooms.mapped("room_type_id").ids
+        if not room_type_ids or not target_dates:
+            # The query below interpolates these as SQL tuples, and an empty
+            # one renders as "IN ()", which is a syntax error. A property with
+            # no rooms configured, or a reversed date range, has no rules by
+            # definition: answer with an empty list instead of a 500.
+            return []
         selected_fields = [
             "id",
             "date",

--- a/pms_api_rest/tests/__init__.py
+++ b/pms_api_rest/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_availability_plan_service
 from . import test_external_folio_guest_name
 from . import test_folio_invoiced_error_code
 from . import test_pms_board_service_room_type

--- a/pms_api_rest/tests/test_availability_plan_service.py
+++ b/pms_api_rest/tests/test_availability_plan_service.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Commit [Sun]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""``get_availability_plan_rules`` builds its query with raw SQL and
+interpolates the target dates and the room types of the property as SQL
+tuples. An empty tuple renders as ``IN ()``, which Postgres rejects with a
+syntax error, so the endpoint answered 500 instead of an empty list in two
+reachable situations:
+
+* a property with no rooms configured (no room types to look rules up for),
+* a reversed date range, which produces no target dates at all.
+
+Both mean "there are no rules" and must return an empty list.
+"""
+from datetime import date, timedelta
+
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.component.core import WorkContext
+from odoo.addons.pms.tests.common import TestPms
+
+
+@tagged("post_install", "-at_install")
+class TestAvailabilityPlanService(TestPms, AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # The endpoint sudo()es its own lookups; use admin so record rules do
+        # not interfere with the access checks.
+        cls.env = cls.env(user=cls.env["res.users"].browse(1))
+        # pms_api_check_access() requires the caller to be assigned to the
+        # property whose rooms are being read.
+        cls.pms_property1.user_ids = [(4, cls.env.user.id)]
+
+    def _service(self):
+        collection = _PseudoCollection("pms.services", self.env)
+        work = WorkContext(
+            model_name="rest.service.registration", collection=collection
+        )
+        return work.component(usage="availability-plans")
+
+    def _search_param(self, date_from, date_to, pms_property=None):
+        return self.env.datamodels["pms.availability.plan.rule.search.param"](
+            dateFrom=str(date_from),
+            dateTo=str(date_to),
+            pmsPropertyId=(pms_property or self.pms_property1).id,
+        )
+
+    def _add_room(self):
+        room_type = self.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [self.pms_property1.id],
+                "name": "Double Avail Test",
+                "default_code": "DBL_Avail",
+                "class_id": self.room_type_class1.id,
+                "list_price": 25,
+            }
+        )
+        self.env["pms.room"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "name": "Double 201",
+                "room_type_id": room_type.id,
+                "capacity": 2,
+            }
+        )
+        return room_type
+
+    def test_no_rooms_returns_empty_list(self):
+        """A property with no rooms has no room types, hence no rules."""
+        rooms = self.env["pms.room"].search(
+            [("pms_property_id", "=", self.pms_property1.id)]
+        )
+        self.assertFalse(rooms)
+        today = date.today()
+        result = self._service().get_availability_plan_rules(
+            self.availability_plan1.id,
+            self._search_param(today, today + timedelta(days=2)),
+        )
+        self.assertEqual(result, [])
+
+    def test_reversed_date_range_returns_empty_list(self):
+        """dateTo before dateFrom yields no target dates."""
+        self._add_room()
+        today = date.today()
+        result = self._service().get_availability_plan_rules(
+            self.availability_plan1.id,
+            self._search_param(today, today - timedelta(days=1)),
+        )
+        self.assertEqual(result, [])
+
+    def test_existing_rule_is_returned(self):
+        """The early return must not shadow the regular path."""
+        room_type = self._add_room()
+        today = date.today()
+        self.env["pms.availability.plan.rule"].create(
+            {
+                "availability_plan_id": self.availability_plan1.id,
+                "pms_property_id": self.pms_property1.id,
+                "room_type_id": room_type.id,
+                "date": today,
+                "min_stay": 2,
+            }
+        )
+        result = self._service().get_availability_plan_rules(
+            self.availability_plan1.id,
+            self._search_param(today, today),
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].roomTypeId, room_type.id)
+        self.assertEqual(result[0].minStay, 2)


### PR DESCRIPTION
`get_availability_plan_rules()` builds its query with raw SQL and interpolates the target dates and the room types of the property as SQL tuples. An empty tuple renders as `IN ()`, which Postgres rejects with a syntax error, so the endpoint answered **500 instead of an empty list** in two reachable situations:

- a property with **no rooms configured**, so there are no room types to look rules up for — this is what happens with a property that has been created but not set up yet, and the front still asks for its rules;
- a **reversed date range** (`dateTo` before `dateFrom`), which produces no target dates at all.

Both mean "there are no rules for this query", which the contract already expresses as an empty list: the result loop only emits an item when it finds a matching rule, so an empty input naturally yields `[]`. The guard returns early instead of reaching the query.

Same guard style as `pms_folio_service`, and it aligns the endpoint with its pricelist sibling, which does not use raw SQL and already answers `[]` in these cases.

### Tests

New `TestAvailabilityPlanService` with three cases. Verified that the two bug cases **fail without the fix** (`ProgrammingError: syntax error at or near ")"`) and pass with it, and that the happy path passes both ways:

- `test_no_rooms_returns_empty_list` — property with no rooms, 3-day range.
- `test_reversed_date_range_returns_empty_list` — `dateTo` before `dateFrom`.
- `test_existing_rule_is_returned` — one room type with one rule, to make sure the early return does not shadow the regular path.

### Not addressed here

- The four other `date in %s` interpolations in `pms_calendar_service` share the reversed-range exposure.
- Switching these queries to `= ANY(%s)` (psycopg2 adapts an empty list to `ARRAY[]`, which is valid) would remove the whole class of bug.

Both are worth a follow-up; this change keeps the fix to the endpoint that is failing.

### Note on pre-commit

`ruff` reports one pre-existing `E501` in this file (the `ValidationError` string at what is now line 293, 96 chars). It is untouched by this change — it already fails on `16.0` — so it is left as is rather than reformatting unrelated code.